### PR TITLE
slope and aspect calculations test for neighbor existence with "BAD_NODE_VALUE"

### DIFF
--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3483,10 +3483,16 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # determine the values for the x, y, and z coordinates of each node,
         # pass these to rfuncs.calculate_slope_aspect_BFP to calculate the
         # slope and aspect.
-
+        
+        indBool=(n!=BAD_INDEX_VALUE)        
+        
         for i in range(len(id)):
-            ns=list(n[i])
+            # make a list of the neighbor nodes and 
+            # check that none of the nodes are bad
+            
+            ns=list(n[0][indBool[0]])
             ns.append(id[i])
+                                    
             x=self.node_x[ns]
             y=self.node_y[ns]
             z=val[ns]
@@ -3533,9 +3539,15 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # pass these to rfuncs.calculate_slope_aspect_BFP to calculate the
         # slope and aspect.
 
+        indBool=(n!=BAD_INDEX_VALUE)        
+        
         for i in range(len(id)):
-            ns=list(n[i])
+            # make a list of the neighbor nodes and 
+            # check that none of the nodes are bad
+            
+            ns=list(n[0][indBool[0]])
             ns.append(id[i])
+
             x=self.node_x[ns]
             y=self.node_y[ns]
             z=val[ns]
@@ -3802,7 +3814,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         tuple of floats
             Tuple containing (*slope*, *aspect*)
         """
-
         # additional note, KRB has written three codes in raster.py
         # one to calculate slope, one to calculate aspect, and one
         # to calculate both
@@ -3819,9 +3830,15 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # pass these to rfuncs.calculate_slope_aspect_BFP to calculate the
         # slope and aspect.
 
+        indBool=(n!=BAD_INDEX_VALUE)        
+        
         for i in range(len(id)):
-            ns=list(n[i])
+            # make a list of the neighbor nodes and 
+            # check that none of the nodes are bad
+            
+            ns=list(n[0][indBool[0]])
             ns.append(id[i])
+            
             x=self.node_x[ns]
             y=self.node_y[ns]
             z=val[ns]


### PR DESCRIPTION
raster.py functions written by K Barnhart to calculate slope and aspect have been modified to not use cells that have "BAD_INDEX_VALUE" for the neighborhood. Before this fix, model would break if there were open boundaries (and thus cells without a full set of 8 neighbors).

this does not fix any of the problems noted in the text about the aspect calculation not working correctly. KRB will look into this when she has a chance. 
