### PR TITLE
Fix writing boolean fields to netcdf

### DIFF
--- a/landlab/io/netcdf/_constants.py
+++ b/landlab/io/netcdf/_constants.py
@@ -15,6 +15,7 @@ _NP_TO_NC_TYPE = {
     'uint16': 'u2',
     'uint32': 'u4',
     'uint64': 'u8',
+    'bool': 'i1',
 }
 
 

--- a/landlab/io/netcdf/write.py
+++ b/landlab/io/netcdf/write.py
@@ -135,7 +135,7 @@ def _add_variables_at_points(root, fields):
         else:
             var[n_times] = node_fields[var_name].flat[0]
 
-        var.units = node_fields.units[var_name]
+        var.units = node_fields.units[var_name] or '?'
         var.long_name = var_name
 
 


### PR DESCRIPTION
Fixed a bug that caused errors when writing `boolean` values to netcdf4 format. This address issue #90, which deals with writing `int64` values to netcdf3. Since netcdf3 doesn't support `int64`, netcdf4 must be used but the netcdf4 writer didn't properly deal with `boolean` types. `boolean` types are now written to netcdf as one-byte integers.

In addition, if units are not given for a field, use "?".
