### PR TITLE
Convert weave to cython

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include *.txt
 include *.rst
+recursive-include landlab *.pyx
 recursive-include docs *.txt
 include ez_setup.py
+include README.md

--- a/landlab/components/flexure/cfuncs.pyx
+++ b/landlab/components/flexure/cfuncs.pyx
@@ -4,6 +4,9 @@ import numpy as np
 cimport numpy as np
 cimport cython
 
+from libc.math cimport fabs
+from libc.stdlib cimport abs
+
 
 _RHO_MANTLE = 3300.
 _GRAVITY = 9.81
@@ -11,6 +14,7 @@ _GRAVITY = 9.81
 
 DTYPE = np.double
 ctypedef np.double_t DTYPE_t
+
 
 @cython.boundscheck(False)
 def subside_parallel_row(np.ndarray[DTYPE_t, ndim=1] w,
@@ -23,10 +27,10 @@ def subside_parallel_row(np.ndarray[DTYPE_t, ndim=1] w,
   cdef int i
   cdef int j
 
-  for i in xrange(ncols):
-    if abs(load[i]) > 1e-6:
+  for i in range(ncols):
+    if fabs(load[i]) > 1e-6:
       c = load[i] * inv_c
-      for j in xrange(ncols):
+      for j in range(ncols):
         w[j] += - c * r[abs(j - i)]
 
 
@@ -37,8 +41,8 @@ def subside_grid(np.ndarray[DTYPE_t, ndim=2] w,
   cdef int nrows = w.shape[0]
   cdef i, j
 
-  for i in xrange(nrows):
-    for j in xrange(nrows):
+  for i in range(nrows):
+    for j in range(nrows):
       subside_parallel_row(w[j], load[i], r[abs(j - i)], alpha)
 
 
@@ -50,8 +54,8 @@ def subside_grid_strip(np.ndarray[DTYPE_t, ndim=2] load,
   cdef np.ndarray w = np.zeros((stop - start, load.shape[1]), dtype=DTYPE)
   cdef i
 
-  for i in xrange(load.shape[0]):
-    for j in xrange(start, stop):
+  for i in range(load.shape[0]):
+    for j in range(start, stop):
       subside_parallel_row(w[j - start], load[i], r[abs(j - i)], alpha)
 
   return w, strip_range

--- a/landlab/components/flow_routing/cfuncs.pyx
+++ b/landlab/components/flow_routing/cfuncs.pyx
@@ -1,0 +1,56 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+
+DTYPE_FLOAT = np.double
+ctypedef np.double_t DTYPE_FLOAT_t
+
+DTYPE_INT = np.int
+ctypedef np.int_t DTYPE_INT_t
+
+
+@cython.boundscheck(False)
+def adjust_flow_receivers(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
+                          np.ndarray[DTYPE_INT_t, ndim=1] dst_nodes,
+                          np.ndarray[DTYPE_FLOAT_t, ndim=1] z,
+                          np.ndarray[DTYPE_FLOAT_t, ndim=1] link_slope,
+                          np.ndarray[DTYPE_INT_t, ndim=1] active_links,
+                          np.ndarray[DTYPE_INT_t, ndim=1] receiver,
+                          np.ndarray[DTYPE_INT_t, ndim=1] receiver_link,
+                          np.ndarray[DTYPE_FLOAT_t, ndim=1] steepest_slope):
+    """Adjust flow receivers based on link slopes and steepest gradients.
+
+    Parameters
+    ----------
+    src_nodes : array_like
+        Ordered upstream node ids.
+    dst_nodes : array_like
+        Node ids of nodes receiving flow.
+    z : array_like
+        Node elevations.
+    link_slope : array_like
+        Link gradients.
+    active_links : array_like
+        Link IDs for active links.
+    receiver : array_like
+        Flow-receiver link IDs.
+    steepest_slope : array_like
+        Gradient of steepest descent from nodes.
+    """
+    cdef unsigned int n_nodes = src_nodes.size
+    cdef int src_id
+    cdef int dst_id
+
+    for i in range(n_nodes):
+        src_id = src_nodes[i]
+        dst_id = dst_nodes[i]
+
+        if z[src_id] > z[dst_id] and link_slope[i] > steepest_slope[src_id]:
+            receiver[src_id] = dst_id
+            steepest_slope[src_id] = link_slope[i]
+            receiver_link[src_id] = active_links[i]
+        elif z[dst_id] > z[src_id] and - link_slope[i] > steepest_slope[dst_id]:
+            receiver[dst_id] = src_id
+            steepest_slope[dst_id] = - link_slope[i]
+            receiver_link[dst_id] = active_links[i]

--- a/landlab/components/flow_routing/cfuncs.pyx
+++ b/landlab/components/flow_routing/cfuncs.pyx
@@ -50,7 +50,7 @@ def adjust_flow_receivers(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
             receiver[src_id] = dst_id
             steepest_slope[src_id] = link_slope[i]
             receiver_link[src_id] = active_links[i]
-        elif z[dst_id] > z[src_id] and - link_slope[i] > steepest_slope[dst_id]:
+        elif z[dst_id] > z[src_id] and -link_slope[i] > steepest_slope[dst_id]:
             receiver[dst_id] = src_id
             steepest_slope[dst_id] = - link_slope[i]
             receiver_link[dst_id] = active_links[i]

--- a/landlab/components/flow_routing/flow_direction_DN.py
+++ b/landlab/components/flow_routing/flow_direction_DN.py
@@ -233,29 +233,16 @@ def flow_directions(elev, active_links, fromnode, tonode, link_slope,
     #as of Dec 2014, we prioritise the weave if a weave is viable, and only do 
     #the numpy methods if it's not (~10% speed gain on 100x100 grid; 
     #presumably better if the grid is bigger)
-    if use_weave:
-        n_nodes = len(fromnode)
-        code="""
-            int f;
-            int t;
-            for (int i=0; i<n_nodes; i++) {
-                f = fromnode[i];
-                t = tonode[i];
-                if (elev[f]>elev[t] && link_slope[i]>steepest_slope[f]) {
-                    receiver[f] = t;
-                    steepest_slope[f] = link_slope[i];
-                    receiver_link[f] = active_links[i];
-                }
-                else if (elev[t]>elev[f] && -link_slope[i]>steepest_slope[t]) {
-                    receiver[t] = f;
-                    steepest_slope[t] = -link_slope[i];
-                    receiver_link[t] = active_links[i];
-                }
-            }
-        """
-        weave.inline(code, ['n_nodes', 'fromnode', 'tonode', 'elev', 
-                            'link_slope', 'steepest_slope', 'receiver', 
-                            'receiver_link', 'active_links'])
+    method = 'weave'
+    if method in ('cython', 'weave'):
+        if method == 'cython':
+            from .cfuncs import adjust_flow_receivers
+        elif method == 'weave':
+            from .weavefuncs import adjust_flow_receivers
+
+        adjust_flow_receivers(fromnode, tonode, elev, link_slope,
+                              active_links, receiver, receiver_link,
+                              steepest_slope)
     else:
         if grid==None or not RasterModelGrid in inspect.getmro(grid.__class__):
             #print "looped method"

--- a/landlab/components/flow_routing/weavefuncs.py
+++ b/landlab/components/flow_routing/weavefuncs.py
@@ -1,0 +1,29 @@
+from scipy import weave
+
+
+def adjust_flow_receivers(fromnode, tonode, elev, link_slope, active_links,
+                          receiver, receiver_link, steepest_slope):
+    n_nodes = fromnode.size
+
+    code="""
+    int f;
+    int t;
+    for (int i=0; i < n_nodes; i++) {
+        f = fromnode[i];
+        t = tonode[i];
+        if (elev[f] > elev[t] && link_slope[i] > steepest_slope[f]) {
+            receiver[f] = t;
+            steepest_slope[f] = link_slope[i];
+            receiver_link[f] = active_links[i];
+        }
+        else if (elev[t] > elev[f] && - link_slope[i] > steepest_slope[t]) {
+            receiver[t] = f;
+            steepest_slope[t] = -link_slope[i];
+            receiver_link[t] = active_links[i];
+        }
+    }
+    """
+
+    weave.inline(code, ['n_nodes', 'fromnode', 'tonode', 'elev',
+                        'link_slope', 'steepest_slope', 'receiver',
+                        'receiver_link', 'active_links'])

--- a/landlab/components/stream_power/cfuncs.pyx
+++ b/landlab/components/stream_power/cfuncs.pyx
@@ -1,0 +1,134 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+#from libc.math cimport fabs
+
+
+DTYPE_FLOAT = np.double
+ctypedef np.double_t DTYPE_FLOAT_t
+
+DTYPE_INT = np.int
+ctypedef np.int_t DTYPE_INT_t
+
+
+cdef extern from "math.h":
+    double fabs(double x) nogil
+    double pow(double x, double y) nogil
+
+
+@cython.boundscheck(False)
+def erode_avoiding_pits(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
+                        np.ndarray[DTYPE_INT_t, ndim=1] dst_nodes,
+                        np.ndarray[DTYPE_FLOAT_t, ndim=1] node_z,
+                        np.ndarray[DTYPE_FLOAT_t, ndim=1] node_dz):
+    """Erode node elevations while avoiding creating pits.
+
+    Parameters
+    ----------
+    src_nodes : array_like
+        Ordered upstream node ids.
+    dst_nodes : array_like
+        Node ids of nodes receiving flow.
+    node_z : array_like
+        Node elevations.
+    node_dz : array_like
+        Node erosion rates.
+    """
+    cdef unsigned int n_nodes = src_nodes.size
+    cdef double z_src_after
+    cdef double z_dst_after
+    cdef unsigned int src_id
+    cdef unsigned int dst_id
+    cdef unsigned int i
+
+    for i in range(n_nodes):
+        src_id = src_nodes[i]
+        dst_id = dst_nodes[src_id]
+
+        z_src_after = node_z[src_id] - node_dz[src_id]
+        z_dst_after = node_z[dst_id] - node_dz[dst_id]
+
+        if z_src_after < z_dst_after:
+            node_dz[src_id] = (node_z[src_id] - z_dst_after) * 0.999999
+
+
+@cython.boundscheck(False)
+def erode_with_alpha(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
+                     np.ndarray[DTYPE_INT_t, ndim=1] dst_nodes,
+                     np.ndarray[DTYPE_FLOAT_t, ndim=1] alpha,
+                     np.ndarray[DTYPE_FLOAT_t, ndim=1] z):
+    """Erode node elevations based on a scaling factor.
+
+    Parameters
+    ----------
+    src_nodes : array_like
+        Ordered upstream node ids.
+    dst_nodes : array_like
+        Node ids of nodes receiving flow.
+    alpha : array_like
+        Erosion factor.
+    z : array_like
+        Node elevations.
+    """
+    cdef unsigned int n_nodes = src_nodes.size
+    cdef unsigned int src_id
+    cdef unsigned int dst_id
+    cdef unsigned int i
+
+    for i in range(n_nodes):
+        src_id = src_nodes[i]
+        dst_id = dst_nodes[src_id]
+        if src_id != dst_id:
+            z[src_id] = ((z[src_id] + alpha[src_id] * z[dst_id]) /
+                         (1.0 + alpha[src_id]))
+
+
+def erode_with_link_alpha(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
+                          np.ndarray[DTYPE_INT_t, ndim=1] dst_nodes,
+                          np.ndarray[DTYPE_FLOAT_t, ndim=1] alpha,
+                          DTYPE_FLOAT_t n,
+                          np.ndarray[DTYPE_FLOAT_t, ndim=1] z):
+    """Erode node elevations using alpha scaled by link length.
+
+    Parameters
+    ----------
+    src_nodes : array_like
+        Ordered upstream node ids.
+    dst_nodes : array_like
+        Node ids of nodes receiving flow.
+    alpha : array_like
+        Erosion factor scaled by link length to the *n - 1*.
+    n : float
+        Exponent.
+    z : array_like
+        Node elevations.
+    """
+    cdef unsigned int n_nodes = src_nodes.size
+    cdef unsigned int src_id
+    cdef unsigned int dst_id
+    cdef unsigned int i
+    cdef double z_diff
+    cdef double prev_z
+    cdef double next_z
+    cdef double f
+
+    for i in range(n_nodes):
+        src_id = src_nodes[i]
+        dst_id = dst_nodes[src_id]
+
+        if src_id != dst_id:
+            next_z = z[src_id]
+
+            while True:
+                prev_z = next_z;
+
+                z_diff = prev_z - z[dst_id]
+                f = alpha[src_id] * pow(z_diff, n - 1.)
+                next_z = prev_z - ((prev_z - z[src_id] + f * z_diff) /
+                                   (1. + n * f))
+
+                if fabs((next_z - prev_z) / next_z) < 1.48e-08:
+                    break
+
+            z[src_id] = next_z

--- a/landlab/components/stream_power/weavefuncs.py
+++ b/landlab/components/stream_power/weavefuncs.py
@@ -1,0 +1,75 @@
+from scipy import weave
+
+
+def erode_avoiding_pits(node_order_upstream, flow_receiver, node_z,
+                        erosion_increment):
+    n_nodes = node_order_upstream.size
+    code="""
+    int current_node;
+    double elev_this_node_before;
+    double elev_this_node_after;
+    double elev_dstr_node_after;
+
+    for (int i = 0; i < n_nodes; i++) {
+        current_node = node_order_upstream[i];
+        elev_this_node_before = node_z[current_node];
+        elev_this_node_after = elev_this_node_before - erosion_increment[current_node];
+        elev_dstr_node_after = elev_dstr[current_node] - erosion_increment[flow_receiver[current_node]];
+        if (elev_this_node_after<elev_dstr_node_after) {
+            erosion_increment[current_node] = (elev_this_node_before-elev_dstr_node_after)*0.999999;
+        }
+    }
+    """
+    weave.inline(code, ['n_nodes', 'node_order_upstream', 'node_z',
+                        'erosion_increment', 'elev_dstr', 'flow_receiver'])
+
+
+def erode_with_alpha(upstream_order_IDs, flow_receivers, alpha, z):
+    code = """
+    int current_node;
+    int j;
+    for (int i = 0; i < n_nodes; i++) {
+        current_node = upstream_order_IDs[i];
+        j = flow_receivers[current_node];
+        if (current_node != j) {
+            z[current_node] = (z[current_node] + alpha[current_node]*z[j])/(1.0+alpha[current_node]);
+        }
+    }
+    """
+    weave.inline(code, ['n_nodes', 'upstream_order_IDs', 'flow_receivers',
+                        'z', 'alpha'])
+
+
+def erode_with_link_alpha(upstream_order_IDs, flow_receivers,
+                          alpha_by_flow_link_lengthtothenless1, n, z):
+    code = """
+    int current_node;
+    int j;
+    double current_z;
+    double previous_z;
+    double elev_diff;
+    double elev_diff_tothenless1;
+    for (int i = 0; i < n_nodes; i++) {
+        current_node = upstream_order_IDs[i];
+        j = flow_receivers[current_node];
+        previous_z = z[current_node];
+        if (current_node != j) {
+            while (1) {
+                elev_diff = previous_z-z[j];
+
+                //this isn't defined if in some iterations the elev_diff
+                // goes negative
+                elev_diff_tothenless1 = pow(elev_diff, n-1.);
+                current_z = previous_z - (previous_z - z[current_node] + alpha_by_flow_link_lengthtothenless1[current_node]*elev_diff_tothenless1*elev_diff)/(1.+n*alpha_by_flow_link_lengthtothenless1[current_node]*elev_diff_tothenless1);
+                if (fabs((current_z - previous_z)/current_z) < 1.48e-08) {
+                    break;
+                }
+                previous_z = current_z;
+            }
+            z[current_node] = current_z;
+        }
+    }
+    """
+    weave.inline(code, ['n_nodes', 'upstream_order_IDs', 'flow_receivers',
+                        'z', 'alpha_by_flow_link_lengthtothenless1', 'n'],
+                 headers=["<math.h>"])

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ cython_pathspec = os.path.join('landlab', 'components','**','*.pyx')
 ext_modules = cythonize(cython_pathspec)
 
 
-setup(name='TheLandlab',
+setup(name='landlab',
       version=__version__,
       author='Eric Hutton',
       author_email='eric.hutton@colorado.edu',


### PR DESCRIPTION
Converts @SiccarPoint's weave code to cython. Using Cython will make distributing landlab binaries easier and make us compatible with Python 3 again.

I've moved the weave code into modules called `weavefuncs.py` and added the cython code in modules called `cfuncs.pyx`. You can toggle between the weave and cython methods by setting the `methods` flag above the weave/cython blocks in the code. I've verified that the cython matches the weave byte-for-byte for the provided examples and that there isn't loss of speed. I'll wait for @SiccarPoint's go-ahead before merging this pull request and, if everything checkouts out, I'll remove the weave code so that only cython is used.

Components affected are:
* flow_routing
* stream_power
* flexure
