### PR TITLE
Added doctests and more documentation for read_netcdf

### DIFF
--- a/landlab/io/netcdf/__init__.py
+++ b/landlab/io/netcdf/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 try:
     import netCDF4 as nc4
 except ImportError:
@@ -7,6 +9,11 @@ except ImportError:
 else:
     WITH_NETCDF4 = True
 
+NETCDF4_EXAMPLE_FILE = os.path.join(os.path.dirname(__file__), 'tests', 'data',
+                                    'test-netcdf4.nc')
+NETCDF3_64BIT_EXAMPLE_FILE = os.path.join(os.path.dirname(__file__), 'tests',
+                                          'data', 'test-netcdf3-64bit.nc')
+
 
 from .read import read_netcdf
 from .write import write_netcdf
@@ -14,4 +21,5 @@ from .errors import NotRasterGridError
 
 
 __all__ = ['read_netcdf', 'write_netcdf', 'NotRasterGridError',
-           'WITH_NETCDF4', ]
+           'WITH_NETCDF4', 'NETCDF4_EXAMPLE_FILE',
+           'NETCDF3_64BIT_EXAMPLE_FILE']

--- a/landlab/io/netcdf/read.py
+++ b/landlab/io/netcdf/read.py
@@ -99,12 +99,45 @@ def _get_raster_spacing(coords):
         return spacing[0]
 
 
-def read_netcdf(nc_file, reshape=False, just_grid=False):
-    """
-    Reads the NetCDF file *nc_file*, and writes it to the fields of a new
-    RasterModelGrid, which it then returns.
-    Check the names of the fields in the returned grid with
-    grid.at_nodes.keys().
+def read_netcdf(nc_file, just_grid=False):
+    """Create a RasterModelGrid from a netcdf file.
+
+    Create a new RasterModelGrid from the netcdf file, *nc_file*. If the
+    netcdf file also contains data, add that data to the grid's fields.
+
+    Parameters
+    ----------
+    nc_file : str
+        Name of a netcdf file.
+    just_grid : boolean, optional
+        Create a new grid but don't add value data.
+
+    Returns
+    -------
+    RasterModelGrid
+        A newly-created RasterModelGrid.
+
+    Examples
+    --------
+    >>> from landlab.io.netcdf import read_netcdf
+    >>> from landlab.io.netcdf import NETCDF4_EXAMPLE_FILE
+    >>> grid = read_netcdf(NETCDF4_EXAMPLE_FILE)
+    >>> grid.shape
+    (4, 3)
+    >>> grid.node_spacing
+    1.0
+    >>> grid.at_node.keys()
+    [u'surface__elevation']
+    >>> grid.at_node['surface__elevation']
+    array([  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
+            11.])
+
+    >>> from landlab.io.netcdf import NETCDF3_64BIT_EXAMPLE_FILE
+    >>> grid = read_netcdf(NETCDF3_64BIT_EXAMPLE_FILE)
+    >>> grid.shape
+    (4, 3)
+    >>> grid.node_spacing
+    1.0
     """
     from landlab import RasterModelGrid
 

--- a/landlab/io/netcdf/read.py
+++ b/landlab/io/netcdf/read.py
@@ -100,10 +100,12 @@ def _get_raster_spacing(coords):
 
 
 def read_netcdf(nc_file, just_grid=False):
-    """Create a RasterModelGrid from a netcdf file.
+    """Create a :class:`~.RasterModelGrid` from a netcdf file.
 
-    Create a new RasterModelGrid from the netcdf file, *nc_file*. If the
-    netcdf file also contains data, add that data to the grid's fields.
+    Create a new :class:`~.RasterModelGrid` from the netcdf file, *nc_file*.
+    If the netcdf file also contains data, add that data to the grid's fields.
+    To create a new grid without any associated data from the netcdf file,
+    set the *just_grid* keyword to ``True``.
 
     Parameters
     ----------
@@ -114,13 +116,22 @@ def read_netcdf(nc_file, just_grid=False):
 
     Returns
     -------
-    RasterModelGrid
-        A newly-created RasterModelGrid.
+    :class:`~.RasterModelGrid`
+        A newly-created :class:`~.RasterModelGrid`.
 
     Examples
     --------
+    Import :func:`read_netcdf` and the path to an example netcdf file included
+    with landlab.
+
     >>> from landlab.io.netcdf import read_netcdf
     >>> from landlab.io.netcdf import NETCDF4_EXAMPLE_FILE
+
+    Create a new grid from the netcdf file. The example grid is a uniform
+    rectilinear grid with 4 rows and 3 columns of nodes with unit spacing.
+    The data file also contains data defined at the nodes for the grid for
+    a variable called, *surface__elevation*.
+
     >>> grid = read_netcdf(NETCDF4_EXAMPLE_FILE)
     >>> grid.shape
     (4, 3)
@@ -131,6 +142,9 @@ def read_netcdf(nc_file, just_grid=False):
     >>> grid.at_node['surface__elevation']
     array([  0.,   1.,   2.,   3.,   4.,   5.,   6.,   7.,   8.,   9.,  10.,
             11.])
+
+    :func:`read_netcdf` will try to determine the format of the netcdf file.
+    For example, the same call will also work for *netcdf3*-formatted files.
 
     >>> from landlab.io.netcdf import NETCDF3_64BIT_EXAMPLE_FILE
     >>> grid = read_netcdf(NETCDF3_64BIT_EXAMPLE_FILE)

--- a/landlab/io/netcdf/tests/test_read_netcdf.py
+++ b/landlab/io/netcdf/tests/test_read_netcdf.py
@@ -6,8 +6,9 @@ Unit tests for landlab.io.netcdf module.
 import os
 import numpy as np
 from StringIO import StringIO
-from unittest import skipIf
+#from unittest import skipIf
 from nose.tools import assert_equal
+from nose.plugins.skip import SkipTest
 
 from landlab.io.netcdf import read_netcdf, WITH_NETCDF4
 
@@ -20,7 +21,10 @@ def test_read_netcdf3_64bit():
     assert_equal(grid.shape, (4, 3))
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_read_netcdf4():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     grid = read_netcdf(os.path.join(_TEST_DATA_DIR, 'test-netcdf4.nc'))
     assert_equal(grid.shape, (4, 3))

--- a/landlab/io/netcdf/tests/test_write_netcdf.py
+++ b/landlab/io/netcdf/tests/test_write_netcdf.py
@@ -6,7 +6,7 @@ Unit tests for landlab.io.netcdf module.
 import os
 import numpy as np
 from StringIO import StringIO
-from unittest import skipIf
+#from unittest import skipIf
 from nose.tools import assert_equal, assert_true, assert_raises
 try:
     from nose import assert_list_equal
@@ -59,8 +59,11 @@ def test_netcdf_write_as_netcdf3_classic():
             assert_array_equal(f.variables[name][:].flat, field.at_node[name])
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_netcdf_write():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     field = RasterModelGrid(4, 3)
     field.add_field('node', 'topographic_elevation', np.arange(12.))
 
@@ -89,8 +92,11 @@ def test_netcdf_write():
         root.close()
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_netcdf_write_as_netcdf4_classic():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     field = RasterModelGrid(4, 3)
     field.add_field('node', 'topographic_elevation', np.arange(12.))
     field.add_field('node', 'uplift_rate', np.arange(12.))
@@ -105,8 +111,11 @@ def test_netcdf_write_as_netcdf4_classic():
                                field.at_node[name])
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_netcdf_write_names_keyword_as_list():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     field = RasterModelGrid(4, 3)
     field.add_field('node', 'topographic_elevation', np.arange(12.))
     field.add_field('node', 'uplift_rate', np.arange(12.))
@@ -122,8 +131,11 @@ def test_netcdf_write_names_keyword_as_list():
                            field.at_node['topographic_elevation'])
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_netcdf_write_names_keyword_as_str():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     field = RasterModelGrid(4, 3)
     field.add_field('node', 'topographic_elevation', np.arange(12.))
     field.add_field('node', 'uplift_rate', np.arange(12.))
@@ -138,8 +150,11 @@ def test_netcdf_write_names_keyword_as_str():
                            field.at_node['uplift_rate'])
 
 
-@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
+#@skipIf(not WITH_NETCDF4, 'netCDF4 package not installed')
 def test_netcdf_write_names_keyword_as_none():
+    if not WITH_NETCDF4:
+        raise SkipTest('netCDF4 package not installed')
+
     field = RasterModelGrid(4, 3)
     field.add_field('node', 'topographic_elevation', np.arange(12.))
     field.add_field('node', 'uplift_rate', np.arange(12.))

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(name='landlab',
               'landlab_ex_3 = landlab.examples.diffusion2Dtest3:main',
           ]
       },
-      package_data={'': ['data/*asc', 'preciptest.in']},
+      package_data={'': ['data/*asc', 'data/*nc', 'preciptest.in']},
       test_suite='nose.collector',
       cmdclass={
           'install': install_and_register,


### PR DESCRIPTION
The `landlab.io.netcdf.read_netcdf` function was in need of better documentation and examples. This pull request tidies-up and adds documentation to the docstring for `read_netcdf`. In addition, it adds doctest examples that create a `RasterModelGrid` from some example netcdf files.