### PR TITLE
Better documentation for testing and building wheels

### DIFF
--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -243,13 +243,54 @@ will be added to the current pull request and the tests automatically rerun.
 
 You can also run unit tests locally with the `test-installed-landlab.py` script
 found in the `scripts` folder::
-
     > python test-installed-landlab.py --doctest
 
 If you don't want to run the doctests, you can drop the `--doctest` option.
 Note that this script will test whatever version of landlab you have installed,
 which may or may not be the one you are working on in your current working
 directory.
+
+
+Building Binary Distributions
+=============================
+
+Ultimately, this will be automated but, for now, this is how we build our
+binary distributions. The basic workflow is the following:
+
+* Create a fresh virtual Python environment
+* Install landlab dependencies
+* Install landlab
+* Create a wheel
+* Deploy the distribution to PyPI.
+
+The bash script, `dist_to_pypi.sh` is intended to help with this process.
+Note that it uses `conda` to create environments and install packages. Thus,
+to use this script you will need to have Anaconda installed. To build (and
+upload) a new set of binaries::
+    > bash_to_pypi.sh version [version [...]]
+
+Where *version* is the Python version for your build. You can also build
+distributions for multiple version of Python. For example::
+    > bash_to_pypi.sh 2.6 2.7 3.3 3.4
+
+If the version of landlab you are installing is the same as what is already
+on PyPI, you will not be able to upload the new version. To upload a new
+set of wheels, you must fist increase the landlab version number in
+`landlab/__init__.py`.
+
+Windows distributions are built in much the same way. However, they are
+created on Appveyor as part of the Windows CI. Note that although Appveyor
+runs the landlab tests with every push to GitHub, binary distributions are
+only built when a version is tagged. To create a tag for a new release::
+    > git tag <version>
+
+You will then need to push the tag to GitHub to activate the build. For
+example::
+    > git tag v0.1.27
+    > git push --tags
+
+For consistency, please stick with the above version format and follow the
+usual Python versioning standards.
 
 
 Troubleshooting

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -214,6 +214,10 @@ Coding Style
 * Further, Landlab-specific advice for developing your own components can be found
   in the :ref:`component development guide <dev_components>`.
 
+If you want to check how well you are doing, please look at our
+`Landscape page <https://landscape.io>`. Landscape will grade the health of
+the landlab code with every push to GitHub.
+
 
 Testing
 =======

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -215,7 +215,7 @@ Coding Style
   in the :ref:`component development guide <dev_components>`.
 
 If you want to check how well you are doing, please look at our
-`Landscape page <https://landscape.io>`. Landscape will grade the health of
+`Landscape page <https://landscape.io>`_. Landscape will grade the health of
 the landlab code with every push to GitHub.
 
 
@@ -233,8 +233,8 @@ shows the latest testing results. A new set of tests are executed whenever
 any changes are pushed to the Landlab repository and with every pull request.
 We currently run test suites for Python versions 2.6, 2.7, 3.3, and 3.4.
 
-Continuous integration for Windows is done on `Appveyor <https://appveyor.com>`
-and also tests with Python 2.6, 2.7, 3.3, and 3.4.
+Continuous integration for Windows is done on
+`Appveyor <https://ci.appveyor.com>`_ and also tests with Python 2.6, 2.7, 3.3, and 3.4.
 
 Once you send a pull request from GitHub, you will be taken to the Landlab
 pull request page and all unit tests are run. You will see the status

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -227,9 +227,10 @@ Landlab uses `Travis <https://travis-ci.org>`_ for continuous integration
 testing. The `landlab page on Travis <https://travis-ci.org/landlab/landlab>`_
 shows the latest testing results. A new set of tests are executed whenever
 any changes are pushed to the Landlab repository and with every pull request.
-We currently run test suites for Python versions 2.6, 2.7, 3.3, and 3.4 (for
-Python 3 versions we use the `2to3 <https://docs.python.org/2/library/2to3.html>`_
-tool).
+We currently run test suites for Python versions 2.6, 2.7, 3.3, and 3.4.
+
+Continuous integration for Windows is done on `Appveyor <https://appveyor.com>`
+and also tests with Python 2.6, 2.7, 3.3, and 3.4.
 
 Once you send a pull request from GitHub, you will be taken to the Landlab
 pull request page and all unit tests are run. You will see the status
@@ -240,11 +241,15 @@ responsible for the failures, please fix them until the tests pass. Note that
 you do not need to send a new pull request after committing for fixes. They
 will be added to the current pull request and the tests automatically rerun.
 
-You can also run unit tests locally with `nose
-<https://nose.readthedocs.org>`_. From the top-level Landlab folder (landlab with a lowercase *l* and the folder
-that contains `setup.py`) run::
+You can also run unit tests locally with the `test-installed-landlab.py` script
+found in the `scripts` folder::
 
-  > nosetests
+    > python test-installed-landlab.py --doctest
+
+If you don't want to run the doctests, you can drop the `--doctest` option.
+Note that this script will test whatever version of landlab you have installed,
+which may or may not be the one you are working on in your current working
+directory.
 
 
 Troubleshooting

--- a/scripts/dist_to_pypi.sh
+++ b/scripts/dist_to_pypi.sh
@@ -43,6 +43,8 @@ done
 
 conda create -n dist python=2.7
 source activate dist
+conda install numpy
+conda install six
 
 python setup.py sdist
 


### PR DESCRIPTION
#130 and #131.

Adds documentation that describes how to:
* run the doctests and unittests
* build wheel distributions
* use Landscape