### PR TITLE
Fix failing unit tests on Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ environment:
     NUMPY_VERSION: "1.9.1"
 
   matrix:
-    #    - PYTHON_VERSION: "2.6"
-    #    - PYTHON_VERSION: "2.7"
-    #    - PYTHON_VERSION: "3.3"
+    - PYTHON_VERSION: "2.6"
+    - PYTHON_VERSION: "2.7"
+    - PYTHON_VERSION: "3.3"
     - PYTHON_VERSION: "3.4"
 
 platform:

--- a/landlab/components/flow_routing/flow_direction_DN.py
+++ b/landlab/components/flow_routing/flow_direction_DN.py
@@ -13,6 +13,8 @@ import inspect
 
 from landlab import RasterModelGrid, BAD_INDEX_VALUE
 from landlab.grid.raster_funcs import calculate_steepest_descent_across_cell_faces
+from landlab.core.utils import as_id_array
+
 
 UNDEFINED_INDEX = BAD_INDEX_VALUE
 
@@ -249,7 +251,7 @@ def flow_directions(elev, active_links, fromnode, tonode, link_slope,
     # include boundary nodes as well as interior ones; "pits" would be sink
     # nodes that are also interior nodes).
     (sink, ) = np.where(node_id==receiver)
-    sink = sink.astype(np.int, copy=False)
+    sink = as_id_array(sink)
     
     return receiver, steepest_slope, sink, receiver_link
     

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -21,7 +21,6 @@ def as_id_array(x):
 
     Examples
     --------
-
     >>> import numpy as np
     >>> from landlab.core.utils import as_id_array
     >>> x = np.arange(5)
@@ -35,16 +34,22 @@ def as_id_array(x):
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
+    >>> y.dtype == np.int
+    True
 
     >>> x = np.arange(5, dtype=np.int64)
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
+    >>> y.dtype == np.int
+    True
 
     >>> x = np.arange(5, dtype=np.intp)
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
+    >>> y.dtype == np.int
+    True
     """
     if x.dtype != np.int or x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -54,13 +54,24 @@ def as_id_array(x):
     >>> y.dtype == np.int
     True
     """
-    if x.dtype == np.intp and np.dtype(np.intp) == np.int:
-        return x.view(np.int)
-
     if x.dtype == np.int:
         return x.view(np.int)
     else:
         return x.astype(np.int)
+
+
+if np.dtype(np.intp) == np.int:
+    def _as_id_array(x):
+        if x.dtype == np.intp or x.dtype == np.int:
+            return x.view(np.int)
+        else:
+            return x.astype(np.int)
+else:
+    def _as_id_array(x):
+        if x.dtype == np.int:
+            return x.view(np.int)
+        else:
+            return x.astype(np.int)
 
 
 def get_functions_from_module(mod, pattern=None):

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -61,7 +61,9 @@ def as_id_array(x):
     True
     """
     if x.dtype == np.intp and np.dtype(np.intp) == np.int:
-        return np.array(x, dtype=np.int)
+        id_array = x.view(np.int)
+        return id_array
+        #return np.array(x, dtype=np.int)
 
     if x.dtype != np.int or x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -41,9 +41,12 @@ def as_id_array(x):
     >>> y
     array([0, 1, 2, 3, 4])
     """
-    id_array = x.astype(np.int, copy=False)
-    if id_array.dtype.itemsize != SIZEOF_INT:
-        raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))
+    if x.dtype != np.int and x.itemsize != SIZEOF_INT:
+        id_array = x.astype(np.int, copy=True)
+        if id_array.dtype.itemsize != SIZEOF_INT:
+            raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))
+    else:
+        id_array = x
     return id_array
 
 

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -1,5 +1,48 @@
 #! /usr/bin/env python
 
+import numpy as np
+
+
+def as_id_array(x):
+    """Convert an array to an array of ids.
+
+    Parameters
+    ----------
+    x : ndarray
+        Array of IDs.
+
+    Returns
+    -------
+    ndarray
+        A, possibly new, array of IDs.
+
+    Examples
+    --------
+
+    >>> import numpy as np
+    >>> from landlab.core.utils import as_id_array
+    >>> x = np.arange(5)
+    >>> y = as_id_array(x)
+    >>> y
+    array([0, 1, 2, 3, 4])
+    >>> x is y
+    True
+
+    >>> x = np.arange(5, dtype=np.int32)
+    >>> y = as_id_array(x)
+    >>> y
+    array([0, 1, 2, 3, 4])
+
+    >>> x = np.arange(5, dtype=np.int64)
+    >>> y = as_id_array(x)
+    >>> y
+    array([0, 1, 2, 3, 4])
+    """
+    id_array = x.astype(np.int, copy=False)
+    if id_array.dtype != np.int:
+        raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))
+    return id_array
+
 
 def get_functions_from_module(mod, pattern=None):
     import inspect, re

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -30,6 +30,13 @@ def as_id_array(x):
     >>> x is y
     True
 
+    >>> x = np.arange(5, dtype=np.int)
+    >>> y = as_id_array(x)
+    >>> y
+    array([0, 1, 2, 3, 4])
+    >>> x is y
+    True
+
     >>> x = np.arange(5, dtype=np.int32)
     >>> y = as_id_array(x)
     >>> y
@@ -45,6 +52,8 @@ def as_id_array(x):
     True
 
     >>> x = np.arange(5, dtype=np.intp)
+    >>> x.dtype
+    >>> np.dtype(np.intp) != np.int
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -53,14 +53,14 @@ def as_id_array(x):
 
     >>> x = np.arange(5, dtype=np.intp)
     >>> x.dtype
-    >>> np.dtype(np.intp) != np.int
+    >>> np.dtype(np.intp) == np.int
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
     >>> y.dtype == np.int
     True
     """
-    if x.dtype == np.intp and np.dtype(np.intp) != np.int:
+    if x.dtype == np.intp and np.dtype(np.intp) == np.int:
         return np.array(x, dtype=np.int)
 
     if x.dtype != np.int or x.itemsize != SIZEOF_INT:

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -40,6 +40,11 @@ def as_id_array(x):
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
+
+    >>> x = np.arange(5, dtype=np.intp)
+    >>> y = as_id_array(x)
+    >>> y
+    array([0, 1, 2, 3, 4])
     """
     if x.dtype != np.int and x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -27,8 +27,6 @@ def as_id_array(x):
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
-    >>> x is y
-    True
 
     >>> x = np.arange(5, dtype=np.int)
     >>> y = as_id_array(x)

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -51,6 +51,9 @@ def as_id_array(x):
     >>> y.dtype == np.int
     True
     """
+    if x.dtype == np.intp and np.dtype(np.intp) != np.int:
+        return np.array(x, dtype=np.int)
+
     if x.dtype != np.int or x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)
         if id_array.dtype.itemsize != SIZEOF_INT:

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -3,6 +3,9 @@
 import numpy as np
 
 
+SIZEOF_INT = np.dtype(np.int).itemsize
+
+
 def as_id_array(x):
     """Convert an array to an array of ids.
 
@@ -39,7 +42,7 @@ def as_id_array(x):
     array([0, 1, 2, 3, 4])
     """
     id_array = x.astype(np.int, copy=False)
-    if id_array.dtype != np.int:
+    if id_array.dtype.itemsize != SIZEOF_INT:
         raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))
     return id_array
 

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -34,8 +34,6 @@ def as_id_array(x):
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
-    >>> x is y
-    True
 
     >>> x = np.arange(5, dtype=np.int32)
     >>> y = as_id_array(x)
@@ -52,8 +50,6 @@ def as_id_array(x):
     True
 
     >>> x = np.arange(5, dtype=np.intp)
-    >>> x.dtype
-    >>> np.dtype(np.intp) == np.int
     >>> y = as_id_array(x)
     >>> y
     array([0, 1, 2, 3, 4])
@@ -61,9 +57,12 @@ def as_id_array(x):
     True
     """
     if x.dtype == np.intp and np.dtype(np.intp) == np.int:
-        id_array = x.view(np.int)
-        return id_array
-        #return np.array(x, dtype=np.int)
+        return x.view(np.int)
+
+    if x.dtype == np.int:
+        return x.view(np.int)
+    else:
+        return x.astype(np.int, copy=True)
 
     if x.dtype != np.int or x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -60,15 +60,7 @@ def as_id_array(x):
     if x.dtype == np.int:
         return x.view(np.int)
     else:
-        return x.astype(np.int, copy=True)
-
-    if x.dtype != np.int or x.itemsize != SIZEOF_INT:
-        id_array = x.astype(np.int, copy=True)
-        if id_array.dtype.itemsize != SIZEOF_INT:
-            raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))
-    else:
-        id_array = x
-    return id_array
+        return x.astype(np.int)
 
 
 def get_functions_from_module(mod, pattern=None):

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -46,7 +46,7 @@ def as_id_array(x):
     >>> y
     array([0, 1, 2, 3, 4])
     """
-    if x.dtype != np.int and x.itemsize != SIZEOF_INT:
+    if x.dtype != np.int or x.itemsize != SIZEOF_INT:
         id_array = x.astype(np.int, copy=True)
         if id_array.dtype.itemsize != SIZEOF_INT:
             raise RuntimeError('id array is of type {dtype}'.format(dtype=id_array.dtype))

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -188,6 +188,7 @@ from landlab.field import ModelDataFields, ScalarDataFields
 from landlab.field.scalar_data_fields import FieldError
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from . import grid_funcs as gfuncs
+from ..core.utils import as_id_array
 
 
 #: Indicates an index is, in some way, *bad*.
@@ -461,7 +462,7 @@ class ModelGrid(ModelDataFields):
         core_nodes will return just core nodes.
         """
         (active_node_ids, ) = numpy.where(self.node_status != CLOSED_BOUNDARY)
-        return active_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(active_node_ids)
 
     @property
     def core_nodes(self):
@@ -472,7 +473,7 @@ class ModelGrid(ModelDataFields):
             return self._core_nodes
         except:
             (core_node_ids, ) = numpy.where(self.node_status == CORE_NODE)
-            return core_node_ids.astype(numpy.int, copy=False)
+            return as_id_array(core_node_ids)
 
     @property
     def boundary_nodes(self):
@@ -483,7 +484,7 @@ class ModelGrid(ModelDataFields):
             return self._boundary_nodes
         except:
             (boundary_node_ids, ) = numpy.where(self.node_status != CORE_NODE)
-            return boundary_node_ids.astype(numpy.int, copy=False)
+            return as_id_array(boundary_node_ids)
 
     @property
     def node_boundary_status(self):
@@ -509,7 +510,7 @@ class ModelGrid(ModelDataFields):
         Node id for all nodes not marked as a closed boundary
         """
         (open_node_ids, ) = numpy.where(self.node_status != CLOSED_BOUNDARY)
-        return open_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(open_node_ids)
 
     @property
     def open_boundary_nodes(self):
@@ -517,7 +518,7 @@ class ModelGrid(ModelDataFields):
         (open_boundary_node_ids, ) = numpy.where(
             (self.node_status != CLOSED_BOUNDARY) &
             (self.node_status != CORE_NODE))
-        return open_boundary_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(open_boundary_node_ids)
 
     @property
     def closed_boundary_nodes(self):
@@ -525,7 +526,7 @@ class ModelGrid(ModelDataFields):
         """
         (closed_boundary_node_ids, ) = numpy.where(
             self.node_status == CLOSED_BOUNDARY)
-        return closed_boundary_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(closed_boundary_node_ids)
 
     @property
     def fixed_gradient_boundary_nodes(self):
@@ -533,7 +534,7 @@ class ModelGrid(ModelDataFields):
         """
         (fixed_gradient_boundary_node_ids, ) = numpy.where(
             self.node_status == FIXED_GRADIENT_BOUNDARY)
-        return fixed_gradient_boundary_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(fixed_gradient_boundary_node_ids)
 
     @property
     def fixed_value_boundary_nodes(self):
@@ -541,7 +542,7 @@ class ModelGrid(ModelDataFields):
         """
         (fixed_value_boundary_node_ids, ) = numpy.where(
             self.node_status == FIXED_VALUE_BOUNDARY)
-        return fixed_value_boundary_node_ids.astype(numpy.int, copy=False)
+        return as_id_array(fixed_value_boundary_node_ids)
 
     @property
     def active_links(self):
@@ -561,13 +562,13 @@ class ModelGrid(ModelDataFields):
             use :func:`node_at_core_cell` for an exact equivalent.
         """
         (active_cell_ids, ) = numpy.where(self.node_status == CORE_NODE)
-        return active_cell_ids.astype(numpy.int, copy=False)
+        return as_id_array(active_cell_ids)
 
     @property
     def node_at_core_cell(self):
         """Node ID associated with core grid cells."""
         (core_cell_ids, ) = numpy.where(self.node_status == CORE_NODE)
-        return core_cell_ids.astype(numpy.int, copy=False)
+        return as_id_array(core_cell_ids)
 
     @property
     def active_cell_index_at_nodes(self):
@@ -697,7 +698,7 @@ class ModelGrid(ModelDataFields):
             Deprecated due to outdated terminology;
             use :func:`get_core_nodes` instead.
         """
-        return numpy.where(self.node_status == CORE_NODE)[0].astype(numpy.int, copy=False)
+        return as_id_array(numpy.where(self.node_status == CORE_NODE)[0])
 
     def get_core_nodes(self):
         """Node IDs of core nodes.
@@ -1724,7 +1725,7 @@ class ModelGrid(ModelDataFields):
                          (fromnode_status == CLOSED_BOUNDARY)))
 
         (self.active_link_ids, ) = numpy.where(active_links)
-        self.active_link_ids = self.active_link_ids.astype(numpy.int, copy=False)
+        self.active_link_ids = as_id_array(self.active_link_ids)
 
         self._num_active_links = len(self.active_link_ids)
         self._num_active_faces = self._num_active_links
@@ -1751,8 +1752,8 @@ class ModelGrid(ModelDataFields):
             node_corecell
             _boundary_nodes
         """
-        self.activecell_node = numpy.where(self.node_status != CLOSED_BOUNDARY)[0].astype(numpy.int, copy=False)
-        self.corecell_node = numpy.where(self.node_status == CORE_NODE)[0].astype(numpy.int, copy=False)
+        self.activecell_node = as_id_array(numpy.where(self.node_status != CLOSED_BOUNDARY)[0])
+        self.corecell_node = as_id_array(numpy.where(self.node_status == CORE_NODE)[0])
         self._num_core_cells = self.corecell_node.size
         self._num_core_nodes = self._num_core_cells
         self._num_active_nodes = self.activecell_node.size
@@ -1765,7 +1766,7 @@ class ModelGrid(ModelDataFields):
         self.node_activecell = numpy.empty(self.number_of_nodes, dtype=int)
         self.node_activecell.fill(BAD_INDEX_VALUE)
         self.node_activecell.flat[self.activecell_node] = self.active_cells
-        self._boundary_nodes = numpy.where(self.node_status != CORE_NODE)[0].astype(numpy.int, copy=False)
+        self._boundary_nodes = as_id_array(numpy.where(self.node_status != CORE_NODE)[0])
 
 
     def update_links_nodes_cells_to_new_BCs(self):
@@ -2001,9 +2002,8 @@ class ModelGrid(ModelDataFields):
 
         # Set up the inlink arrays
         tonodes = self.activelink_tonode
-        self.node_numactiveinlink = numpy.bincount(
-            tonodes, minlength=self.number_of_nodes).astype(numpy.int,
-                                                            copy=False)
+        self.node_numactiveinlink = as_id_array(numpy.bincount(
+            tonodes, minlength=self.number_of_nodes))
 
         counts = count_repeated_values(self.activelink_tonode)
         for (count, (tonodes, active_link_ids)) in enumerate(counts):
@@ -2011,9 +2011,8 @@ class ModelGrid(ModelDataFields):
 
         # Set up the outlink arrays
         fromnodes = self.activelink_fromnode
-        self.node_numactiveoutlink = numpy.bincount(
-            fromnodes, minlength=self.number_of_nodes).astype(numpy.int,
-                                                              copy=False)
+        self.node_numactiveoutlink = as_id_array(numpy.bincount(
+            fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
             self.node_active_outlink_matrix[count][fromnodes] = active_link_ids
@@ -2036,9 +2035,8 @@ class ModelGrid(ModelDataFields):
 
         # Set up the inlink arrays
         tonodes = self.node_at_link_head[self.active_links]
-        self.node_numactiveinlink = numpy.bincount(
-            tonodes, minlength=self.number_of_nodes).astype(numpy.int,
-                                                            copy=False)
+        self.node_numactiveinlink = as_id_array(numpy.bincount(
+            tonodes, minlength=self.number_of_nodes))
 
         # OK, HERE WE HAVE TO MAKE A CHANGE, BECAUSE THE INDICES RETURNED BY
         # count_repeated_values ARE "ACTIVE LINK INDICES", WHICH WE ARE NO
@@ -2052,9 +2050,8 @@ class ModelGrid(ModelDataFields):
 
         # Set up the outlink arrays
         fromnodes = self.node_at_link_tail[self.active_links]
-        self.node_numactiveoutlink = numpy.bincount(
-            fromnodes, minlength=self.number_of_nodes).astype(numpy.int,
-                                                              copy=False)
+        self.node_numactiveoutlink = as_id_array(numpy.bincount(
+            fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
             self.node_active_outlink_matrix2[count][fromnodes] = self.active_links[active_link_ids]
@@ -2406,7 +2403,7 @@ class ModelGrid(ModelDataFields):
         ndarray
             IDs of boundary nodes.
         """
-        return numpy.where(self.node_status != 0)[0].astype(numpy.int, copy=False)
+        return as_id_array(numpy.where(self.node_status != 0)[0])
 
     def _assign_boundary_nodes_to_grid_sides(self):
         """

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -964,7 +964,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                               (diag_fromnode_status == CLOSED_BOUNDARY)))
 
         (_diag_active_links, ) = np.where(diag_active_links)
-        #_diag_active_links = _diag_active_links.astype(np.int, copy=False)
         _diag_active_links = as_id_array(_diag_active_links)
 
         self._num_diag_active_links = len(_diag_active_links)
@@ -1547,7 +1546,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             ID = int(ID)
         except:
             ID = as_id_array(ID)
-            #ID = ID.astype(np.int, copy=False)
         return np.array([ID, ID + self.number_of_node_columns,
                          ID + self.number_of_node_columns + 1, ID + 1])
 
@@ -2485,7 +2483,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
         #save some internal data to speed updating:
         self.fixed_value_node_properties = {}
-        #self.fixed_value_node_properties['boundary_node_IDs'] = np.where(self.node_status==FIXED_VALUE_BOUNDARY)[0].astype(np.int, copy=False)
         self.fixed_value_node_properties['boundary_node_IDs'] = as_id_array(
             np.where(self.node_status == FIXED_VALUE_BOUNDARY)[0])
 
@@ -2619,8 +2616,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self.looped_node_properties = {}
         all_the_IDs = np.concatenate((these_boundary_IDs, existing_IDs))
         ID_ordering = np.argsort(all_the_IDs)
-        #self.looped_node_properties['boundary_node_IDs'] = all_the_IDs[ID_ordering].astype(np.int, copy=False)
-        #self.looped_node_properties['linked_node_IDs'] = np.concatenate((these_linked_nodes,existing_links))[ID_ordering].astype(np.int, copy=False)
         self.looped_node_properties['boundary_node_IDs'] = as_id_array(all_the_IDs[ID_ordering])
         self.looped_node_properties['linked_node_IDs'] = as_id_array(np.concatenate((these_linked_nodes,existing_links))[ID_ordering])
 
@@ -2915,12 +2910,9 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             self.fixed_gradient_node_properties = {}
             self.fixed_gradient_link_properties = {}
             self.fixed_gradient_node_properties['fixed_gradient_of'] = gradient_of
-            #self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
             self.fixed_gradient_node_properties['boundary_node_IDs'] = as_id_array(fixed_gradient_nodes)
-            #self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
             self.fixed_gradient_node_properties['anchor_node_IDs'] = as_id_array(fixed_gradient_linked_nodes)
             self.fixed_gradient_node_properties['values_to_add'] = fixed_gradient_values_to_add
-            #self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
             self.fixed_gradient_link_properties['boundary_link_IDs'] = as_id_array(boundary_links)
             #Update the link gradients over whole grid, as if there's values in the grid already, there could be compatibility issues...
             self.fixed_gradient_link_properties['boundary_link_gradients'] = self.calculate_gradients_at_links(self['node'][gradient_of])[boundary_links]
@@ -2946,12 +2938,9 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             self.fixed_gradient_node_properties = {}
             self.fixed_gradient_link_properties = {}
             self.fixed_gradient_node_properties['fixed_gradient_of'] = gradient_of
-            #self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
             self.fixed_gradient_node_properties['boundary_node_IDs'] = as_id_array(fixed_gradient_nodes)
-            #self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
             self.fixed_gradient_node_properties['anchor_node_IDs'] = as_id_array(fixed_gradient_linked_nodes)
             self.fixed_gradient_node_properties['values_to_add'] = fixed_gradient_values_to_add
-            #self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
             self.fixed_gradient_link_properties['boundary_link_IDs'] = as_id_array(boundary_links)
             #Update the link gradients over whole grid, as if there's values in the grid already, there could be compatibility issues...
             self.fixed_gradient_link_properties['boundary_link_gradients'] = self.calculate_gradients_at_links(self['node'][gradient_of])[boundary_links]

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -22,6 +22,7 @@ from landlab.field.scalar_data_fields import FieldError
 from . import raster_funcs as rfuncs
 from ..io import write_esri_ascii
 from ..io.netcdf import write_netcdf
+from ..core.utils import as_id_array
 
 
 def node_has_boundary_neighbor(mg, id):
@@ -3935,10 +3936,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         array([13,  4])
         """
         ids = np.ravel_multi_index((row, col), self.shape, **kwds)
-        try:
-            return ids.astype(np.int, copy=False)
-        except TypeError:
-            return ids.astype(np.int)
+        return as_id_array(ids)
 
     def _setup_face_widths(self):
         """

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -964,7 +964,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                               (diag_fromnode_status == CLOSED_BOUNDARY)))
 
         (_diag_active_links, ) = np.where(diag_active_links)
-        _diag_active_links = _diag_active_links.astype(np.int, copy=False)
+        #_diag_active_links = _diag_active_links.astype(np.int, copy=False)
+        _diag_active_links = as_id_array(_diag_active_links)
 
         self._num_diag_active_links = len(_diag_active_links)
         self._diag_activelink_fromnode = self._diag_link_fromnode[_diag_active_links]
@@ -1545,7 +1546,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         try:
             ID = int(ID)
         except:
-            ID = ID.astype(np.int, copy=False)
+            ID = as_id_array(ID)
+            #ID = ID.astype(np.int, copy=False)
         return np.array([ID, ID + self.number_of_node_columns,
                          ID + self.number_of_node_columns + 1, ID + 1])
 
@@ -2483,7 +2485,10 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
         #save some internal data to speed updating:
         self.fixed_value_node_properties = {}
-        self.fixed_value_node_properties['boundary_node_IDs'] = np.where(self.node_status==FIXED_VALUE_BOUNDARY)[0].astype(np.int, copy=False)
+        #self.fixed_value_node_properties['boundary_node_IDs'] = np.where(self.node_status==FIXED_VALUE_BOUNDARY)[0].astype(np.int, copy=False)
+        self.fixed_value_node_properties['boundary_node_IDs'] = as_id_array(
+            np.where(self.node_status == FIXED_VALUE_BOUNDARY)[0])
+
         if value:
             if type(value) == float or type(value) == int:
                 values_to_use = float(value)
@@ -2614,8 +2619,10 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self.looped_node_properties = {}
         all_the_IDs = np.concatenate((these_boundary_IDs, existing_IDs))
         ID_ordering = np.argsort(all_the_IDs)
-        self.looped_node_properties['boundary_node_IDs'] = all_the_IDs[ID_ordering].astype(np.int, copy=False)
-        self.looped_node_properties['linked_node_IDs'] = np.concatenate((these_linked_nodes,existing_links))[ID_ordering].astype(np.int, copy=False)
+        #self.looped_node_properties['boundary_node_IDs'] = all_the_IDs[ID_ordering].astype(np.int, copy=False)
+        #self.looped_node_properties['linked_node_IDs'] = np.concatenate((these_linked_nodes,existing_links))[ID_ordering].astype(np.int, copy=False)
+        self.looped_node_properties['boundary_node_IDs'] = as_id_array(all_the_IDs[ID_ordering])
+        self.looped_node_properties['linked_node_IDs'] = as_id_array(np.concatenate((these_linked_nodes,existing_links))[ID_ordering])
 
         if np.any(self.node_status[self.looped_node_properties['boundary_node_IDs']] == 2):
             raise AttributeError('Switching a boundary between fixed gradient and looped will result in bad BC handling! Bailing out...')
@@ -2908,10 +2915,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             self.fixed_gradient_node_properties = {}
             self.fixed_gradient_link_properties = {}
             self.fixed_gradient_node_properties['fixed_gradient_of'] = gradient_of
-            self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
-            self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
+            #self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
+            self.fixed_gradient_node_properties['boundary_node_IDs'] = as_id_array(fixed_gradient_nodes)
+            #self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
+            self.fixed_gradient_node_properties['anchor_node_IDs'] = as_id_array(fixed_gradient_linked_nodes)
             self.fixed_gradient_node_properties['values_to_add'] = fixed_gradient_values_to_add
-            self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
+            #self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
+            self.fixed_gradient_link_properties['boundary_link_IDs'] = as_id_array(boundary_links)
             #Update the link gradients over whole grid, as if there's values in the grid already, there could be compatibility issues...
             self.fixed_gradient_link_properties['boundary_link_gradients'] = self.calculate_gradients_at_links(self['node'][gradient_of])[boundary_links]
 
@@ -2936,10 +2946,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             self.fixed_gradient_node_properties = {}
             self.fixed_gradient_link_properties = {}
             self.fixed_gradient_node_properties['fixed_gradient_of'] = gradient_of
-            self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
-            self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
+            #self.fixed_gradient_node_properties['boundary_node_IDs'] = fixed_gradient_nodes.astype(np.int, copy=False)
+            self.fixed_gradient_node_properties['boundary_node_IDs'] = as_id_array(fixed_gradient_nodes)
+            #self.fixed_gradient_node_properties['anchor_node_IDs'] = fixed_gradient_linked_nodes.astype(np.int, copy=False)
+            self.fixed_gradient_node_properties['anchor_node_IDs'] = as_id_array(fixed_gradient_linked_nodes)
             self.fixed_gradient_node_properties['values_to_add'] = fixed_gradient_values_to_add
-            self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
+            #self.fixed_gradient_link_properties['boundary_link_IDs'] = boundary_links.astype(np.int, copy=False)
+            self.fixed_gradient_link_properties['boundary_link_IDs'] = as_id_array(boundary_links)
             #Update the link gradients over whole grid, as if there's values in the grid already, there could be compatibility issues...
             self.fixed_gradient_link_properties['boundary_link_gradients'] = self.calculate_gradients_at_links(self['node'][gradient_of])[boundary_links]
 

--- a/landlab/grid/structured_quad/links.py
+++ b/landlab/grid/structured_quad/links.py
@@ -571,8 +571,6 @@ def active_link_ids(shape, node_status):
     >>> active_link_ids((3, 4), status)
     array([ 1,  2,  5,  6, 11, 12, 13])
     """
-    #return np.where(is_active_link(shape, node_status))[0].astype(np.int,
-    #                                                              copy=True)
     return as_id_array(np.where(is_active_link(shape, node_status))[0])
 
     
@@ -650,7 +648,6 @@ def horizontal_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
     # number of vertical links. We do this by starting at the "minimum horizontal
     # link id" found above and going to the end of the list. 
     horizontal_links = horizontal_links[min_hori_id:]
-    #horizontal_links = horizontal_links.astype(int)
     
     # Return an array with length of number_of_vertical_links that has '-1' for
     # inactive links and the active link id for active links
@@ -724,7 +721,6 @@ def vertical_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
     
     # In the array of '-1's, we input the active link ids. 
     vertical_links[vertical_ids] = vertical_ids
-    #vertical_links = vertical_links.astype(int)
 
     # Return an array with length of number_of_vertical_links that has '-1' for
     # inactive links and the active link id for active links

--- a/landlab/grid/structured_quad/links.py
+++ b/landlab/grid/structured_quad/links.py
@@ -4,6 +4,7 @@ import numpy as np
 from . import nodes
 from ..base import CORE_NODE, CLOSED_BOUNDARY
 from ..unstructured.links import LinkGrid
+from ...core.utils import as_id_array
 
 
 def shape_of_vertical_links(shape):
@@ -570,8 +571,9 @@ def active_link_ids(shape, node_status):
     >>> active_link_ids((3, 4), status)
     array([ 1,  2,  5,  6, 11, 12, 13])
     """
-    return np.where(is_active_link(shape, node_status))[0].astype(np.int,
-                                                                  copy=False)
+    #return np.where(is_active_link(shape, node_status))[0].astype(np.int,
+    #                                                              copy=True)
+    return as_id_array(np.where(is_active_link(shape, node_status))[0])
 
     
 def horizontal_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
@@ -648,11 +650,11 @@ def horizontal_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
     # number of vertical links. We do this by starting at the "minimum horizontal
     # link id" found above and going to the end of the list. 
     horizontal_links = horizontal_links[min_hori_id:]
-    horizontal_links = horizontal_links.astype(int)
+    #horizontal_links = horizontal_links.astype(int)
     
     # Return an array with length of number_of_vertical_links that has '-1' for
     # inactive links and the active link id for active links
-    return horizontal_links
+    return as_id_array(horizontal_links)
 
 
 def vertical_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
@@ -722,11 +724,11 @@ def vertical_active_link_ids(shape, active_link_ids, BAD_INDEX_VALUE=-1):
     
     # In the array of '-1's, we input the active link ids. 
     vertical_links[vertical_ids] = vertical_ids
-    vertical_links = vertical_links.astype(int)
+    #vertical_links = vertical_links.astype(int)
 
     # Return an array with length of number_of_vertical_links that has '-1' for
     # inactive links and the active link id for active links
-    return vertical_links
+    return as_id_array(vertical_links)
     
 def find_horizontal_south_neighbor(shape, horizontal_link_ids, BAD_INDEX_VALUE=-1):
     """Get IDs of SOUTH, horizontal link neighbor

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -1,6 +1,7 @@
 import numpy as np
 from six.moves import range
 
+from ...core.utils import as_id_type
 from ...utils.jaggedarray import JaggedArray
 from .status import CORE_NODE, CLOSED_BOUNDARY
 
@@ -87,7 +88,8 @@ def find_active_links(node_status, node_at_link_ends):
 
     (active_link_ids, ) = np.where(link_is_active(status_at_link_ends))
 
-    return active_link_ids.astype(np.int, copy=False)
+    return as_id_array(active_link_ids)
+    #return active_link_ids.astype(np.int, copy=True)
 
 
 def in_link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -117,7 +119,8 @@ def in_link_count_per_node(node_at_link_ends, number_of_nodes=None):
 
     #if len(node_at_link_end) != len(node_at_link_start):
     #    raise ValueError('Link arrays must be the same length')
-    return np.bincount(node_at_link_end, minlength=number_of_nodes).astype(np.int, copy=False)
+    return as_id_array(np.bincount(node_at_link_end, minlength=number_of_nodes))
+    #return np.bincount(node_at_link_end, minlength=number_of_nodes).astype(np.int, copy=True)
 
 
 def out_link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -194,7 +197,8 @@ def _sort_links_by_node(node_at_link_ends, link_ids=None, sortby=0):
     if link_ids is not None:
         return np.array(link_ids, dtype=np.int)[sorted_links]
     else:
-        return sorted_links.astype(np.int, copy=True)
+        return as_id_array(sorted_links)
+        #return sorted_links.astype(np.int, copy=True)
 
 
 def in_link_ids_at_node(node_at_link_ends, link_ids=None, number_of_nodes=None):

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -1,7 +1,7 @@
 import numpy as np
 from six.moves import range
 
-from ...core.utils import as_id_type
+from ...core.utils import as_id_array
 from ...utils.jaggedarray import JaggedArray
 from .status import CORE_NODE, CLOSED_BOUNDARY
 

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -89,7 +89,6 @@ def find_active_links(node_status, node_at_link_ends):
     (active_link_ids, ) = np.where(link_is_active(status_at_link_ends))
 
     return as_id_array(active_link_ids)
-    #return active_link_ids.astype(np.int, copy=True)
 
 
 def in_link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -120,7 +119,6 @@ def in_link_count_per_node(node_at_link_ends, number_of_nodes=None):
     #if len(node_at_link_end) != len(node_at_link_start):
     #    raise ValueError('Link arrays must be the same length')
     return as_id_array(np.bincount(node_at_link_end, minlength=number_of_nodes))
-    #return np.bincount(node_at_link_end, minlength=number_of_nodes).astype(np.int, copy=True)
 
 
 def out_link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -151,7 +149,8 @@ def out_link_count_per_node(node_at_link_ends, number_of_nodes=None):
     node_at_link_start, node_at_link_end = _split_link_ends(node_at_link_ends)
     if len(node_at_link_end) != len(node_at_link_start):
         raise ValueError('Link arrays must be the same length')
-    return np.bincount(node_at_link_start, minlength=number_of_nodes).astype(np.int, copy=True)
+    return as_id_array(np.bincount(node_at_link_start,
+                                   minlength=number_of_nodes))
 
 
 def link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -198,7 +197,6 @@ def _sort_links_by_node(node_at_link_ends, link_ids=None, sortby=0):
         return np.array(link_ids, dtype=np.int)[sorted_links]
     else:
         return as_id_array(sorted_links)
-        #return sorted_links.astype(np.int, copy=True)
 
 
 def in_link_ids_at_node(node_at_link_ends, link_ids=None, number_of_nodes=None):

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -148,7 +148,7 @@ def out_link_count_per_node(node_at_link_ends, number_of_nodes=None):
     node_at_link_start, node_at_link_end = _split_link_ends(node_at_link_ends)
     if len(node_at_link_end) != len(node_at_link_start):
         raise ValueError('Link arrays must be the same length')
-    return np.bincount(node_at_link_start, minlength=number_of_nodes).astype(np.int, copy=False)
+    return np.bincount(node_at_link_start, minlength=number_of_nodes).astype(np.int, copy=True)
 
 
 def link_count_per_node(node_at_link_ends, number_of_nodes=None):
@@ -194,7 +194,7 @@ def _sort_links_by_node(node_at_link_ends, link_ids=None, sortby=0):
     if link_ids is not None:
         return np.array(link_ids, dtype=np.int)[sorted_links]
     else:
-        return sorted_links.astype(np.int, copy=False)
+        return sorted_links.astype(np.int, copy=True)
 
 
 def in_link_ids_at_node(node_at_link_ends, link_ids=None, number_of_nodes=None):

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -321,7 +321,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         node_status[boundary_nodes] = 1
         
         # It's also useful to have a list of interior nodes
-        core_nodes = numpy.where(node_status==0)[0].astype(numpy.int, copy=False)
+        core_nodes = numpy.where(node_status==0)[0].astype(numpy.int64, copy=False)
         
         #save the arrays and update the properties
         self.node_status = node_status

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -5,6 +5,8 @@ import six
 from six.moves import range
 
 from landlab.grid.base import ModelGrid, CORE_NODE, BAD_INDEX_VALUE
+from landlab.core.utils import as_id_array
+
 from scipy.spatial import Voronoi
 
 def simple_poly_area(x, y):
@@ -312,6 +314,8 @@ class VoronoiDelaunayGrid(ModelGrid):
         boundary_nodes = numpy.concatenate(
             (convex_hull_nodes.astype(numpy.int, copy=True),
              coplanar_nodes.astype(numpy.int, copy=True)))
+        boundary_nodes = as_id_array(numpy.concatenate(
+            (convex_hull_nodes, coplanar_nodes)))
 
         # Now we'll create the "node_status" array, which contains the code
         # indicating whether the node is interior and active (=0) or a

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -310,8 +310,8 @@ class VoronoiDelaunayGrid(ModelGrid):
         convex_hull_nodes = numpy.array(list(set(hull.simplices.flatten())))
         coplanar_nodes = hull.coplanar[:,0]
         boundary_nodes = numpy.concatenate(
-            (convex_hull_nodes, coplanar_nodes)).astype(int, copy=False)
-    
+            (convex_hull_nodes, coplanar_nodes)).astype(numpy.int, copy=False)
+
         # Now we'll create the "node_status" array, which contains the code
         # indicating whether the node is interior and active (=0) or a
         # boundary (=1). This means that all perimeter (convex hull) nodes are
@@ -321,7 +321,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         node_status[boundary_nodes] = 1
         
         # It's also useful to have a list of interior nodes
-        core_nodes = numpy.where(node_status==0)[0].astype(numpy.int64, copy=False)
+        core_nodes = numpy.where(node_status==0)[0].astype(numpy.int, copy=False)
         
         #save the arrays and update the properties
         self.node_status = node_status

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -310,7 +310,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         convex_hull_nodes = numpy.array(list(set(hull.simplices.flatten())))
         coplanar_nodes = hull.coplanar[:,0]
         boundary_nodes = numpy.concatenate(
-            (convex_hull_nodes, coplanar_nodes)).astype(numpy.int, copy=True)
+            (convex_hull_nodes, coplanar_nodes)).astype(int, copy=False)
     
         # Now we'll create the "node_status" array, which contains the code
         # indicating whether the node is interior and active (=0) or a

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -311,9 +311,6 @@ class VoronoiDelaunayGrid(ModelGrid):
         # points. We include these in our set of boundary nodes.
         convex_hull_nodes = numpy.array(list(set(hull.simplices.flatten())))
         coplanar_nodes = hull.coplanar[:,0]
-        boundary_nodes = numpy.concatenate(
-            (convex_hull_nodes.astype(numpy.int, copy=True),
-             coplanar_nodes.astype(numpy.int, copy=True)))
         boundary_nodes = as_id_array(numpy.concatenate(
             (convex_hull_nodes, coplanar_nodes)))
 
@@ -326,7 +323,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         node_status[boundary_nodes] = 1
         
         # It's also useful to have a list of interior nodes
-        core_nodes = numpy.where(node_status==0)[0].astype(numpy.int, copy=False)
+        core_nodes = as_id_array(numpy.where(node_status==0)[0])
         
         #save the arrays and update the properties
         self.node_status = node_status

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -310,8 +310,8 @@ class VoronoiDelaunayGrid(ModelGrid):
         convex_hull_nodes = numpy.array(list(set(hull.simplices.flatten())))
         coplanar_nodes = hull.coplanar[:,0]
         boundary_nodes = numpy.concatenate(
-            (convex_hull_nodes.astype(numpy.int, copy=False),
-             coplanar_nodes.astype(numpy.int, copy=False)))
+            (convex_hull_nodes.astype(numpy.int, copy=True),
+             coplanar_nodes.astype(numpy.int, copy=True)))
 
         # Now we'll create the "node_status" array, which contains the code
         # indicating whether the node is interior and active (=0) or a

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -310,7 +310,8 @@ class VoronoiDelaunayGrid(ModelGrid):
         convex_hull_nodes = numpy.array(list(set(hull.simplices.flatten())))
         coplanar_nodes = hull.coplanar[:,0]
         boundary_nodes = numpy.concatenate(
-            (convex_hull_nodes, coplanar_nodes)).astype(numpy.int, copy=False)
+            (convex_hull_nodes.astype(numpy.int, copy=False),
+             coplanar_nodes.astype(numpy.int, copy=False)))
 
         # Now we'll create the "node_status" array, which contains the code
         # indicating whether the node is interior and active (=0) or a

--- a/landlab/utils/count_repeats.py
+++ b/landlab/utils/count_repeats.py
@@ -3,6 +3,8 @@
 
 import numpy as np
 
+from ..core.utils import as_id_array
+
 
 def count_repeated_values(x):
     """Count how many times in an array values repeat and where they appear.
@@ -58,7 +60,8 @@ def count_repeated_values(x):
     (unique_values, unique_inds) = np.unique(x, return_index=True)
     if len(unique_values) > 0:
         x_inds = np.arange(len(x), dtype=np.int)
-        counts.append((unique_values, unique_inds.astype(np.int, copy=True)))
+        #counts.append((unique_values, unique_inds.astype(np.int, copy=True)))
+        counts.append((unique_values, as_id_array(unique_inds)))
 
         while 1:
             x = np.delete(x, unique_inds)

--- a/landlab/utils/count_repeats.py
+++ b/landlab/utils/count_repeats.py
@@ -50,14 +50,6 @@ def count_repeated_values(x):
     3
     >>> counts[0]
     (array([20, 30, 40]), array([0, 1, 2]))
-    >>> counts[0][0].dtype
-    dtype('int64')
-    >>> counts[0][0].dtype.itemsize
-    8
-    >>> counts[0][1].dtype
-    dtype('int64')
-    >>> counts[0][1].dtype.itemsize
-    8
     >>> counts[1]
     (array([30]), array([3]))
     >>> counts[2]
@@ -66,22 +58,6 @@ def count_repeated_values(x):
     counts = []
 
     (unique_values, unique_inds) = np.unique(x, return_index=True)
-    #if len(unique_values) > 0:
-    #    x_inds = np.arange(len(x), dtype=np.int)
-    #    #counts.append((unique_values, unique_inds.astype(np.int, copy=True)))
-    #    #counts.append((unique_values, as_id_array(unique_inds)))
-    #    counts.append((unique_values, x_inds[unique_ids]))
-
-    #    while 1:
-    #        x = np.delete(x, unique_inds)
-    #        x_inds = np.delete(x_inds, unique_inds)
-    #        (unique_values, unique_inds) = np.unique(x, return_index=True)
-
-    #        if len(unique_values) > 0:
-    #            counts.append((unique_values, x_inds[unique_inds]))
-    #        else:
-    #            break
-
     x_inds = np.arange(len(x), dtype=np.int)
     while len(unique_values) > 0:
         counts.append((unique_values, x_inds[unique_inds]))

--- a/landlab/utils/count_repeats.py
+++ b/landlab/utils/count_repeats.py
@@ -66,19 +66,27 @@ def count_repeated_values(x):
     counts = []
 
     (unique_values, unique_inds) = np.unique(x, return_index=True)
-    if len(unique_values) > 0:
-        x_inds = np.arange(len(x), dtype=np.int)
-        #counts.append((unique_values, unique_inds.astype(np.int, copy=True)))
-        counts.append((unique_values, as_id_array(unique_inds)))
+    #if len(unique_values) > 0:
+    #    x_inds = np.arange(len(x), dtype=np.int)
+    #    #counts.append((unique_values, unique_inds.astype(np.int, copy=True)))
+    #    #counts.append((unique_values, as_id_array(unique_inds)))
+    #    counts.append((unique_values, x_inds[unique_ids]))
 
-        while 1:
-            x = np.delete(x, unique_inds)
-            x_inds = np.delete(x_inds, unique_inds)
-            (unique_values, unique_inds) = np.unique(x, return_index=True)
+    #    while 1:
+    #        x = np.delete(x, unique_inds)
+    #        x_inds = np.delete(x_inds, unique_inds)
+    #        (unique_values, unique_inds) = np.unique(x, return_index=True)
 
-            if len(unique_values) > 0:
-                counts.append((unique_values, x_inds[unique_inds]))
-            else:
-                break
+    #        if len(unique_values) > 0:
+    #            counts.append((unique_values, x_inds[unique_inds]))
+    #        else:
+    #            break
+
+    x_inds = np.arange(len(x), dtype=np.int)
+    while len(unique_values) > 0:
+        counts.append((unique_values, x_inds[unique_inds]))
+        x = np.delete(x, unique_inds)
+        x_inds = np.delete(x_inds, unique_inds)
+        (unique_values, unique_inds) = np.unique(x, return_index=True)
 
     return counts

--- a/landlab/utils/count_repeats.py
+++ b/landlab/utils/count_repeats.py
@@ -50,6 +50,14 @@ def count_repeated_values(x):
     3
     >>> counts[0]
     (array([20, 30, 40]), array([0, 1, 2]))
+    >>> counts[0][0].dtype
+    dtype('int64')
+    >>> counts[0][0].dtype.itemsize
+    8
+    >>> counts[0][1].dtype
+    dtype('int64')
+    >>> counts[0][1].dtype.itemsize
+    8
     >>> counts[1]
     (array([30]), array([3]))
     >>> counts[2]

--- a/landlab/utils/structured_grid.py
+++ b/landlab/utils/structured_grid.py
@@ -1853,7 +1853,7 @@ def nodes_around_points_on_unit_grid(shape, coords, mode='raise'):
 
     return np.ravel_multi_index(((rows, rows + 1, rows + 1, rows),
                                  (cols, cols, cols + 1, cols + 1)),
-                                shape, mode=mode).T.astype(np.int, copy=False)
+                                shape, mode=mode).T.astype(np.int, copy=True)
 
 
 def nodes_around_points(shape, coords, spacing=(1., 1.),

--- a/landlab/utils/structured_grid.py
+++ b/landlab/utils/structured_grid.py
@@ -6,6 +6,7 @@ from six.moves import range
 from ..grid.base import (CORE_NODE, FIXED_GRADIENT_BOUNDARY,
                          FIXED_VALUE_BOUNDARY, TRACKS_CELL_BOUNDARY,
                          CLOSED_BOUNDARY, BAD_INDEX_VALUE)
+from ..core.utils import as_id_array
 
 
 def node_count(shape):
@@ -678,7 +679,7 @@ def active_links(shape, node_status_array=None, link_nodes=None):
 
     (active_links, ) = np.where(active_links)
 
-    return active_links.astype(np.int)
+    return as_id_array(active_links)
 
 
 def active_face_index(shape):
@@ -1847,13 +1848,13 @@ def nodes_around_points_on_unit_grid(shape, coords, mode='raise'):
     array([4, 7, 8, 5])
     """
     if isinstance(coords[0], np.ndarray):
-        (rows, cols) = (coords[0].astype(np.int), coords[1].astype(np.int))
+        (rows, cols) = (as_id_array(coords[0]), as_id_array(coords[1]))
     else:
         (rows, cols) = (int(coords[0]), int(coords[1]))
 
-    return np.ravel_multi_index(((rows, rows + 1, rows + 1, rows),
-                                 (cols, cols, cols + 1, cols + 1)),
-                                shape, mode=mode).T.astype(np.int, copy=True)
+    return as_id_array(np.ravel_multi_index(((rows, rows + 1, rows + 1, rows),
+                                             (cols, cols, cols + 1, cols + 1)),
+                                            shape, mode=mode).T)
 
 
 def nodes_around_points(shape, coords, spacing=(1., 1.),
@@ -1874,10 +1875,10 @@ def nodes_around_points(shape, coords, spacing=(1., 1.),
         ...
     ValueError: invalid entry in coordinates array
     """
-    return nodes_around_points_on_unit_grid(
+    return as_id_array(nodes_around_points_on_unit_grid(
         shape,
         ((coords[0] - origin[0]) / spacing[0],
-         (coords[1] - origin[1]) / spacing[1])).astype(np.int, copy=False)
+         (coords[1] - origin[1]) / spacing[1])))
 
 
 def nodes_around_point(shape, coords, spacing=(1., 1.)):
@@ -1888,6 +1889,7 @@ def nodes_around_point(shape, coords, spacing=(1., 1.)):
     return np.array([node_id, node_id + shape[1], node_id + shape[1] + 1,
                      node_id + 1])
 
+
 def interior_node_id_to_node_id(shape, core_node_ids):
     """
     Converts the id of an interior node ID (i.e., if just the interior nodes
@@ -1896,7 +1898,8 @@ def interior_node_id_to_node_id(shape, core_node_ids):
     IGW = shape[1]-2
     real_ID = (core_node_ids//IGW + 1) * shape[1] + (core_node_ids%IGW) + 1
     assert np.all(real_ID < shape[0]*shape[1])
-    return real_ID.astype(int)
+    return as_id_array(real_ID)
+
 
 def node_id_to_interior_node_id(shape, node_ids):
     """
@@ -1908,4 +1911,4 @@ def node_id_to_interior_node_id(shape, node_ids):
     if np.any(interior_ID < 0) or np.any(interior_ID >= (shape[0]-2)*(shape[1]-2)):
         raise IndexError("A supplied node was outside the interior grid")
     else:
-        return interior_ID.astype(int)
+        return as_id_array(interior_ID)


### PR DESCRIPTION
This pull request fixes the failing tests on Windows. All of the failures were the result of arrays of landlab element ids being different flavors of `int`. On some systems, functions like `numpy.bincount` return arrays with `dtype=intp`, which may or may not be the same as a regular `int`. The new function `landlab.core.utils.as_id_array` converts an array to a standardized array of ids. For landlab, this is an array with `dtype=int`. Where possible, the new array is just a view of the original but, sometimes, it's necessary to create a new array.