### PR TITLE
Fix failing docs build

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,7 +2,7 @@ scipy>=0.14
 numpy
 nose>=1.3
 matplotlib
-netCDF4
+numpydoc
 sympy
 pandas
 cython>=0.22

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,6 @@
-scipy>=0.14
+scipy
 numpy
-nose>=1.3
+nose
 matplotlib
 numpydoc
 sympy


### PR DESCRIPTION
The docs are not building on readthedocs. It seems readthedocs is having trouble installing the netCDF package.