### PR TITLE
Mcflugen/make node status private

### DIFF
--- a/landlab/components/cellular_automata/celllab_cts.py
+++ b/landlab/components/cellular_automata/celllab_cts.py
@@ -339,7 +339,7 @@ class CellLabCTSModel(object):
         # node
         self.bnd_lnk = numpy.zeros(self.grid.number_of_links, dtype=bool)
         for link_id in range(self.grid.number_of_links):
-            if self.grid.node_status[self.grid.node_at_link_tail[link_id]]!=_CORE or self.grid.node_status[self.grid.node_at_link_head[link_id]]!=_CORE:
+            if self.grid.status_at_node[self.grid.node_at_link_tail[link_id]]!=_CORE or self.grid.status_at_node[self.grid.node_at_link_head[link_id]]!=_CORE:
                 self.bnd_lnk[link_id] = True
 
         # Set up the initial node-state grid
@@ -769,9 +769,9 @@ class CellLabCTSModel(object):
         old_head_node_state = self.node_state[head_node]
 
         # Change to the new states
-        if self.grid.node_status[tail_node]==_CORE:
+        if self.grid.status_at_node[tail_node]==_CORE:
             self.node_state[tail_node] = self.node_pair[new_link_state][0]
-        if self.grid.node_status[head_node]==_CORE: #landlab.grid.base.CORE_NODE:
+        if self.grid.status_at_node[head_node]==_CORE: #landlab.grid.base.CORE_NODE:
             self.node_state[head_node] = self.node_pair[new_link_state][1]
 
         if _DEBUG:
@@ -803,8 +803,8 @@ class CellLabCTSModel(object):
 
         # If the link connects to a boundary, we might have a different state
         # than the one we planned
-        #if self.grid.node_status[self.grid.link_fromnode[link]]!=_CORE or \
-        #   self.grid.node_status[self.grid.link_tonode[link]]!=_CORE:
+        #if self.grid.status_at_node[self.grid.link_fromnode[link]]!=_CORE or \
+        #   self.grid.status_at_node[self.grid.link_tonode[link]]!=_CORE:
         if self.bnd_lnk[link]:
             fns = self.node_state[self.grid.node_at_link_tail[link]]
             tns = self.node_state[self.grid.node_at_link_head[link]]
@@ -931,9 +931,9 @@ class CellLabCTSModel(object):
                 tmp = self.propid[tail_node]
                 self.propid[tail_node] = self.propid[head_node]
                 self.propid[head_node] = tmp
-                if self.grid.node_status[tail_node]!=_CORE:
+                if self.grid.status_at_node[tail_node]!=_CORE:
                     self.prop_data[self.propid[tail_node]] = self.prop_reset_value
-                if self.grid.node_status[head_node]!=_CORE:
+                if self.grid.status_at_node[head_node]!=_CORE:
                     self.prop_data[self.propid[head_node]] = self.prop_reset_value
                 if event.prop_update_fn is not None:
                     event.prop_update_fn(self, tail_node, head_node, event.time)

--- a/landlab/components/cellular_automata/landlab_ca.py
+++ b/landlab/components/cellular_automata/landlab_ca.py
@@ -755,9 +755,9 @@ class LandlabCellularAutomaton(object):
         old_head_node_state = self.node_state[head_node]
 
         # Change to the new states
-        if self.grid.node_status[tail_node]==landlab.grid.base.CORE_NODE:
+        if self.grid.status_at_node[tail_node]==landlab.grid.base.CORE_NODE:
             self.node_state[tail_node] = self.cell_pair[new_link_state][0]
-        if self.grid.node_status[head_node]==landlab.grid.base.CORE_NODE:
+        if self.grid.status_at_node[head_node]==landlab.grid.base.CORE_NODE:
             self.node_state[head_node] = self.cell_pair[new_link_state][1]
 
         if _DEBUG:
@@ -795,9 +795,9 @@ class LandlabCellularAutomaton(object):
         ###fn = self.grid.activelink_fromnode[link]
         ###tn = self.grid.activelink_tonode[link]
         if _DEBUG:
-            six.print_('fn',fn,'tn',tn,'fnstat',self.grid.node_status[fn],'tnstat',self.grid.node_status[tn])
-        if self.grid.node_status[fn]!=landlab.grid.base.CORE_NODE or \
-           self.grid.node_status[tn]!=landlab.grid.base.CORE_NODE:
+            six.print_('fn',fn,'tn',tn,'fnstat',self.grid.status_at_node[fn],'tnstat',self.grid.status_at_node[tn])
+        if self.grid.status_at_node[fn]!=landlab.grid.base.CORE_NODE or \
+           self.grid.status_at_node[tn]!=landlab.grid.base.CORE_NODE:
             ###fns = self.node_state[self.grid.activelink_fromnode[link]]
             ###tns = self.node_state[self.grid.activelink_tonode[link]]
             ###orientation = self.active_link_orientation[link]
@@ -933,9 +933,9 @@ class LandlabCellularAutomaton(object):
                 tmp = self.propid[tail_node]
                 self.propid[tail_node] = self.propid[head_node]
                 self.propid[head_node] = tmp
-                if self.grid.node_status[tail_node]!=landlab.grid.base.CORE_NODE:
+                if self.grid.status_at_node[tail_node]!=landlab.grid.base.CORE_NODE:
                     self.prop_data[self.propid[tail_node]] = self.prop_reset_value
-                if self.grid.node_status[head_node]!=landlab.grid.base.CORE_NODE:
+                if self.grid.status_at_node[head_node]!=landlab.grid.base.CORE_NODE:
                     self.prop_data[self.propid[head_node]] = self.prop_reset_value
 
             if _DEBUG:

--- a/landlab/components/craters/dig_craters.py
+++ b/landlab/components/craters/dig_craters.py
@@ -103,7 +103,7 @@ class impactor(object):
         self.loop_dict = {} #this holds information on how looped BCs execute - see set_slope()
 
         #perform a BC condition check:
-        if not numpy.all(numpy.equal(grid.node_status[numpy.nonzero(grid.node_status)], 3)):
+        if not numpy.all(numpy.equal(grid.status_at_node[numpy.nonzero(grid.status_at_node)], 3)):
             self.looped_BCs = False
             six.print_('*****-----*****-----*****')
             six.print_('This module is designed to run with looped boundary conditions.')
@@ -290,8 +290,8 @@ class impactor(object):
                     #points_under_surface_reversed = impactor_elevs_along_line[::-1]<=self.elev[snapped_pts_along_line[::-1]]
                     reversed_index = numpy.argmax(self.dummy_int[:(num_divisions)])
                     #reversed_index = numpy.argmax(points_under_surface_reversed)
-                    intersect_pt_node_status = self.grid.node_status[self.dummy_2[(num_divisions-1)::-1][reversed_index]]
-                    #intersect_pt_node_status = self.grid.node_status[snapped_pts_along_line[::-1][reversed_index]]
+                    intersect_pt_node_status = self.grid.status_at_node[self.dummy_2[(num_divisions-1)::-1][reversed_index]]
+                    #intersect_pt_node_status = self.grid.status_at_node[snapped_pts_along_line[::-1][reversed_index]]
                 except IndexError: #only one item in array
                     six.print_(len(self.dummy_4[:(num_divisions)]))
                     assert len(self.dummy_4[:(num_divisions)]) == 1
@@ -299,8 +299,8 @@ class impactor(object):
                     #points_under_surface_reversed = impactor_elevs_along_line<=self.elev[snapped_pts_along_line]
                     reversed_index = numpy.argmax(self.dummy_int[:(num_divisions)])
                     #reversed_index = numpy.argmax(points_under_surface_reversed)
-                    intersect_pt_node_status = self.grid.node_status[self.dummy_2[:(num_divisions)]]
-                    #intersect_pt_node_status = self.grid.node_status[snapped_pts_along_line]
+                    intersect_pt_node_status = self.grid.status_at_node[self.dummy_2[:(num_divisions)]]
+                    #intersect_pt_node_status = self.grid.status_at_node[snapped_pts_along_line]
                 if numpy.any(self.dummy_int[:(num_divisions)]):
                 #if numpy.any(points_under_surface_reversed):
                     #print 'points under surface...', numpy.sum(points_under_surface_reversed)

--- a/landlab/components/flow_accum/examples/flow_accum_test_driver.py
+++ b/landlab/components/flow_accum/examples/flow_accum_test_driver.py
@@ -27,7 +27,7 @@ vectors.elev = np.array([10.,10.,0.,10.,10.,10.,8.,8.,9.,10.,10.,4.,6.,7.,10.,10
 
 print(vectors.elev.reshape((5,5)))
 print(np.array(range(25)).reshape((5,5)))
-#print mg.node_status.reshape((5,5))
+#print mg.status_at_node.reshape((5,5))
 
 #imshow_grid(mg,vectors.elev)
 #plot()

--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -186,9 +186,9 @@ class DepressionFinderAndRouter(Component):
             elif self._elev[t] > self._elev[h]:
                 self.is_pit[t] = False
             elif self._elev[h] == self._elev[t]:
-                if self._grid.node_boundary_status[h] == FIXED_VALUE_BOUNDARY:
+                if self._grid.status_at_node[h] == FIXED_VALUE_BOUNDARY:
                     self.is_pit[t] = False
-                elif self._grid.node_boundary_status[t] == FIXED_VALUE_BOUNDARY:
+                elif self._grid.status_at_node[t] == FIXED_VALUE_BOUNDARY:
                     self.is_pit[h] = False
                     
         # If we have a raster grid, handle the diagonal active links too
@@ -205,9 +205,9 @@ class DepressionFinderAndRouter(Component):
                 elif self._elev[t] > self._elev[h]:
                     self.is_pit[t] = False
                 elif self._elev[h] == self._elev[t]:
-                    if self._grid.node_boundary_status[h] == FIXED_VALUE_BOUNDARY:
+                    if self._grid.status_at_node[h] == FIXED_VALUE_BOUNDARY:
                         self.is_pit[t] = False
-                    elif self._grid.node_boundary_status[t] == FIXED_VALUE_BOUNDARY:
+                    elif self._grid.status_at_node[t] == FIXED_VALUE_BOUNDARY:
                         self.is_pit[h] = False
 
         # Record the number of pits and the IDs of pit nodes.
@@ -267,7 +267,7 @@ class DepressionFinderAndRouter(Component):
         """
         Determine whether the given node is a valid outlet for the depression.
         """
-        if self._grid.node_boundary_status[the_node]==FIXED_VALUE_BOUNDARY:
+        if self._grid.status_at_node[the_node] == FIXED_VALUE_BOUNDARY:
             #print '   this node is an open boundary, so of course it can drain'
             return True
             

--- a/landlab/components/flow_routing/route_flow_dn.py
+++ b/landlab/components/flow_routing/route_flow_dn.py
@@ -219,7 +219,9 @@ class FlowRouter(Component):
         # otherwise.
         link_slope = -self._grid.calculate_gradients_at_d8_active_links(elevs)
         # Find the baselevel nodes
-        (baselevel_nodes, ) = numpy.where(numpy.logical_or(self._grid.node_status==1, self._grid.node_status==2))
+        (baselevel_nodes, ) = numpy.where(
+            numpy.logical_or(self._grid.status_at_node == 1,
+                             self._grid.status_at_node == 2))
 
         # Calculate flow directions
         receiver, steepest_slope, sink, recvr_link  = \

--- a/landlab/components/linkca/link_ca.py
+++ b/landlab/components/linkca/link_ca.py
@@ -420,9 +420,9 @@ class LinkCellularAutomaton():
         old_tonode_state = self.node_state[tonode]
 
         # Change to the new states
-        if self.grid.node_status[fromnode]==landlab.grid.base.CORE_NODE:
+        if self.grid.status_at_node[fromnode]==landlab.grid.base.CORE_NODE:
             self.node_state[fromnode] = self.cell_pair[new_link_state][0]
-        if self.grid.node_status[tonode]==landlab.grid.base.CORE_NODE:
+        if self.grid.status_at_node[tonode]==landlab.grid.base.CORE_NODE:
             self.node_state[tonode] = self.cell_pair[new_link_state][1]
 
         if _DEBUG:
@@ -454,9 +454,9 @@ class LinkCellularAutomaton():
         fn = self.grid.activelink_fromnode[link]
         tn = self.grid.activelink_tonode[link]
         if _DEBUG:
-            print('fn',fn,'tn',tn,'fnstat',self.grid.node_status[fn],'tnstat',self.grid.node_status[tn])
-        if self.grid.node_status[fn]!=landlab.grid.base.CORE_NODE or \
-           self.grid.node_status[tn]!=landlab.grid.base.CORE_NODE:
+            print('fn',fn,'tn',tn,'fnstat',self.grid.status_at_node[fn],'tnstat',self.grid.status_at_node[tn])
+        if self.grid.status_at_node[fn]!=landlab.grid.base.CORE_NODE or \
+           self.grid.status_at_node[tn]!=landlab.grid.base.CORE_NODE:
             fns = self.node_state[self.grid.activelink_fromnode[link]]
             tns = self.node_state[self.grid.activelink_tonode[link]]
             orientation = self.active_link_orientation(link)  # VARIES WITH LATTICE AND ORIENTATION CHOICE

--- a/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
+++ b/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
@@ -194,49 +194,49 @@ class PerronNLDiffuse(object):
         self.left_flag = 1
         self.right_flag = 1
         # self.corner_flags = [1,1,1,1] #In ID order, so BL,BR,TL,TR
-        if numpy.all(grid.node_status[bottom_nodes[1:-1]] == 4):
+        if numpy.all(grid.status_at_node[bottom_nodes[1:-1]] == 4):
             # ^This should be all of them, or none of them
             self.bottom_flag = 4
-        elif numpy.all(grid.node_status[bottom_nodes[1:-1]] == 3):
+        elif numpy.all(grid.status_at_node[bottom_nodes[1:-1]] == 3):
             self.bottom_flag = 3
-        elif numpy.all(grid.node_status[bottom_nodes[1:-1]] == 2):
+        elif numpy.all(grid.status_at_node[bottom_nodes[1:-1]] == 2):
             self.bottom_flag = 2
-        elif numpy.all(grid.node_status[bottom_nodes[1:-1]] == 1):
+        elif numpy.all(grid.status_at_node[bottom_nodes[1:-1]] == 1):
             pass
         else:
             raise NameError('''Different cells on the same grid edge have
                             different boundary statuses!!''')
             # Note this could get fraught if we need to open a cell to let
             # water flow out...
-        if numpy.all(grid.node_status[top_nodes[1:-1]] == 4):
+        if numpy.all(grid.status_at_node[top_nodes[1:-1]] == 4):
             self.top_flag = 4
-        elif numpy.all(grid.node_status[top_nodes[1:-1]] == 3):
+        elif numpy.all(grid.status_at_node[top_nodes[1:-1]] == 3):
             self.top_flag = 3
-        elif numpy.all(grid.node_status[top_nodes[1:-1]] == 2):
+        elif numpy.all(grid.status_at_node[top_nodes[1:-1]] == 2):
             self.top_flag = 2
-        elif numpy.all(grid.node_status[top_nodes[1:-1]] == 1):
+        elif numpy.all(grid.status_at_node[top_nodes[1:-1]] == 1):
             pass
         else:
             raise NameError('''Different cells on the same grid edge have
                             different boundary statuses!!''')
-        if numpy.all(grid.node_status[left_nodes[1:-1]] == 4):
+        if numpy.all(grid.status_at_node[left_nodes[1:-1]] == 4):
             self.left_flag = 4
-        elif numpy.all(grid.node_status[left_nodes[1:-1]] == 3):
+        elif numpy.all(grid.status_at_node[left_nodes[1:-1]] == 3):
             self.left_flag = 3
-        elif numpy.all(grid.node_status[left_nodes[1:-1]] == 2):
+        elif numpy.all(grid.status_at_node[left_nodes[1:-1]] == 2):
             self.left_flag = 2
-        elif numpy.all(grid.node_status[left_nodes[1:-1]] == 1):
+        elif numpy.all(grid.status_at_node[left_nodes[1:-1]] == 1):
             pass
         else:
             raise NameError('''Different cells on the same grid edge have
                             different boundary statuses!!''')
-        if numpy.all(grid.node_status[right_nodes[1:-1]] == 4):
+        if numpy.all(grid.status_at_node[right_nodes[1:-1]] == 4):
             self.right_flag = 4
-        elif numpy.all(grid.node_status[right_nodes[1:-1]] == 3):
+        elif numpy.all(grid.status_at_node[right_nodes[1:-1]] == 3):
             self.right_flag = 3
-        elif numpy.all(grid.node_status[right_nodes[1:-1]] == 2):
+        elif numpy.all(grid.status_at_node[right_nodes[1:-1]] == 2):
             self.right_flag = 2
-        elif numpy.all(grid.node_status[right_nodes[1:-1]] == 1):
+        elif numpy.all(grid.status_at_node[right_nodes[1:-1]] == 1):
             pass
         else:
             raise NameError('''Different cells on the same grid edge have
@@ -256,7 +256,7 @@ class PerronNLDiffuse(object):
                                  apply to the data the diffuser is trying to
                                  work with!""")
 
-        if numpy.any(grid.node_status == 2):
+        if numpy.any(grid.status_at_node == 2):
             self.fixed_grad_offset_map = numpy.empty(nrows*ncols, dtype=float)
             self.fixed_grad_anchor_map = numpy.empty_like(
                                                     self.fixed_grad_offset_map)
@@ -264,7 +264,7 @@ class PerronNLDiffuse(object):
                 'boundary_node_IDs']] = grid.fixed_gradient_node_properties[
                                                                'values_to_add']
 
-        self.corner_flags = grid.node_status[[0, ncols-1, -ncols, -1]]
+        self.corner_flags = grid.status_at_node[[0, ncols-1, -ncols, -1]]
 
         op_mat_just_corners = operating_matrix_ID_map[self.corner_interior_IDs,
                                                       :]

--- a/landlab/components/overland_flow/examples/overland_flow_with_model_grid_deAlmeida_analyticalSolution.py
+++ b/landlab/components/overland_flow/examples/overland_flow_with_model_grid_deAlmeida_analyticalSolution.py
@@ -71,7 +71,7 @@ start_time = time.time()
 
 # These functions find link neighbors for horizontal and vertical active links.
 # First, we find all active links in the raster grid.
-active_ids = links.active_link_ids(mg.shape, mg.node_status)
+active_ids = links.active_link_ids(mg.shape, mg.status_at_node)
 
 # Then we find all horizontal link ids...
 horizontal_ids = links.horizontal_link_ids(mg.shape)

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -234,7 +234,7 @@ class OverlandFlow(Component):
         # links which are needed for the de Almeida solution
 
         # First we identify all active links
-        self.active_ids = links.active_link_ids(grid.shape, grid.node_status)
+        self.active_ids = links.active_link_ids(grid.shape, grid.status_at_node)
 
         # And then find all horizontal link IDs (Active and Inactive)
         self.horizontal_ids = links.horizontal_link_ids(grid.shape)
@@ -255,7 +255,7 @@ class OverlandFlow(Component):
             grid.shape, self.active_ids)
 
         if self.use_fixed_links:
-            fixed_link_ids = links.fixed_link_ids(grid.shape, grid.node_status)
+            fixed_link_ids = links.fixed_link_ids(grid.shape, grid.status_at_node)
             fixed_horizontal_links = links.horizontal_fixed_link_ids(
                 grid.shape, fixed_link_ids)
             fixed_vertical_links = links.vertical_fixed_link_ids(

--- a/landlab/components/potentiality_flowrouting/examples/drive_pot_fr.py
+++ b/landlab/components/potentiality_flowrouting/examples/drive_pot_fr.py
@@ -34,7 +34,7 @@ mg.at_node['topographic__elevation'] = z
 #mg.set_fixed_value_boundaries_at_grid_edges(True, True, True, True)
 mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 figure(3)
-imshow_node_grid(mg, mg.node_boundary_status)
+imshow_node_grid(mg, mg.status_at_node)
 
 mg.at_node['water__volume_flux_in'] = np.ones_like(z)
 

--- a/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled2.py
+++ b/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled2.py
@@ -39,7 +39,7 @@ section_col = int((0.5*mg.number_of_node_columns)//1)
 mg.at_node['topographic__elevation'][section_col] = 1.
 mg.set_closed_boundaries_at_grid_edges(True, False, False, False)
 mg.set_fixed_value_boundaries_at_grid_edges(False, True, True, True)
-mg.node_status[section_col] = 2
+mg.status_at_node[section_col] = 2
 mg.update_links_nodes_cells_to_new_BCs()
 mg.at_node['water__volume_flux_in'].fill(0.)
 mg.at_node['water__volume_flux_in'][inlet_node] = 1.

--- a/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled3.py
+++ b/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled3.py
@@ -40,7 +40,7 @@ section_col = int((0.5*mg.number_of_node_columns)//1)
 mg.at_node['topographic__elevation'][section_col] = 1.
 mg.set_closed_boundaries_at_grid_edges(True, False, False, False)
 mg.set_fixed_value_boundaries_at_grid_edges(False, True, True, True)
-mg.node_status[section_col] = 2
+mg.status_at_node[section_col] = 2
 mg.update_links_nodes_cells_to_new_BCs()
 mg.at_node['water__volume_flux_in'].fill(0.)
 mg.at_node['water__volume_flux_in'][inlet_node] = 1.

--- a/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled3b.py
+++ b/landlab/components/potentiality_flowrouting/examples/drive_pot_fr_coupled3b.py
@@ -40,7 +40,7 @@ section_col = int((0.5*mg.number_of_node_columns)//1)
 mg.at_node['topographic__elevation'][section_col] = 1.
 mg.set_closed_boundaries_at_grid_edges(True, False, False, False)
 mg.set_fixed_value_boundaries_at_grid_edges(False, True, True, True)
-mg.node_status[section_col] = 2
+mg.status_at_node[section_col] = 2
 mg.update_links_nodes_cells_to_new_BCs()
 mg.at_node['water__volume_flux_in'].fill(0.)
 mg.at_node['water__volume_flux_in'][inlet_node] = 1.

--- a/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
+++ b/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
@@ -179,7 +179,7 @@ class PotentialityFlowRouter(Component):
 
         #make and store a 2d reference for node BCs
         self._BCs = 4*np.ones_like(self.elev_raster)
-        self._BCs[self._core].flat = self._grid.get_node_status()
+        self._BCs[self._core].flat = self._grid.status_at_node
         BCR = self._BCs #for conciseness below
         #these are conditions for boundary->boundary contacts AND anything->closed contacts w/i the grid, both of which forbid flow
         self.boundaryboundaryN = np.logical_or(np.logical_and(BCR[self._core]>0, BCR[self._Ns]>0), np.logical_or(BCR[self._Ns]==4, BCR[self._core]==4))

--- a/landlab/components/sed_trp_shallow_flow/examples/sed_trp_basin_flow_driver.py
+++ b/landlab/components/sed_trp_shallow_flow/examples/sed_trp_basin_flow_driver.py
@@ -24,8 +24,8 @@ inlet_nodes = [0,1,2, ncols, 2*ncols]
 
 mg = RasterModelGrid(nrows, ncols, dx)
 mg.set_inactive_boundaries(False, True, False, True)
-#mg.node_status[inlet_nodes] = 1
-#mg.node_status[-5] = 1 #Fixed lip outlet
+#mg.status_at_node[inlet_nodes] = 1
+#mg.status_at_node[-5] = 1 #Fixed lip outlet
 #print sgrid.node_tolink_index(mg.shape)[1]
 #mg.reset_list_of_active_links()
 

--- a/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
+++ b/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
@@ -44,7 +44,7 @@ flow_router = FlowRouter(grid)
 grid = flow_router.route_flow()
 
 for i in range(grid.number_of_nodes):
-    print(i, grid.node_x[i], grid.node_y[i], z[i], grid.node_status[i], \
+    print(i, grid.node_x[i], grid.node_y[i], z[i], grid.status_at_node[i], \
           r[i], a[i], q[i], ss[i], rl[i])
 
 # Let's take a look for debugging

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -903,6 +903,11 @@ class ModelGrid(ModelDataFields):
         """Get array of the status of all nodes."""
         return self._node_status
 
+    @node_status.setter
+    def node_status(self, new_status_array):
+        self._node_status[:] = new_status_array[:]
+        self.update_links_nodes_cells_to_new_BCs()
+
     def active_links_at_node(self, *args):
         """active_links_at_node([node_ids])
         Active links of a node.

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -579,20 +579,6 @@ class ModelGrid(ModelDataFields):
             return as_id_array(boundary_node_ids)
 
     @property
-    def node_boundary_status(self):
-        """Get array of the boundary status of nodes.
-
-        Return an array of the status of a grid's nodes. The node status can
-        be one of the following:
-        - `CORE_NODE`
-        - `FIXED_VALUE_BOUNDARY`
-        - `FIXED_GRADIENT_BOUNDARY`
-        - `TRACKS_CELL_BOUNDARY`
-        - `CLOSED_BOUNDARY`
-        """
-        return self.status_at_node
-
-    @property
     def open_boundary_nodes(self):
         """Get array of open boundary nodes."""
         (open_boundary_node_ids, ) = numpy.where(
@@ -778,17 +764,6 @@ class ModelGrid(ModelDataFields):
             return getattr(self, _ARRAY_LENGTH_ATTRIBUTES[element_name])
         except KeyError:
             raise TypeError('element name not understood')
-
-    @make_return_array_immutable
-    def get_node_status(self):
-        """Status of grid nodes.
-
-        Returns
-        -------
-        ndarray
-            Node status of all a grid's nodes.
-        """
-        return self._node_status
 
     @property
     @make_return_array_immutable

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -590,7 +590,7 @@ class ModelGrid(ModelDataFields):
         - `TRACKS_CELL_BOUNDARY`
         - `CLOSED_BOUNDARY`
         """
-        return self.node_status
+        return self.status_at_node
 
     @property
     def open_boundary_nodes(self):
@@ -899,12 +899,12 @@ class ModelGrid(ModelDataFields):
         self._axis_name = tuple(new_names)
 
     @property
-    def node_status(self):
+    def status_at_node(self):
         """Get array of the status of all nodes."""
         return self._node_status
 
-    @node_status.setter
-    def node_status(self, new_status_array):
+    @status_at_node.setter
+    def status_at_node(self, new_status_array):
         self._node_status[:] = new_status_array[:]
         self.update_links_nodes_cells_to_new_BCs()
 
@@ -2002,12 +2002,12 @@ class ModelGrid(ModelDataFields):
         >>> import numpy as np
         >>> from landlab import RasterModelGrid
         >>> mg = RasterModelGrid(3, 4, 1.0)
-        >>> mg.node_status
+        >>> mg.status_at_node
         array([1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1], dtype=int8)
         >>> h = np.array([-9999, -9999, -9999, -9999, -9999, -9999, 12345.,
         ...     0., -9999, 0., 0., 0.])
         >>> mg.set_nodata_nodes_to_inactive(h, -9999)
-        >>> mg.node_status
+        >>> mg.status_at_node
         array([4, 4, 4, 4, 4, 4, 0, 1, 4, 1, 1, 1], dtype=int8)
         """
         self.set_nodata_nodes_to_closed(node_data, nodata_value)
@@ -2056,12 +2056,12 @@ class ModelGrid(ModelDataFields):
         >>> import numpy as np
         >>> import landlab as ll
         >>> mg = ll.RasterModelGrid(3, 4, 1.0)
-        >>> mg.node_status
+        >>> mg.status_at_node
         array([1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1], dtype=int8)
         >>> h = np.array([-9999, -9999, -9999, -9999, -9999, -9999, 12345.,
         ...     0., -9999, 0., 0., 0.])
         >>> mg.set_nodata_nodes_to_closed(h, -9999)
-        >>> mg.node_status
+        >>> mg.status_at_node
         array([4, 4, 4, 4, 4, 4, 0, 1, 4, 1, 1, 1], dtype=int8)
         """
         # Find locations where value equals the NODATA code and set these nodes
@@ -2124,7 +2124,7 @@ class ModelGrid(ModelDataFields):
         >>> import numpy as np
         >>> from landlab import RasterModelGrid
         >>> rmg = RasterModelGrid(4, 9)
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 1, 1, 1,
                1, 0, 0, 0, 0, 0, 0, 0, 1,
                1, 0, 0, 0, 0, 0, 0, 0, 1,
@@ -2138,7 +2138,7 @@ class ModelGrid(ModelDataFields):
         ...     -99., -99., -99., -99., -99., -99., -99., -99., -99.])
 
         >>> rmg.set_nodata_nodes_to_fixed_gradient(z, -99)
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([2, 2, 2, 2, 2, 2, 2, 2, 2,
                2, 2, 2, 0, 0, 0, 0, 0, 2,
                2, 2, 2, 0, 0, 0, 0, 0, 2,
@@ -2799,7 +2799,7 @@ class ModelGrid(ModelDataFields):
         For each boundary node, determines whether it belongs to the left,
         right, top or bottom of the grid, based on its distance from the grid's
         centerpoint (mean (x,y) position). Returns lists of nodes on each of
-        the four grid sides. Assumes self.node_status, self.number_of_nodes,
+        the four grid sides. Assumes self.status_at_node, self.number_of_nodes,
         self.boundary_nodes, self._node_x, and self._node_y have been
         initialized.
 
@@ -2864,13 +2864,13 @@ class ModelGrid(ModelDataFields):
         >>> rmg = ll.HexModelGrid(5, 3, 1.0) # rows, columns, spacing
         >>> rmg.number_of_active_links
         30
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.set_inactive_boundaries(False, False, True, True)
         >>> rmg.number_of_active_links
         21
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 4, 0, 0, 1, 4, 0, 0, 0, 1, 4, 0, 0, 1, 4, 4, 4],
                dtype=int8)
         """

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -4111,17 +4111,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         """
         return np.all(np.equal(self._node_status[ids], CORE_NODE))
 
-    def get_boundary_code(self, id):
-        """Get the status of a node.
-
-        .. deprecated:: 0.6
-            Use :func:`node_boundary_status` instead.
-
-        Returns the boundary status of a node.
-        """
-        # ng june 2013
-        return self._node_status[id]
-
     def get_face_connecting_cell_pair(self, cell_a, cell_b):
         """Get the face that connects two cells.
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -52,14 +52,14 @@ def node_has_boundary_neighbor(mg, id, method='d8'):
     """
     for neighbor in mg.get_neighbor_list(id):
         try:
-            if mg.node_status[neighbor] != CORE_NODE:
+            if mg.status_at_node[neighbor] != CORE_NODE:
                 return True
         except IndexError:
             return True
     if method == 'd8':
         for neighbor in mg.get_diagonal_list(id):
             try:
-                if mg.node_status[neighbor] != CORE_NODE:
+                if mg.status_at_node[neighbor] != CORE_NODE:
                     return True
             except IndexError:
                 return True
@@ -401,7 +401,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> (rmg.number_of_nodes, rmg.number_of_cells, rmg.number_of_links,
         ...  rmg.number_of_active_links)
         (20, 6, 31, 17)
-        >>> rmg.node_status # doctest : +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest : +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.node_corecell[3] == BAD_INDEX_VALUE
@@ -2425,13 +2425,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg = RasterModelGrid(4, 5, 1.0) # rows, columns, spacing
         >>> rmg.number_of_active_links
         17
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.set_inactive_boundaries(False, False, True, True)
         >>> rmg.number_of_active_links
         12
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 4, 0, 0, 0, 1, 4, 0, 0, 0, 1, 4, 4, 4, 4, 4],
               dtype=int8)
 
@@ -2545,13 +2545,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg = RasterModelGrid(4, 5, 1.0) # rows, columns, spacing
         >>> rmg.number_of_active_links
         17
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.set_closed_boundaries_at_grid_edges(False, False, True, True)
         >>> rmg.number_of_active_links
         12
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 4, 1, 0, 0, 0, 4, 4, 4, 4, 4, 4],
               dtype=int8)
         """
@@ -2642,14 +2642,14 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> import numpy as np
         >>> rmg.at_node['topographic__elevation'] = np.random.rand(20)
         >>> rmg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([4, 4, 4, 4, 4, 4, 0, 0, 0, 4, 4, 0, 0, 0, 4, 4, 4, 4, 4, 4],
               dtype=int8)
         >>> rmg.set_fixed_value_boundaries_at_grid_edges(
         ...     False, False, True, True)
         >>> rmg.number_of_active_links
         12
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([4, 4, 4, 4, 4, 4, 0, 0, 0, 1, 4, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
 
@@ -2768,7 +2768,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg = RasterModelGrid(4, 5, 1.0) # rows, columns, spacing
         >>> rmg.number_of_active_links
         17
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.create_node_array_zeros('topographic__elevation')
@@ -2959,7 +2959,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg = RasterModelGrid(4, 5, 1.0) # rows, columns, spacing
         >>> rmg.number_of_active_links
         17
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
               dtype=int8)
         >>> rmg.create_node_array_zeros('topographic__elevation')
@@ -2969,7 +2969,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg['node']['topographic__elevation'][sgrid.boundary_nodes(rmg.shape)] = 0.8
         >>> rmg.set_fixed_gradient_boundaries(True, True, True, True) #first case
         Fixed gradients will be set according to existing data in the grid...
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([2, 2, 2, 2, 2, 2, 0, 0, 0, 2, 2, 0, 0, 0, 2, 2, 2, 2, 2, 2],
               dtype=int8)
         >>> rmg.fixed_gradient_node_properties['fixed_gradient_of']
@@ -4861,7 +4861,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg['node']['topographic__elevation'] = z
         >>> rmg['link']['topographic__slope'] = s
         >>> rmg.set_fixed_link_boundaries_at_grid_edges(True, True, True, True)
-        >>> rmg.node_status # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
         array([2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0,
                0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2], dtype=int8)
         >>> rmg.link_status # doctest: +NORMALIZE_WHITESPACE

--- a/landlab/grid/raster_aspect.py
+++ b/landlab/grid/raster_aspect.py
@@ -8,7 +8,7 @@ def _one_line_slopes(input_array, grid, vals):
     diagonals = input_array[5:]
     neighbors = input_array[1:5]
 
-    if not grid.node_boundary_status[node] == 0:
+    if not grid.status_at_node[node] == 0:
         raise IndexError('One or more of the provided nodes was closed!')
 
     try:

--- a/landlab/grid/structured_quad/links.py
+++ b/landlab/grid/structured_quad/links.py
@@ -578,7 +578,7 @@ def active_link_ids(shape, node_status):
     >>> from landlab.grid.structured_quad.links import active_link_ids
     >>> rmg = RasterModelGrid(3, 4)
     >>> rmg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    >>> status = rmg.node_status
+    >>> status = rmg.status_at_node
     >>> active_link_ids((3, 4), status)
     array([12])
     """
@@ -611,7 +611,7 @@ def is_fixed_link(shape, node_status):
     >>> rmg['node']['topographic__elevation'] = z
     >>> rmg['link']['topographic__slope'] = s
     >>> rmg.set_fixed_link_boundaries_at_grid_edges(True, True, True, True)
-    >>> is_fixed_link(rmg.shape, rmg.node_status)
+    >>> is_fixed_link(rmg.shape, rmg.status_at_node)
     array([False,  True,  True,  True, False, False, False, False, False,
            False, False,  True,  True,  True, False, False, False, False,
            False,  True, False, False,  True,  True, False, False,  True,
@@ -657,7 +657,7 @@ def fixed_link_ids(shape, node_status):
     >>> rmg['node']['topographic__elevation'] = z
     >>> rmg['link']['topographic__slope'] = s
     >>> rmg.set_fixed_link_boundaries_at_grid_edges(True, True, True, True)
-    >>> fixed_link_ids(rmg.shape, rmg.node_status)
+    >>> fixed_link_ids(rmg.shape, rmg.status_at_node)
     array([ 1,  2,  3, 11, 12, 13, 19, 22, 23, 26])
     """
     return as_id_array(np.where(is_fixed_link(shape, node_status))[0])
@@ -718,7 +718,7 @@ def horizontal_active_link_ids(shape, active_ids, bad_index_value=-1):
     ...     horizontal_active_link_ids)
     >>> rmg = RasterModelGrid(4, 5)
     >>> rmg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    >>> status = rmg.node_status
+    >>> status = rmg.status_at_node
     >>> active_ids = active_link_ids((4,5), status)
     >>> horizontal_active_link_ids((4,5), active_ids)
     array([-1, -1, -1, -1, -1, 20, 21, -1, -1, 24, 25, -1, -1, -1, -1, -1])
@@ -814,7 +814,7 @@ def horizontal_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
     >>> rmg['link']['topographic__slope'] = numpy.arange(
     ...     0, rmg.number_of_links)
     >>> rmg.set_fixed_link_boundaries_at_grid_edges(True, True, True, True)
-    >>> status = rmg.node_status
+    >>> status = rmg.status_at_node
     >>> fixed_ids = fixed_link_ids((4,5), status)
     >>> horizontal_fixed_link_ids((4,5), fixed_ids)
     array([-1, -1, -1, -1, 19, -1, -1, 22, 23, -1, -1, 26, -1, -1, -1, -1])
@@ -902,7 +902,7 @@ def vertical_active_link_ids(shape, active_ids, bad_index_value=-1):
     ...     vertical_active_link_ids)
     >>> rmg = RasterModelGrid(4, 5)
     >>> rmg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    >>> status = rmg.node_status
+    >>> status = rmg.status_at_node
     >>> active_ids = active_link_ids((4,5), status)
     >>> vertical_active_link_ids((4,5), active_ids)
     array([-1, -1, -1, -1, -1, -1,  6,  7,  8, -1, -1, -1, -1, -1, -1])
@@ -994,7 +994,7 @@ def vertical_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
     >>> rmg['link']['topographic__slope'] = numpy.arange(
     ...     0, rmg.number_of_links)
     >>> rmg.set_fixed_link_boundaries_at_grid_edges(True, True, True, True)
-    >>> status = rmg.node_status
+    >>> status = rmg.status_at_node
     >>>
     >>> fixed_ids = fixed_link_ids((4,5), status)
     >>> vertical_fixed_link_ids((4,5), fixed_ids)
@@ -1507,7 +1507,7 @@ def d4_horizontal_active_link_neighbors(shape, horizontal_ids,
     >>> from landlab.grid.structured_quad.links import *
     >>> rmg = RasterModelGrid(4, 5)
     >>> rmg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    >>> active_ids = active_link_ids(rmg.shape, rmg.node_status)
+    >>> active_ids = active_link_ids(rmg.shape, rmg.status_at_node)
     >>> horizontal_ids = horizontal_active_link_ids(
     ...     rmg.shape, active_ids)
     >>> d4_horizontal_active_link_neighbors(rmg.shape, horizontal_ids)
@@ -1990,7 +1990,7 @@ def d4_vertical_active_link_neighbors(shape, vertical_ids, bad_index_value=-1):
     >>> from landlab.grid.structured_quad.links import (active_link_ids,
     ...     vertical_active_link_ids, d4_vertical_active_link_neighbors)
     >>> rmg = RasterModelGrid(4, 5)
-    >>> active_link_ids = active_link_ids(rmg.shape, rmg.node_status)
+    >>> active_link_ids = active_link_ids(rmg.shape, rmg.status_at_node)
     >>> vertical_active_ids = vertical_active_link_ids(
     ...     rmg.shape, active_link_ids)
     >>> d4_vertical_active_link_neighbors(rmg.shape, vertical_active_ids)

--- a/landlab/grid/tests/test_raster_grid/test_is_boundary.py
+++ b/landlab/grid/tests/test_raster_grid/test_is_boundary.py
@@ -39,7 +39,7 @@ def test_id_as_list():
 
 @with_setup(setup_grid)
 def test_boundary_flag():
-    rmg.node_status[0] = FIXED_GRADIENT_BOUNDARY
+    rmg.status_at_node[0] = FIXED_GRADIENT_BOUNDARY
     assert_array_equal(
         rmg.is_boundary(np.arange(20)),
         np.array([True,  True,  True,  True,  True,

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -170,14 +170,14 @@ class VoronoiDelaunayGrid(ModelGrid):
         self._num_nodes = len(x)
         self._node_x = x
         self._node_y = y
-        [self.node_status, self._core_nodes, self._boundary_nodes] = \
+        [self._node_status, self._core_nodes, self._boundary_nodes] = \
             self.find_perimeter_nodes(pts)
         self._num_active_nodes = self.number_of_nodes
         self._num_core_nodes = len(self.core_nodes)
         self._num_cells = len(self.core_nodes)
         self._num_active_cells = self.number_of_cells
         [self._cell_at_node, self._node_at_cell] = self.setup_node_cell_connectivity(
-            self.node_status, self.number_of_cells)
+            self._node_status, self.number_of_cells)
         self.node_activecell = self._cell_at_node
         self.activecell_node = self._node_at_cell
 
@@ -329,7 +329,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         core_nodes = as_id_array(numpy.where(node_status == 0)[0])
 
         # save the arrays and update the properties
-        self.node_status = node_status
+        self._node_status = node_status
         self._num_active_nodes = node_status.size
         self._num_core_nodes = len(core_nodes)
         self._num_core_cells = len(core_nodes)

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -74,7 +74,7 @@ def imshow_node_grid(grid, values, **kwds):
     if RasterModelGrid in inspect.getmro(grid.__class__):
         data.shape = grid.shape
 
-    data = np.ma.masked_where((grid.node_status == 4).reshape(grid.shape),
+    data = np.ma.masked_where((grid.status_at_node == 4).reshape(grid.shape),
                               data)
 
     myimage = _imshow_grid_values(grid, data, **kwds)
@@ -340,7 +340,7 @@ def _imshow_grid_values(grid, values, var_name=None, var_units=None,
         cm = plt.get_cmap(cmap)
         if limits is None:
             # only want to work with NOT CLOSED nodes
-            open_nodes = grid.node_status != 4
+            open_nodes = grid.status_at_node != 4
             if symmetric_cbar:
                 (var_min, var_max) = (values.flat[
                     open_nodes].min(), values.flat[open_nodes].max())


### PR DESCRIPTION
This pull request renames the `node_status` attribute of `ModelGrid` to `_node_status` to indicate that it's private. Instead users should use the new getter/setter, `status_at_node`.

Removed the redundant/deprecated methods,
* `get_boundary_code`
* `node_boundary_status`
* `get_node_status`