### PR TITLE
Add OSX builds to Travis

### DIFF
--- a/.ci/appveyor/deploy_to_pypi.ps1
+++ b/.ci/appveyor/deploy_to_pypi.ps1
@@ -1,3 +1,3 @@
 if (($env:appveyor_repo_tag -eq "True") -and ($env:appveyor_repo_branch.StartsWith("v"))) {
-    Invoke-Expression "$env:PYTHON/Scripts/twine upload -u landlab -p $env:PYPI_PASS dist/*
+    Invoke-Expression "$env:PYTHON/Scripts/twine upload -u landlab -p $env:PYPI_PASS dist/*"
 }

--- a/.ci/appveyor/deploy_to_pypi.ps1
+++ b/.ci/appveyor/deploy_to_pypi.ps1
@@ -1,0 +1,3 @@
+if (($env:appveyor_repo_tag -eq "True") -and ($env:appveyor_repo_branch.StartsWith("v"))) {
+    Invoke-Expression "$env:PYTHON/Scripts/twine upload -u landlab -p $env:PYPI_PASS dist/*
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 - source activate test-env
 - pip install coveralls
 - conda install numpy=$NUMPY_VERSION
+- conda install scipy
 - python setup.py install
 script:
 - (cd docs && make html 2> /dev/null)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os:
 - linux
 - osx
 matrix:
-  exclude:
+  allow_failures:
     - os: osx
       env: TRAVIS_PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
   allow_failures:
     - os: osx
       env: TRAVIS_PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
+    - os: osx
+      env: TRAVIS_PYTHON_VERSION="3.4" NUMPY_VERSION="1.9"
 sudo: false
 install:
 - echo "Build on $TRAVIS_OS_NAME for Python $TRAVIS_PYTHON_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 matrix:
   exclude:
     - os: osx
-      env: TRAVIS_PYTHON_VERSION="2.6"
+      env: TRAVIS_PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
 sudo: false
 install:
 - echo "Build on $TRAVIS_OS_NAME for Python $TRAVIS_PYTHON_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 env:
-  - TRAVIS_PYTHON_VERSION="2.6"
-  - TRAVIS_PYTHON_VERSION="2.7"
-  - TRAVIS_PYTHON_VERSION="3.3"
-  - TRAVIS_PYTHON_VERSION="3.4"
+  - TRAVIS_PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
+  - TRAVIS_PYTHON_VERSION="2.7" NUMPY_VERSION="1.9"
+  - TRAVIS_PYTHON_VERSION="2.7" NUMPY_VERSION="1.10"
+  - TRAVIS_PYTHON_VERSION="3.3" NUMPY_VERSION="1.9"
+  - TRAVIS_PYTHON_VERSION="3.4" NUMPY_VERSION="1.9"
+  - TRAVIS_PYTHON_VERSION="3.4" NUMPY_VERSION="1.10"
 os:
 - linux
 - osx
@@ -16,6 +18,7 @@ install:
 - export PATH="$HOME/miniconda/bin:$PATH"
 - source activate test-env
 - pip install coveralls
+- conda install numpy=$NUMPY_VERSION
 - python setup.py install
 script:
 - (cd docs && make html 2> /dev/null)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ os:
 - linux
 - osx
 matrix:
-  allow_failures:
+  exclude:
     - os: osx
+      env: TRAVIS_PYTHON_VERSION="2.6"
 sudo: false
 install:
 - echo "Build on $TRAVIS_OS_NAME for Python $TRAVIS_PYTHON_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
   allow_failures:
     - os: osx
       env: TRAVIS_PYTHON_VERSION="2.6" NUMPY_VERSION="1.9"
-    - os: osx
-      env: TRAVIS_PYTHON_VERSION="3.4" NUMPY_VERSION="1.9"
 sudo: false
 install:
 - echo "Build on $TRAVIS_OS_NAME for Python $TRAVIS_PYTHON_VERSION"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
-language: python
-python:
-- '2.6'
-- '2.7'
-- '3.3'
-- '3.4'
+env:
+  - TRAVIS_PYTHON_VERSION="2.6"
+  - TRAVIS_PYTHON_VERSION="2.7"
+  - TRAVIS_PYTHON_VERSION="3.3"
+  - TRAVIS_PYTHON_VERSION="3.4"
 os:
 - linux
 - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ deploy:
   on:
     tags: true
     repo: landlab/landlab
+  distributions: "sdist bdist_wheel"
 notifications:
   slack:
     secure: gRKbqjPgp0ZcFtecHOwjLAFbzzBr2zyFrxk7OAS/cea/9U8bLQNA0jZs3ZHtAgR53gdnFlx/GI10d/KD9XMKU55gQkO4FSvfYMK7Xzs2tfnEa5flTqQKRfjB1oJ2fmb81yshUe+xKsXBoedP7SPYv2mutMOY8srKwUcuE0yGmAw=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     MINICONDA_VERSION: "3.5.5"
     WITH_COMPILER: "cmd /E:ON /V:ON /C .\\.ci\\appveyor\\run_with_env.cmd"
     NUMPY_VERSION: "1.9.1"
+    PYPI_PASS:
+      secure: McZCupcxPPhf+ZTqvVMc2sEEg1L9o34VQZOhc85dNJI=
 
   matrix:
     - PYTHON_VERSION: "2.6"
@@ -53,6 +55,9 @@ deploy:
   folder: incoming/huttone/
   on:
     appveyor_repo_tag: true
+
+deploy_script:
+  - "powershell .ci/appveyor/deploy_to_pypi.ps1"
 
 notifications:
   - provider: Slack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,16 +46,6 @@ artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.
   - path: 'dist\*'
 
-deploy:
-  provider: FTP
-  protocol: ftp
-  host: csdms.colorado.edu
-  username: anonymous
-  password: appveyor@appveyor.com
-  folder: incoming/huttone/
-  on:
-    appveyor_repo_tag: true
-
 deploy_script:
   - "powershell .ci/appveyor/deploy_to_pypi.ps1"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,7 @@ install:
   - "python --version"
   - "conda install -q --yes numpy=%NUMPY_VERSION% pip jinja2 scipy nose>=1.3 matplotlib netCDF4 sympy pandas Cython"
   - "pip install wheel"
+  - "pip install twine"
   - "%WITH_COMPILER% python setup.py install"
 
 build: false


### PR DESCRIPTION
This pull request adds OSX builds to Travis (#75). Our tests are now run on: linux, Mac, and a range of numpy versions for each of these operating systems. If the tests run on a tagged release, and all the tests pass, a source and binary distribution is automatically deployed to the Python Package Index.

There seems to be a problem with Python 2.6 and numpy version 1.9 on Mac (at least as provided by Anaconda). I'm just allowing this single test to fail. If it becomes a problem later, we can look into what's causing it to fail.