### PR TITLE
Make status_at_link array read-only.

### DIFF
--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -895,6 +895,7 @@ class ModelGrid(ModelDataFields):
         self._axis_name = tuple(new_names)
 
     @property
+    @make_return_array_immutable
     def status_at_link(self):
         """Get array of the status of all links."""
         return self._link_status


### PR DESCRIPTION
This pull request make the array returned by `status_at_link` read-only. The status of links should be the result of the status of their head and tail nodes.