### PR TITLE
SiccarPoint/delete fields

### DIFF
--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -648,7 +648,7 @@ class ModelDataFields(object):
         name: str
             Name of the field.
         units: str
-            Units for the field
+            Units for the field.
 
         Raises
         ------
@@ -656,6 +656,24 @@ class ModelDataFields(object):
             If the named field does not exist.
         """
         self[group].set_units(name, units)
+
+    def delete_field(self, group, name):
+        """Erases an existing field.
+
+        Parameters
+        ----------
+        group : str
+            Name of the group.
+        name: str
+            Name of the field.
+
+        Raises
+        ------
+        KeyError
+            If the named field does not exist.
+        """
+        del self._groups[group].units[name]
+        del self._groups[group][name]
 
     def __getitem__(self, group):
         """Get a group of fields."""

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -106,3 +106,19 @@ def test_has_group():
 
     assert_true(fields.has_group('node'))
     assert_false(fields.has_group('cell'))
+
+
+def test_delete_field():
+    fields = ModelDataFields()
+    fields.new_field_location('link', 17)
+
+    assert_dict_equal(dict(), fields.at_link)
+    assert_raises(AttributeError, lambda: fields.at_node)
+
+    fields.add_zeros('link', 'vals')
+    assert_array_equal(np.zeros(17), fields.at_link['vals'])
+
+    assert_raises(KeyError, lambda: fields.delete_field('node', 'vals'))
+    fields.delete_field('link', 'vals')
+    assert_raises(KeyError, lambda: fields.field_units('link', 'vals'))
+    assert_raises(KeyError, lambda: fields.at_link['vals'])


### PR DESCRIPTION
A new method to delete a field that already exists in the grid, plus associated test.