### PR TITLE
Fixed link-fixed value node conflict

### DIFF
--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1399,7 +1399,7 @@ class ModelGrid(ModelDataFields):
                         'Assuming your solar properties are in degrees, '
                         'but your slopes and aspects are in radians...')
                     (alt, az) = (numpy.radians(alt), numpy.radians(az))
-                    #...because it would be super easy to specify radians,
+                    # ...because it would be super easy to specify radians,
                     # but leave the default params alone...
             else:
                 raise TypeError("unit must be 'degrees' or 'radians'")
@@ -1763,7 +1763,8 @@ class ModelGrid(ModelDataFields):
                             u[self.activelink_tonode[i]])
         else:
             for i in range(0, self.number_of_active_links):
-                if v[self.activelink_fromnode[i]] > v[self.activelink_tonode[i]]:
+                if (v[self.activelink_fromnode[i]] >
+                        v[self.activelink_tonode[i]]):
                     fv[i] = u[self.activelink_fromnode[i]]
                 else:
                     fv[i] = u[self.activelink_tonode[i]]
@@ -1779,9 +1780,11 @@ class ModelGrid(ModelDataFields):
         A link is inactive if either node is closed.
         A link is fixed if either node is fixed gradient.
 
-        Note that any link which has been previously set as fixed will remain
-        so, and if a closed-core node pair is found at each of its ends, the
-        closed node will be converted to a fixed gradient node.
+        Note that by default, any link which has been previously set as fixed
+        will remain so, and if a closed-core node pair is found at each of its
+        ends, the closed node will be converted to a fixed gradient node. If
+        you want to close a node which has a fixed link already connected to
+        it, first change the link status to inactive.
 
         A further test is performed to ensure that the final maps of node and
         link status are internally consistent.
@@ -1797,30 +1800,54 @@ class ModelGrid(ModelDataFields):
         fromnode_status = self._node_status[self.node_at_link_tail]
         tonode_status = self._node_status[self.node_at_link_head]
 
-        if not numpy.all((fromnode_status[already_fixed] == FIXED_GRADIENT_BOUNDARY) |
-                         (tonode_status[already_fixed] == FIXED_GRADIENT_BOUNDARY)):
-            assert numpy.all(fromnode_status[already_fixed] == CLOSED_BOUNDARY !=
-                             tonode_status[already_fixed] == CLOSED_BOUNDARY)
+        if not numpy.all((fromnode_status[already_fixed] ==
+                          FIXED_GRADIENT_BOUNDARY) |
+                         (tonode_status[already_fixed] ==
+                          FIXED_GRADIENT_BOUNDARY)):
+            assert numpy.all(np.logical_not((fromnode_status[already_fixed] ==
+                                             CLOSED_BOUNDARY) &
+                                            (tonode_status[already_fixed] ==
+                                             CLOSED_BOUNDARY)))
             fromnode_status[already_fixed] = numpy.where(
-                fromnode_status[already_fixed] == CLOSED_BOUNDARY,
+                (fromnode_status[already_fixed] == CLOSED_BOUNDARY) &
+                (tonode_status[already_fixed] == CORE_NODE),
                 FIXED_GRADIENT_BOUNDARY,
                 fromnode_status[already_fixed])
             tonode_status[already_fixed] = numpy.where(
-                tonode_status[already_fixed] == CLOSED_BOUNDARY,
+                (tonode_status[already_fixed] == CLOSED_BOUNDARY) &
+                (fromnode_status[already_fixed] == CORE_NODE),
                 FIXED_GRADIENT_BOUNDARY,
                 tonode_status[already_fixed])
+            print("""
+                  Remember, fixed_links are dominant over node statuses.
+                  Your grid may have had an incompatibility between
+                  fixed_links and closed nodes, which has been resolved by
+                  converting the closed nodes to fixed gradient nodes. If
+                  you were trying to deliberately close a node which had
+                  once been set to fixed gradient, you need to open the
+                  links before changing the node statuses. If you were
+                  setting a node to fixed_value, you can ignore this
+                  message.
+                  """)
 
         active_links = (((fromnode_status == CORE_NODE) & ~
                          (tonode_status == CLOSED_BOUNDARY)) |
                         ((tonode_status == CORE_NODE) & ~
                          (fromnode_status == CLOSED_BOUNDARY)))
-        #...this still includes things that will become fixed_link
+        # ...this still includes things that will become fixed_link
 
         fixed_links = ((((fromnode_status == FIXED_GRADIENT_BOUNDARY) &
                          (tonode_status == CORE_NODE)) |
                         ((tonode_status == FIXED_GRADIENT_BOUNDARY) &
                          (fromnode_status == CORE_NODE))) |
                        already_fixed)
+        
+        fixed_link_fixed_val = (((fromnode_status == FIXED_VALUE_BOUNDARY) |
+                                 (tonode_status == FIXED_VALUE_BOUNDARY)) &
+                                already_fixed)                        
+        # these are the "special cases", where the user is probably trying to
+        # adjust an individual fixed_link back to fixed value. We'll allow it:
+        fixed_links[fixed_link_fixed_val] = False
 
         try:
             self._link_status.fill(4)

--- a/landlab/grid/tests/test_raster_grid/test_fixed_link_boundary.py
+++ b/landlab/grid/tests/test_raster_grid/test_fixed_link_boundary.py
@@ -1,0 +1,59 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+
+from landlab import RasterModelGrid
+from landlab import FIXED_VALUE_BOUNDARY as FV
+from landlab import CLOSED_BOUNDARY as CB
+from landlab import FIXED_GRADIENT_BOUNDARY as FG
+
+
+def test_fixed_link_boundaries_at_grid_edges():
+    grid = RasterModelGrid(3, 4)
+    grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
+    grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)
+    grid.set_fixed_link_boundaries_at_grid_edges(True, False, False, False)
+    assert_array_equal(grid.status_at_node,
+                       [FG, FG, FG, FG,
+                        FV, 0, 0, FV,
+                        FV, FV, FV, FV])
+
+    assert_array_equal(grid.status_at_link,
+                       [4, 2, 2, 4, 4, 0, 0, 4,
+                        4, 4, 4, 0, 0, 0, 4, 4,
+                        4])
+
+def test_nodata_fixed_links():
+    grid = RasterModelGrid(3, 4)
+    grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
+    grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)
+    z = grid['node']['topographic__elevation']
+    z[3:5] = -9999
+    grid.set_nodata_nodes_to_fixed_gradient(z, -9999)
+    assert_array_equal(grid.status_at_node,
+                       [FV, FV, FV, FG,
+                        FG, 0, 0, FV,
+                        FV, FV, FV, FV])
+
+    assert_array_equal(grid.status_at_link,
+                       [4, 0, 0, 4, 4, 0, 0, 4,
+                        4, 4, 4, 2, 0, 0, 4, 4,
+                        4])
+
+def test_fixed_gradient_and_value_boundary():
+    grid = RasterModelGrid(3, 4)
+    grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
+    grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)
+
+    grid.set_closed_boundaries_at_grid_edges(True, False, True, False)
+    grid.set_fixed_gradient_boundaries(False, True, False, True)
+    grid.status_at_node[1] = 1
+
+    assert_array_equal(grid.status_at_node,
+                       [CB, FV, CB, CB,
+                        FG, 0, 0, FG,
+                        CB, CB, CB, CB])
+
+    assert_array_equal(grid.status_at_link,
+                       [4, 0, 4, 4, 4, 4, 4, 4,
+                        4, 4, 4, 2, 0, 2, 4, 4,
+                        4])

--- a/landlab/grid/tests/test_raster_grid/test_fixed_link_boundary.py
+++ b/landlab/grid/tests/test_raster_grid/test_fixed_link_boundary.py
@@ -8,6 +8,8 @@ from landlab import FIXED_GRADIENT_BOUNDARY as FG
 
 
 def test_fixed_link_boundaries_at_grid_edges():
+    '''test setting fixed link boundaries at grid edges'''
+
     grid = RasterModelGrid(3, 4)
     grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
     grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)
@@ -22,7 +24,9 @@ def test_fixed_link_boundaries_at_grid_edges():
                         4, 4, 4, 0, 0, 0, 4, 4,
                         4])
 
+
 def test_nodata_fixed_links():
+    '''test setting nodata nodes to fixed gradient'''
     grid = RasterModelGrid(3, 4)
     grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
     grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)
@@ -39,7 +43,9 @@ def test_nodata_fixed_links():
                         4, 4, 4, 2, 0, 0, 4, 4,
                         4])
 
+
 def test_fixed_gradient_and_value_boundary():
+    '''testing multiple boundary conditions with fixed links'''
     grid = RasterModelGrid(3, 4)
     grid['node']['topographic__elevation'] = np.zeros(grid.number_of_nodes)
     grid['link']['topographic__slope'] = np.zeros(grid.number_of_links)


### PR DESCRIPTION
This pull resolves an issue where it was not possible to change a node
at the end of a fixed link to a fixed value node. It is now possible.

Note it is *still* impossible, by necessity and by design, to set a
node at the end of a fixed link to closed. You need to convert the
fixed link to a regular open (or closed) link first.