### PR TITLE
Fix _reset_lists_of_nodes_cells

### DIFF
--- a/landlab/components/detachment_ltd_sed_trp/generate_detachment_ltd_transport.py
+++ b/landlab/components/detachment_ltd_sed_trp/generate_detachment_ltd_transport.py
@@ -9,7 +9,7 @@ E = K*f(qs)*(A**m)*(S**n)
 
 """
 
-from landlab import Component, ModelParameterDictionary
+from landlab import Component, ModelParameterDictionary, CLOSED_BOUNDARY
 from landlab.components.flow_accum import flow_accumulation
 import pylab
 import numpy as np
@@ -64,7 +64,8 @@ this does not assume an erosion threshold (8/29/14).
         self.Q = q
         self.Q_to_m = self.Q**self.m
         self.S_to_n = self.slope**self.n
-        self.interior_nodes = self.rg.get_active_cell_node_ids()
+        self.interior_nodes = (
+            np.where(self.rg.status_at_node != CLOSED_BOUNDARY)[0])
 
         self.dzdt = self.U - (self.K*self.f_qs*self.Q_to_m*self.S_to_n)
 

--- a/landlab/components/flexure/examples/example_two_point_load.py
+++ b/landlab/components/flexure/examples/example_two_point_load.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from landlab.components.flexure import FlexureComponent
 from landlab import RasterModelGrid
-from landlab.plot import imshow_field
 
 
 SHAPE = (100, 100)

--- a/landlab/components/flow_accum/flow_accumulation.py
+++ b/landlab/components/flow_accum/flow_accumulation.py
@@ -10,6 +10,8 @@
 import numpy as np
 import six
 
+from landlab import CLOSED_BOUNDARY
+
 
 class AccumFlow(object):
     """
@@ -30,7 +32,7 @@ class AccumFlow(object):
             assert(len(data.flowacc) == len(self.flow_accum_by_area[:-1]))
 
     def calc_flowacc(self, grid, data):
-        active_cell_ids = grid.get_active_cell_node_ids()
+        active_cell_ids = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         #Perform test to see if the flowdir data is a single vector, or multidimensional, here. Several ways possible: 1. Is the vector multidimensional?, e.g., try: data.flowdirs.shape[1] 2. set a flag in flowdir.
 
         try:

--- a/landlab/components/flow_accum/flow_accumulation2.py
+++ b/landlab/components/flow_accum/flow_accumulation2.py
@@ -9,7 +9,7 @@
 from __future__ import print_function
 
 import landlab
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 import numpy as np
 
 
@@ -29,7 +29,7 @@ class AccumFlow(object):
         self.flow_accum_by_area = np.zeros(grid.number_of_nodes+1) #prefilled with zeros, size of WHOLE grid+1, to allow -1 ids
 
     def calc_flowacc(self, grid, z, flowdirs):
-        active_cell_ids = grid.get_active_cell_node_ids()
+        active_cell_ids = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         #Perform test to see if the flowdir data is a single vector, or multidimensional, here. Several ways possible: 1. Is the vector multidimensional?, e.g., try: data.flowdirs.shape[1] 2. set a flag in flowdir.
 
         try:

--- a/landlab/components/pet/examples/potential_evapotranspiration_field_example.py
+++ b/landlab/components/pet/examples/potential_evapotranspiration_field_example.py
@@ -4,10 +4,11 @@
 #import landlab
 from landlab import RasterModelGrid
 from landlab.components.radiation.radiation_field import Radiation
-from landlab.components.pet.potential_evapotranspiration_field import PotentialEvapotranspiration
+from landlab.components.pet.potential_evapotranspiration_field import (
+    PotentialEvapotranspiration)
 import numpy as np
 import matplotlib.pyplot as plt
-from landlab.plot.imshow import imshow_field
+from landlab.plot.imshow import imshow_grid
 
 grid = RasterModelGrid( 100, 100, 20. )
 elevation = np.random.rand(grid.number_of_nodes) * 1000
@@ -20,11 +21,11 @@ rad.update( current_time )
 PET.update( ConstantPotentialEvapotranspiration = 10.0 )
 
 plt.figure(0)
-imshow_field(grid,'RadiationFactor',
-                values_at = 'cell', grid_units = ('m','m'))
+imshow_grid(grid,'RadiationFactor', values_at = 'cell',
+            grid_units = ('m','m'))
 
 plt.figure(1)
-imshow_field(grid,'PotentialEvapotranspiration',
-                values_at = 'cell', grid_units = ('m','m'))
+imshow_grid(grid,'PotentialEvapotranspiration', values_at = 'cell',
+            grid_units = ('m','m'))
 plt.savefig('PET_test')
 plt.show()

--- a/landlab/components/radiation/examples/radiation_field_example.py
+++ b/landlab/components/radiation/examples/radiation_field_example.py
@@ -28,7 +28,7 @@ from landlab.components.radiation.radiation_field import Radiation
     import landlab's plotting function that has the capability of plotting
     'fields' stored on the grid.
 """
-from landlab.plot.imshow import imshow_field
+from landlab.plot.imshow import imshow_grid
 """
     import Numpy library. We will use 'random' module from numpy for this
     tutorial.
@@ -93,14 +93,14 @@ rad.update( current_time )
 plt.figure(0)
 """
     Plot the cellular field 'TotalShortWaveRadiation' that is available on the
-    grid. imshow_field is a Landlab plotting tool that reads the input of
+    grid. imshow_grid is a Landlab plotting tool that reads the input of
     grid, the variable name that needs to be plotted, and type of field (whether
     it is 'cell' or 'node', etc... It also reads optional inputs (keywords),
     grid_units (units of grid X and Y axes , e.g. 'm'). For more options, please refer
     documentation for landlab.plot.imshow.
 """
-imshow_field(grid,'TotalShortWaveRadiation', values_at = 'cell',
-             grid_units = ('m','m'))
+imshow_grid(grid,'TotalShortWaveRadiation', values_at = 'cell',
+            grid_units = ('m','m'))
 
 """
     The plot created can be saved using the function 'savefig' available in
@@ -118,7 +118,7 @@ plt.figure(1)
     Using Landlab plotting tool, lets plot another variable 'RadiationFactor'.
 
 """
-imshow_field(grid,'RadiationFactor', values_at = 'cell', grid_units = ('m','m'))
+imshow_grid(grid,'RadiationFactor', values_at = 'cell', grid_units = ('m','m'))
 """
     Save this figure.
 """

--- a/landlab/components/sed_trp_shallow_flow/transport_sed_in_shallow_flow.py
+++ b/landlab/components/sed_trp_shallow_flow/transport_sed_in_shallow_flow.py
@@ -8,7 +8,7 @@ the Bates et al. (2010) algorithm for storage-cell inundation modeling.
 
 """
 
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 import numpy as np
 import six
 
@@ -87,7 +87,7 @@ class SurfaceFlowTransport(object):
         erode_start_time = self.erode_start_time
         ten_thirds = 10./3.
 
-        interior_cells = grid.get_active_cell_node_ids()
+        interior_cells = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
 
 
         # Calculate the effective flow depth at active links. Bates et al. 2010

--- a/landlab/components/simple_power_law_incision/power_law_fluvial_eroder.py
+++ b/landlab/components/simple_power_law_incision/power_law_fluvial_eroder.py
@@ -30,8 +30,7 @@ so these values need not be passed in.  Elevationare eroded and sent back.
 
 """
 
-#import landlab
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 from landlab.components.flow_routing.flow_routing_D8 import RouteFlowD8
 from landlab.components.flow_accum.flow_accumulation2 import AccumFlow
 import numpy as np
@@ -83,7 +82,7 @@ class PowerLawIncision(object):
         frac = self.frac
 
         #interior_nodes are the nodes on which you will be calculating incision
-        interior_nodes = grid.get_active_cell_node_ids()
+        interior_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
 
         #instantiate variable of type RouteFlowD8 Class
         flow_router = RouteFlowD8(len(z))

--- a/landlab/components/simple_power_law_incision/power_law_incision_driver.py
+++ b/landlab/components/simple_power_law_incision/power_law_incision_driver.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pylab import *
-from landlab import RasterModelGrid
+from landlab import RasterModelGrid, CLOSED_BOUNDARY
 from landlab.plot.imshow import imshow_grid
 from landlab.components.dem_support.dem_boundary_conditions import WatershedBoundaryConditions
 from random import uniform
@@ -57,7 +57,7 @@ def main():
 
     #print "elevations before ", rg.node_vector_to_raster(z)
     #interior_nodes are the nodes on which you will be operating
-    interior_nodes = rg.get_active_cell_node_ids()
+    interior_nodes = np.where(rg.status_at_node != CLOSED_BOUNDARY)[0]
 
     while elapsed_time < total_run_time:
         #uplift the landscape

--- a/landlab/components/simple_power_law_incision/power_law_incision_driver_side_outlet.py
+++ b/landlab/components/simple_power_law_incision/power_law_incision_driver_side_outlet.py
@@ -2,12 +2,13 @@ from __future__ import print_function
 
 import numpy as np
 import pylab
-from landlab import RasterModelGrid
+from landlab import RasterModelGrid, CLOSED_BOUNDARY
 from random import uniform
 from landlab.components.simple_power_law_incision.power_law_fluvial_eroder import PowerLawIncision
 from landlab.components.flow_routing.flow_routing_D8 import RouteFlowD8
 from landlab.components.flow_accum.flow_accumulation2 import AccumFlow
 import matplotlib.pyplot as plt
+
 
 def main():
     nr = 50
@@ -38,7 +39,7 @@ def main():
 
     #print "elevations before ", rg.node_vector_to_raster(z)
     #interior_nodes are the nodes on which you will be operating
-    interior_nodes = rg.get_active_cell_node_ids()
+    interior_nodes = np.where(rg.status_at_node != CLOSED_BOUNDARY)[0]
 
     while elapsed_time < total_run_time:
         #erode the landscape

--- a/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
+++ b/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
@@ -7,13 +7,13 @@ Tests and illustrates use of route_flow_dn component.
 """
 from __future__ import print_function
 
-from landlab import RasterModelGrid
+from landlab import RasterModelGrid, CLOSED_BOUNDARY
 from landlab.components.flow_routing.route_flow_dn import FlowRouter
 from landlab.io import read_esri_ascii
 from landlab.plot.imshow import imshow_node_grid
 import os
 import pylab
-from numpy import ones, size
+import numpy as np
 
 dem_name = '../../../io/tests/data/west_bijou_gully.asc'
 outlet_row = 82
@@ -37,7 +37,7 @@ z[13] = 2.
 
 
 # Get array of interior (active) node IDs
-interior_nodes = grid.get_active_cell_node_ids()
+interior_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
 
 # Route flow
 flow_router = FlowRouter(grid)
@@ -53,7 +53,7 @@ for i in range(grid.number_of_nodes):
 #    print i, r[i], rl[i]
 
 # Calculate lengths of flow links
-flow_link_length = ones(size(z))
+flow_link_length = np.ones(np.size(z))
 flow_link_length[interior_nodes] = grid.link_length[rl[interior_nodes]] #DEJH suspects a node ordering bug here - rl is not in ID order, but interior_nodes is
 print('fll:', flow_link_length)
 

--- a/landlab/components/stream_power/sed_flux_dep_incision.py
+++ b/landlab/components/stream_power/sed_flux_dep_incision.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import numpy as np
 from time import sleep
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from landlab.field.scalar_data_fields import FieldError
@@ -588,7 +588,7 @@ class SedDepEroder(object):
 
         self.grid=grid
 
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         if io:
             try:
                 io[active_nodes] = node_z[active_nodes]

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 
 import numpy as np
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 
 from landlab.core.model_parameter_dictionary import MissingKeyError, ParameterValueError
 from landlab.field.scalar_data_fields import FieldError
@@ -231,7 +231,7 @@ class StreamPowerEroder(object):
         is not an excess stream power; any specified erosion threshold is not
         incorporated into it.
         """
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
 
         if W_if_used!=None:
             assert self.use_W, "Widths were provided, but you didn't set the use_W flag in your input file! Aborting..."

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
 
 import numpy as np
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 from time import sleep
 
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from landlab.field.scalar_data_fields import FieldError
+
 
 class TransportLimitedEroder(object):
     """
@@ -472,7 +473,7 @@ class TransportLimitedEroder(object):
         #print "s: ", s_in
         dz = self.weave_iter_sed_trp_balance(grid, capacity, r_in, s_in, dt)
         #print 'max inc rate ', np.amax(np.fabs(dz[self.grid.core_nodes]))
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         if io:
             try:
                 io[active_nodes] += dz[active_nodes]

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_alt.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_alt.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
 
 import numpy as np
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 from time import sleep
 from landlab.utils import structured_grid as sgrid
 import pylab
 
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from landlab.field.scalar_data_fields import FieldError
+
 
 class TransportLimitedEroder(object):
     """
@@ -453,7 +454,7 @@ class TransportLimitedEroder(object):
         ##grid.at_node[node_elevs][sgrid.interior_nodes((nrows,ncols))] = node_z_asgrid.ravel()
         self.grid=grid
 
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         if io:
             try:
                 io[active_nodes] += node_z_asgrid.ravel()[active_nodes]

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_v3.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_v3.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import numpy as np
 import inspect
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 from landlab import RasterModelGrid
 from time import sleep
 from landlab.utils import structured_grid as sgrid
@@ -11,6 +11,7 @@ import pylab
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from landlab.field.scalar_data_fields import FieldError
 from landlab.grid.base import BAD_INDEX_VALUE
+
 
 class TransportLimitedEroder(object):
     """
@@ -515,7 +516,7 @@ class TransportLimitedEroder(object):
 
         self.grid=grid
 
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         if io:
             try:
                 io[active_nodes] += node_z[active_nodes]

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_polydirectional.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_polydirectional.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
 
 import numpy as np
-from landlab import ModelParameterDictionary
+from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 from time import sleep
 from landlab.utils import structured_grid as sgrid
 import pylab
 
 from landlab.core.model_parameter_dictionary import MissingKeyError
 from landlab.field.scalar_data_fields import FieldError
+
 
 class TransportLimitedEroder(object):
     """
@@ -426,9 +427,9 @@ class TransportLimitedEroder(object):
         #
         ##to see if this is actually necessary
         ##grid.at_node[node_elevs][sgrid.interior_nodes((nrows,ncols))] = node_z_asgrid.ravel()
-        self.grid=grid
+        self.grid = grid
 
-        active_nodes = grid.get_active_cell_node_ids()
+        active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         if io:
             try:
                 io[active_nodes] += node_z_asgrid.ravel()[active_nodes]

--- a/landlab/examples/slope_aspect_routines_comparison.py
+++ b/landlab/examples/slope_aspect_routines_comparison.py
@@ -7,7 +7,7 @@
 from landlab import RasterModelGrid
 import matplotlib.pyplot as plt
 import numpy as np
-from landlab.plot.imshow import imshow_field, imshow_grid
+from landlab.plot.imshow import imshow_grid
 
 # Elevation_NS.npy is predetermined elevation profile that has
 # a North and a South facing slope with a flat valley in the middle
@@ -35,7 +35,7 @@ slope_NSP = grid.node_slopes_using_patches(elevs='Elevation', unit='degrees')
 
 pic = 0
 plt.figure(pic)
-imshow_field(grid, 'Elevation', values_at='node', grid_units=('m', 'm'))
+imshow_grid(grid, 'Elevation', values_at='node', grid_units=('m', 'm'))
 plt.title('Elevation in m')
 # plt.savefig('Elevation_NS')
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1521,7 +1521,8 @@ class ModelGrid(ModelDataFields):
         node_net_unit_flux = self.calculate_flux_divergence_at_nodes(
             active_link_flux)
 
-        net_unit_flux = node_net_unit_flux[self.corecell_node]
+        node_at_core_cell = self.node_at_cell[self.core_cells]
+        net_unit_flux = node_net_unit_flux[node_at_core_cell]
 
         return net_unit_flux
 
@@ -1873,23 +1874,11 @@ class ModelGrid(ModelDataFields):
         >>> grid.core_cells
         array([0, 2, 3, 4, 5])
         """
-        self.activecell_node = as_id_array(
-            numpy.where(self._node_status != CLOSED_BOUNDARY)[0])
-        self.corecell_node = as_id_array(
-            numpy.where(self._node_status == CORE_NODE)[0])
+        (self._core_nodes, ) = numpy.where(self._node_status == CORE_NODE)
+        self._num_core_nodes = self._core_nodes.size
 
-        self._num_core_cells = self.corecell_node.size
-        self._num_core_nodes = self._num_core_cells
-        self._num_active_nodes = self.activecell_node.size
-        self._num_active_cells = self._num_core_cells
-        self.active_cells = numpy.arange(self._num_active_cells)
-
-        #self._core_cells = self.cell_at_node[self.core_nodes]
-        self._core_cells = numpy.arange(self._num_core_cells)
-
-        self.node_activecell = numpy.empty(self.number_of_nodes, dtype=int)
-        self.node_activecell.fill(BAD_INDEX_VALUE)
-        self.node_activecell.flat[self.activecell_node] = self.active_cells
+        self._core_cells = self.cell_at_node[self._core_nodes]
+        self._num_core_cells = self._core_cells.size
 
         self._boundary_nodes = as_id_array(
             numpy.where(self._node_status != CORE_NODE)[0])

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -566,7 +566,20 @@ class ModelGrid(ModelDataFields):
 
     @property
     def cell_at_node(self):
-        """Node ID associated with grid cells"""
+        """Node ID associated with grid cells.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
+        >>> grid = RasterModelGrid((4, 5))
+        >>> ids = grid.cell_at_node
+        >>> ids[ids == BAD_INDEX_VALUE] = -1
+        >>> ids # doctest: +NORMALIZE_WHITESPACE
+        array([-1, -1, -1, -1, -1,
+               -1,  0,  1,  2, -1,
+               -1,  3,  4,  5, -1,
+               -1, -1, -1, -1, -1])
+        """
         return self._cell_at_node
 
     @property

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1631,21 +1631,13 @@ class ModelGrid(ModelDataFields):
         self._forced_cell_areas = numpy.empty(self.number_of_nodes)
         mean_cell_area = numpy.mean(self.active_cell_areas)
         self._forced_cell_areas.fill(mean_cell_area)
-        cell_node_ids = self.get_active_cell_node_ids()
+        cell_node_ids = np.where(self.status_at_node != CLOSED_BOUNDARY)[0]
         try:
             self._forced_cell_areas[cell_node_ids] = self.cell_areas
         except AttributeError:
             # in the case of the Voronoi
             self._forced_cell_areas[cell_node_ids] = self.active_cell_areas
         return self._forced_cell_areas
-
-    def get_active_cell_node_ids(self):
-        """Nodes of active cells.
-
-        Return an integer vector of the node IDs of all active (i.e., core +
-        open boundary) cells.
-        """
-        return self.activecell_node
 
     def get_active_link_connecting_node_pair(self, node1, node2):
         """Get the active link that connects a pair of nodes.

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -565,6 +565,11 @@ class ModelGrid(ModelDataFields):
         return self._node_at_cell
 
     @property
+    def cell_at_node(self):
+        """Node ID associated with grid cells"""
+        return self._cell_at_node
+
+    @property
     @return_readonly_id_array
     def active_nodes(self):
         """Get array of active nodes.
@@ -652,11 +657,6 @@ class ModelGrid(ModelDataFields):
         """Get array of nodes associated with core cells."""
         (core_cell_ids, ) = numpy.where(self._node_status == CORE_NODE)
         return core_cell_ids
-
-    @property
-    def core_cell_index_at_nodes(self):
-        """Get array of core cells associated with nodes."""
-        return self.node_corecell
 
     @property
     def core_cells(self):
@@ -1863,25 +1863,34 @@ class ModelGrid(ModelDataFields):
         * corecell_node *
         * active_cells
         * core_cells
-        * node_corecell
         * _boundary_nodes
+
+        Examples
+        --------
+        >>> import landlab
+        >>> grid = landlab.RasterModelGrid((4, 5))
+        >>> grid.status_at_node[7] = landlab.CLOSED_BOUNDARY
+        >>> grid.core_cells
+        array([0, 2, 3, 4, 5])
         """
         self.activecell_node = as_id_array(
             numpy.where(self._node_status != CLOSED_BOUNDARY)[0])
         self.corecell_node = as_id_array(
             numpy.where(self._node_status == CORE_NODE)[0])
+
         self._num_core_cells = self.corecell_node.size
         self._num_core_nodes = self._num_core_cells
         self._num_active_nodes = self.activecell_node.size
         self._num_active_cells = self._num_core_cells
         self.active_cells = numpy.arange(self._num_active_cells)
+
+        #self._core_cells = self.cell_at_node[self.core_nodes]
         self._core_cells = numpy.arange(self._num_core_cells)
-        self.node_corecell = numpy.empty(self.number_of_nodes, dtype=int)
-        self.node_corecell.fill(BAD_INDEX_VALUE)
-        self.node_corecell[self.corecell_node] = self._core_cells
+
         self.node_activecell = numpy.empty(self.number_of_nodes, dtype=int)
         self.node_activecell.fill(BAD_INDEX_VALUE)
         self.node_activecell.flat[self.activecell_node] = self.active_cells
+
         self._boundary_nodes = as_id_array(
             numpy.where(self._node_status != CORE_NODE)[0])
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -561,7 +561,16 @@ class ModelGrid(ModelDataFields):
 
     @property
     def node_at_cell(self):
-        """Node ID associated with grid cells"""
+        """Node ID associated with grid cells.
+        
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
+        >>> grid = RasterModelGrid((4, 5))
+        >>> grid.node_at_cell # doctest: +NORMALIZE_WHITESPACE
+        array([ 6,  7,  8,
+               11, 12, 13])
+        """
         return self._node_at_cell
 
     @property

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -88,6 +88,19 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     -------
     ndarray
         Net unit fluxes at nodes.
+
+    Examples
+    --------
+    >>> from landlab import RasterModelGrid
+    >>> from landlab.grid.grid_funcs import calculate_flux_divergence_at_nodes
+    >>> grid = RasterModelGrid((4, 5))
+    >>> link_flux = np.ones(grid.number_of_active_links, dtype=float)
+    >>> calculate_flux_divergence_at_nodes(grid, link_flux)
+    ...     # doctest: +NORMALIZE_WHITESPACE
+    array([ 0.,  1.,  1.,  1.,  0.,
+            1.,  0.,  0.,  0., -1.,
+            1.,  0.,  0.,  0., -1.,
+            0., -1., -1., -1.,  0.])
     """
     assert len(active_link_flux) == grid.number_of_active_links, (
         "incorrect length of active_link_flux array")
@@ -106,7 +119,7 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     # active link, so we are multiplying the unit flux at each link by the
     # width of its corresponding face.
     flux = np.zeros(len(active_link_flux) + 1)
-    flux[:len(active_link_flux)] = active_link_flux * grid.face_width
+    flux[:len(active_link_flux)] = active_link_flux * grid.face_widths
 
     # Next, we need to add up the incoming and outgoing fluxes.
     #
@@ -122,8 +135,8 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
         net_unit_flux += flux[grid.node_active_outlink_matrix[i][:]]
         net_unit_flux -= flux[grid.node_active_inlink_matrix[i][:]]
 
-    # Now divide by cell areas ... where there are active cells.
+    # Now divide by cell areas ... where there are core cells.
     node_at_active_cell = grid.node_at_cell[grid.core_cells]
-    net_unit_flux[node_at_active_cell] /= grid.active_cell_areas
+    net_unit_flux[node_at_active_cell] /= grid.cell_areas[grid.core_cells]
 
     return net_unit_flux

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -123,6 +123,7 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
         net_unit_flux -= flux[grid.node_active_inlink_matrix[i][:]]
 
     # Now divide by cell areas ... where there are active cells.
-    net_unit_flux[grid.activecell_node] /= grid.active_cell_areas
+    node_at_active_cell = grid.node_at_cell[grid.core_cells]
+    net_unit_flux[node_at_active_cell] /= grid.active_cell_areas
 
     return net_unit_flux

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -405,10 +405,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg.status_at_node # doctest : +NORMALIZE_WHITESPACE
         array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                dtype=int8)
-        >>> rmg.node_corecell[3] == BAD_INDEX_VALUE
-        True
-        >>> rmg.node_corecell[8]
-        2
         >>> rmg.node_numinlink
         array([0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 2])
         >>> rmg.node_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
@@ -539,7 +535,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # or None if it has no associated active cell (i.e., it is a boundary)
         self._node_at_cell = sgrid.node_at_cell(self.shape)
         self.node_activecell = sgrid.active_cell_index_at_nodes(self.shape)
-        self.node_corecell = sgrid.core_cell_index_at_nodes(self.shape)
         self.active_cells = sgrid.active_cell_index(self.shape)
         self._core_cells = sgrid.core_cell_index(self.shape)
         self.activecell_node = self._node_at_cell.copy()

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -129,11 +129,11 @@ class RasterModelGridPlotter(object):
 
         See Also
         --------
-        landlab.plot.imshow_field
+        landlab.plot.imshow_grid
         """
-        from landlab.plot import imshow_field
+        from landlab.plot import imshow_grid
         kwds['values_at'] = group
-        imshow_field(self, var_name, **kwds)
+        imshow_grid(self, var_name, **kwds)
 
 
 def grid_edge_is_closed_from_dict(boundary_conditions):

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -11,6 +11,7 @@ from six.moves import range
 from landlab.testing.decorators import track_this_method
 from landlab.utils import structured_grid as sgrid
 from landlab.utils import count_repeated_values
+from landlab.grid import structured_quad as squad
 
 from .base import ModelGrid
 from .base import (CORE_NODE, FIXED_VALUE_BOUNDARY,
@@ -534,12 +535,10 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # list records, for each node, the ID of its associated active cell,
         # or None if it has no associated active cell (i.e., it is a boundary)
         self._node_at_cell = sgrid.node_at_cell(self.shape)
-        self.node_activecell = sgrid.active_cell_index_at_nodes(self.shape)
+        self._cell_at_node = squad.cells.cell_id_at_nodes(
+            self.shape).reshape((-1, ))
         self.active_cells = sgrid.active_cell_index(self.shape)
         self._core_cells = sgrid.core_cell_index(self.shape)
-        self.activecell_node = self._node_at_cell.copy()
-        self.corecell_node = self._node_at_cell
-        #self.active_faces = sgrid.active_face_index(self.shape)
 
         # Link lists:
         # For all links, we encode the "from" and "to" nodes, and the face

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -404,36 +404,51 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         ...  rmg.number_of_active_links)
         (20, 6, 31, 17)
         >>> rmg.status_at_node # doctest : +NORMALIZE_WHITESPACE
-        array([1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 1, 1, 1, 1, 1, 1],
-               dtype=int8)
+        array([1, 1, 1, 1, 1,
+               1, 0, 0, 0, 1,
+               1, 0, 0, 0, 1,
+               1, 1, 1, 1, 1], dtype=int8)
         >>> rmg.node_numinlink
-        array([0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 2])
+        array([0, 1, 1, 1, 1,
+               1, 2, 2, 2, 2,
+               1, 2, 2, 2, 2,
+               1, 2, 2, 2, 2])
         >>> rmg.node_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10,
                 11, 12, 13, 14],
                [-1, 15, 16, 17, 18, -1, 19, 20, 21, 22, -1, 23, 24, 25, 26, -1,
                 27, 28, 29, 30]])
-        >>> rmg.node_numoutlink
-        array([2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 2, 2, 2, 2, 1, 1, 1, 1, 1, 0])
+        >>> rmg.node_numoutlink # doctest: +NORMALIZE_WHITESPACE
+        array([2, 2, 2, 2, 1,
+               2, 2, 2, 2, 1,
+               2, 2, 2, 2, 1,
+               1, 1, 1, 1, 0])
         >>> rmg.node_outlink_matrix[0] # doctest: +NORMALIZE_WHITESPACE
         array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
                -1, -1, -1, -1, -1])
-        >>> rmg.node_numactiveinlink
-        array([0, 0, 0, 0, 0, 0, 2, 2, 2, 1, 0, 2, 2, 2, 1, 0, 1, 1, 1, 0])
+        >>> rmg.node_numactiveinlink # doctest: +NORMALIZE_WHITESPACE
+        array([0, 0, 0, 0, 0,
+               0, 2, 2, 2, 1,
+               0, 2, 2, 2, 1,
+               0, 1, 1, 1, 0])
         >>> rmg.node_active_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1, -1, -1, -1, -1, -1,  0,  1,  2, -1, -1,  3,  4,  5, -1, -1,
                  6, 7,  8, -1],
                [-1, -1, -1, -1, -1, -1,  9, 10, 11, 12, -1, 13, 14, 15, 16, -1,
                 -1, -1, -1, -1]])
-        >>> rmg.node_numactiveoutlink
-        array([0, 1, 1, 1, 0, 1, 2, 2, 2, 0, 1, 2, 2, 2, 0, 0, 0, 0, 0, 0])
+        >>> rmg.node_numactiveoutlink # doctest: +NORMALIZE_WHITESPACE
+        array([0, 1, 1, 1, 0,
+               1, 2, 2, 2, 0,
+               1, 2, 2, 2, 0,
+               0, 0, 0, 0, 0])
         >>> rmg.node_active_outlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1,  0,  1,  2, -1, -1,  3,  4,  5, -1, -1,  6,  7,  8, -1, -1,
                 -1, -1, -1, -1],
                [-1, -1, -1, -1, -1,  9, 10, 11, 12, -1, 13, 14, 15, 16, -1, -1,
                 -1, -1, -1, -1]])
-        >>> rmg.node_at_cell
-        array([ 6,  7,  8, 11, 12, 13])
+        >>> rmg.node_at_cell # doctest: +NORMALIZE_WHITESPACE
+        array([ 6,  7,  8,
+               11, 12, 13])
         >>> rmg.node_at_link_tail # doctest: +NORMALIZE_WHITESPACE
         array([ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,  0,
                 1, 2,  3,  5,  6,  7,  8, 10, 11, 12, 13, 15, 16, 17, 18])
@@ -472,7 +487,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self._num_links = sgrid.link_count(self.shape)
         self._num_active_links = sgrid.active_link_count(self.shape)
 
-        self._num_faces = sgrid.face_count(self.shape)
+        self._num_faces = squad.faces.number_of_faces(self.shape)
         self._num_active_faces = sgrid.active_face_count(self.shape)
 
         # We need at least one row or column of boundary cells on each
@@ -3933,10 +3948,25 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     def _setup_face_widths(self):
         """Set up array of face widths.
 
-        Produces an array of length nfaces containing the face width (dx).
+        Produces an array of length nfaces containing the face width.
+
+        Returns
+        -------
+        ndarray of float
+            Width of faces (listed as horizontal, then vertical).
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> grid = RasterModelGrid((3, 3))
+        >>> grid.face_widths
+        array([ 1.,  1.,  1.,  1.])
         """
-        self._face_widths = np.empty(self.number_of_faces)
-        self._face_widths.fill(self.dx)
+        n_horizontal_faces = (self.shape[0] - 2) * (self.shape[1] - 1)
+
+        self._face_widths = np.empty(squad.faces.number_of_faces(self.shape))
+        self._face_widths[:n_horizontal_faces] = self.dx
+        self._face_widths[n_horizontal_faces:] = self.dy
         return self._face_widths
 
     def _unit_test(self):

--- a/landlab/grid/structured_quad/cells.py
+++ b/landlab/grid/structured_quad/cells.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from . import nodes
+from .. import BAD_INDEX_VALUE
 
 
 def number_of_cells(shape):
@@ -68,6 +69,35 @@ def node_id_at_cells(shape):
     """
     node_ids = nodes.node_ids(shape)
     return node_ids[1:-1, 1:-1].copy().reshape(shape_of_cells(shape))
+
+
+def cell_id_at_nodes(shape, bad=BAD_INDEX_VALUE):
+    """Cell ID at each node.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        Shape of grid of nodes.
+
+    Returns
+    -------
+    ndarray :
+        ID of cell associated with each node.
+
+    Examples
+    --------
+    >>> from landlab.grid.structured_quad.cells import cell_id_at_nodes
+    >>> cell_id_at_nodes((4, 5), bad=-1) # doctest: +NORMALIZE_WHITESPACE
+    array([[-1, -1, -1, -1, -1],
+           [-1,  0,  1,  2, -1],
+           [-1,  3,  4,  5, -1],
+           [-1, -1, -1, -1, -1]])
+    """
+    cells = np.empty(shape, dtype=int)
+    cells[1:-1, 1:-1] = cell_ids(shape)
+    cells[(0, -1), :] = bad
+    cells[:, (0, -1)] = bad
+    return cells
 
 
 def cell_ids(shape):

--- a/landlab/grid/structured_quad/faces.py
+++ b/landlab/grid/structured_quad/faces.py
@@ -18,6 +18,13 @@ def number_of_faces(shape):
     --------
     >>> from landlab.grid.structured_quad.faces import number_of_faces
     >>> number_of_faces((3, 4))
-    17
+    7
     """
-    return links.number_of_links(shape)
+    if len(shape) != 2:
+        raise ValueError('shape must be size 2')
+
+    if min(shape) > 2:
+        return ((shape[0] - 1) * (shape[1] - 2) +
+                (shape[0] - 2) * (shape[1] - 1))
+    else:
+        return 0

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -334,9 +334,6 @@ class VoronoiDelaunayGrid(ModelGrid):
         self._num_core_nodes = len(core_nodes)
         self._num_core_cells = len(core_nodes)
         self._core_cells = numpy.arange(len(core_nodes), dtype=numpy.int)
-        self.node_corecell = numpy.empty(node_status.size, dtype=numpy.int)
-        self.node_corecell.fill(BAD_INDEX_VALUE)
-        self.node_corecell[core_nodes] = self._core_cells
         self.active_cells = numpy.arange(node_status.size, dtype=numpy.int)
         self._node_at_cell = core_nodes
         self.activecell_node = core_nodes

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -178,19 +178,18 @@ class VoronoiDelaunayGrid(ModelGrid):
         self._num_active_cells = self.number_of_cells
         [self._cell_at_node, self._node_at_cell] = self.setup_node_cell_connectivity(
             self._node_status, self.number_of_cells)
-        self.node_activecell = self._cell_at_node
-        self.activecell_node = self._node_at_cell
+        active_cell_at_node = self.cell_at_node[self.core_nodes]
 
         # ACTIVE CELLS: Construct Voronoi diagram and calculate surface area of
         # each active cell.
         vor = Voronoi(pts)
         self.vor = vor
         self.active_cell_areas = numpy.zeros(self.number_of_active_cells)
-        for node in self.activecell_node:
+        for node in self._node_at_cell:
             xv = vor.vertices[vor.regions[vor.point_region[node]], 0]
             yv = vor.vertices[vor.regions[vor.point_region[node]], 1]
-            self.active_cell_areas[self.node_activecell[
-                node]] = simple_poly_area(xv, yv)
+            self.active_cell_areas[self.cell_at_node[node]] = (
+                simple_poly_area(xv, yv))
 
         # LINKS: Construct Delaunay triangulation and construct lists of link
         # "from" and "to" nodes.
@@ -336,8 +335,6 @@ class VoronoiDelaunayGrid(ModelGrid):
         self._core_cells = numpy.arange(len(core_nodes), dtype=numpy.int)
         self.active_cells = numpy.arange(node_status.size, dtype=numpy.int)
         self._node_at_cell = core_nodes
-        self.activecell_node = core_nodes
-        self.corecell_node = core_nodes
         self._boundary_nodes = boundary_nodes
 
         # Return the results

--- a/landlab/plot/__init__.py
+++ b/landlab/plot/__init__.py
@@ -1,2 +1,2 @@
-from landlab.plot.imshow import (imshow_grid, imshow_field,
-                                 imshow_active_cells)
+from landlab.plot.imshow import (imshow_grid, imshow_node_grid,
+                                 imshow_cell_grid)

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -8,16 +8,9 @@ try:
 except ImportError:
     import warnings
     warnings.warn('matplotlib not found', ImportWarning)
-
+from landlab.grid import CLOSED_BOUNDARY
 from landlab.grid.raster import RasterModelGrid
 from landlab.grid.voronoi import VoronoiDelaunayGrid
-
-
-def assert_array_size_matches(array, size, msg=None):
-    if size != array.size:
-        if msg is None:
-            msg = '%d != %d' % (size, array.size)
-        raise ValueError(msg)
 
 
 def imshow_node_grid(grid, values, **kwds):
@@ -31,7 +24,7 @@ def imshow_node_grid(grid, values, **kwds):
 
     Parameters
     ----------
-    grid : RasterModelGrid
+    grid : ModelGrid
         Grid containing node field to plot.
     values : array_like or str
         Node values or a field name as a string from which to draw the data.
@@ -66,216 +59,71 @@ def imshow_node_grid(grid, values, **kwds):
     Use matplotlib functions like xlim, ylim to modify your
     plot after calling imshow_node_grid, as desired.
     """
-    if type(values) == str:
-        value_str = values
-        values = grid.at_node[values]
-
-    assert_array_size_matches(values, grid.number_of_nodes,
-                              'number of values does not match number of nodes')
-
-    data = values.view()
-
-    if RasterModelGrid in inspect.getmro(grid.__class__):
-        data.shape = grid.shape
-        data = np.ma.masked_where((grid.status_at_node == 4).reshape(grid.shape),
-                              data)
+    if isinstance(values, str):
+        values_at_node = grid.at_node[values]
     else:
-        data = np.ma.masked_where(grid.status_at_node == 4, data)
+        values_at_node = values
 
-    myimage = _imshow_grid_values(grid, data, **kwds)
+    if values_at_node.size != grid.number_of_nodes:
+        raise ValueError('number of values does not match number of nodes')
 
-    try:
-        plt.title(value_str)
-    except NameError:
-        pass
+    values_at_node = np.ma.masked_where(
+        grid.status_at_node == CLOSED_BOUNDARY, values_at_node)
 
-    return myimage
+    myimage = _imshow_grid_values(grid, values_at_node.reshape(grid.shape),
+                                  **kwds)
 
-
-def imshow_active_node_grid(grid, values, other_node_val='min', **kwds):
-    """
-    Prepares a map view of data over only the active (i.e., not closed) nodes
-    in the grid.
-    Method can take any of the same **kwds as imshow().
-
-    requires:
-    grid: the grid
-    values: the values on the open, active nodes OR the values on all nodes in
-    the grid. If the latter is provided, this method will only plot the active
-    subset.
-
-    If *other_node_val* is set, this is the value that will be displayed for
-    all nodes that are not active. It defaults to 'min', which is the minimum
-    value found on any active node in the grid.
-    """
-    active_nodes = grid.active_nodes
-    try:
-        assert_array_size_matches(values, active_nodes.size,
-                                  'number of values does not match number of active nodes')
-    except ValueError:
-        assert_array_size_matches(values[active_nodes], active_nodes.size,
-                                  'number of values does not match number of active nodes')
-        values_to_use = values[active_nodes]
-    else:
-        values_to_use = values
-
-    data = np.zeros(grid.number_of_nodes)
-    if other_node_val != 'min':
-        data.fill(other_node_val)
-    else:
-        data.fill(np.min(values_to_use))
-    data[active_nodes] = values_to_use.flat
-
-    if RasterModelGrid in inspect.getmro(grid.__class__):
-        data.shape = grid.shape
-
-    myimage = _imshow_grid_values(grid, data, **kwds)
-
-    if type(values) == str:
+    if isinstance(values, str):
         plt.title(values)
 
     return myimage
 
 
-def imshow_core_node_grid(grid, values, other_node_val='min', **kwds):
-    """
-    Prepares a map view of data over only the core nodes
-    in the grid.
-    Method can take any of the same **kwds as imshow().
-
-    requires:
-    grid: the grid
-    values: the values on the core nodes OR the values on all nodes in
-    the grid. If the latter is provided, this method will only plot the core
-    subset. Alternatively, can be a string giving the name of a grid field,
-    defined either on core nodes or all nodes.
-
-    If *other_node_val* is set, this is the value that will be displayed for
-    all nodes that are not core. It defaults to 'min', which is the minimum
-    value found on any core node in the grid.
-    """
-    active_nodes = grid.core_nodes
-
-    if type(values) == str:
-        value_str = values
-        try:
-            values = grid.at_core_node[values]
-        except FieldError:
-            values = grid.at_node[values][active_nodes]
-
-    try:
-        assert_array_size_matches(values, active_nodes.size,
-                                  'number of values does not match number of active nodes')
-    except ValueError:
-        assert_array_size_matches(values[active_nodes], active_nodes.size,
-                                  'number of values does not match number of active nodes')
-        values_to_use = values[active_nodes]
-    else:
-        values_to_use = values
-
-    data = np.zeros(grid.number_of_nodes)
-    if other_node_val != 'min':
-        data.fill(other_node_val)
-    else:
-        data.fill(np.min(values_to_use))
-    data[active_nodes] = values_to_use.flat
-
-    if RasterModelGrid in inspect.getmro(grid.__class__):
-        data.shape = grid.shape
-
-    myimage = _imshow_grid_values(grid, data, **kwds)
-
-    try:
-        plt.title(value_str)
-    except NameError:
-        pass
-
-    return myimage
-
-
 def imshow_cell_grid(grid, values, **kwds):
-    """
+    """Map view of grid data over all grid cells.
+
     Prepares a map view of data over all cells in the grid.
-    Method can take any of the same **kwds as imshow().
+    Method can take any of the same **kwds as `imshow`.
 
-    requires:
-    grid: the grid
-    values: the values on the cells OR the values on all nodes in the grid, from
-    which the cell values will be extracted. Alternatively, can be a field
-    name (string) from which to draw the data from the grid.
+    Parameters
+    ----------
+    grid : RasterModelGrid
+        A uniform rectilinear grid to plot.
+    values : array_like or str
+        Values at the cells *or* values on all nodes in the grid, from which
+        cell values will be extracted. Alternatively, can be a field name
+        (string) from which to draw the data from the grid.
+
+    Raises
+    ------
+    ValueError
+        If input grid is not uniform rectilinear.
     """
-    cells = grid.node_at_cell
-
-    if type(values) == str:
-        value_str = values
+    if isinstance(values, str):
         try:
-            values = grid.at_cell[values]
+            values_at_cell = grid.at_cell[values]
         except FieldError:
-            values = grid.at_node[values][cells]
-
-    try:
-        assert_array_size_matches(values, cells.size,
-                                  'number of values does not match number of cells')
-    except ValueError:
-        assert_array_size_matches(values[cells], cells.size,
-                                  'number of values does not match number of cells')
-        values_to_use = values[cells]
+            values_at_cell = grid.at_node[values]
     else:
-        values_to_use = values
+        values_at_cell = values
 
-    data = values_to_use.view()
-    if RasterModelGrid in inspect.getmro(grid.__class__):
-        data.shape = (grid.shape[0] - 2, grid.shape[1] - 2)
+    if values_at_cell.size == grid.number_of_nodes:
+        values_at_cell = values_at_cell[grid.node_at_cell]
 
-    myimage = _imshow_grid_values(grid, data, **kwds)
+    if values_at_cell.size != grid.number_of_cells:
+        raise ValueError('number of values must match number of cells or '
+                         'number of nodes')
 
-    try:
-        plt.title(value_str)
-    except NameError:
-        pass
+    values_at_cell = np.ma.asarray(values_at_cell)
+    values_at_cell.mask = True
+    values_at_cell.mask[grid.core_cells] = False
 
-    return myimage
+    myimage = _imshow_grid_values(grid,
+                                  values_at_cell.reshape(grid.cell_grid_shape),
+                                  **kwds)
 
-
-def imshow_active_cell_grid(grid, values, other_node_val='min', **kwds):
-    """
-    Prepares a map view of data over all active (i.e., core and open boundary)
-    cells in the grid.
-    Method can take any of the same **kwds as imshow().
-
-    requires:
-    grid: the grid
-    values: the values on the active cells OR the values on all nodes in the
-    grid, from which the active cell values will be extracted.
-
-    If *other_node_val* is set, this is the value that will be displayed for
-    all cells that are not active. It defaults to 'min', which is the minimum
-    value found on any active cell in the grid.
-    """
-
-    active_cells = grid.node_at_core_cell
-
-    try:
-        assert_array_size_matches(values, active_cells.size,
-                                  'number of values does not match number of active cells')
-    except ValueError:
-        assert_array_size_matches(values[active_cells], active_cells.size,
-                                  'number of values does not match number of active cells')
-        values_to_use = values[active_cells]
-    else:
-        values_to_use = values
-
-    data = np.zeros(grid.number_of_nodes)
-    if other_node_val != 'min':
-        data.fill(other_node_val)
-    else:
-        data.fill(np.min(values_to_use))
-    data[active_cells] = values_to_use
-    data = data[grid.node_at_cell]
-    if RasterModelGrid in inspect.getmro(grid.__class__):
-        data.shape = (grid.shape[0] - 2, grid.shape[1] - 2)
-
-    myimage = _imshow_grid_values(grid, data, **kwds)
+    if isinstance(values, str):
+        plt.title(values)
 
     return myimage
 
@@ -292,24 +140,20 @@ def _imshow_grid_values(grid, values, var_name=None, var_units=None,
     cmap = plt.get_cmap(cmap)
     cmap.set_bad(color=color_for_closed)
 
-    if RasterModelGrid in gridtypes:
-        if len(values.shape) != 2:
-            raise ValueError(
-                'dimension of values must be 2 (%s)' % values.shape)
+    if isinstance(grid, RasterModelGrid):
+        if values.ndim != 2:
+            raise ValueError('values must have ndim == 2')
 
         y = np.arange(values.shape[0] + 1) * grid.dx - grid.dx * .5
         x = np.arange(values.shape[1] + 1) * grid.dx - grid.dx * .5
 
         kwds = dict(cmap=cmap)
         (kwds['vmin'], kwds['vmax']) = (values.min(), values.max())
-        # ^default condition
         if (limits is None) and ((vmin is None) and (vmax is None)):
             if symmetric_cbar:
                 (var_min, var_max) = (values.min(), values.max())
                 limit = max(abs(var_min), abs(var_max))
                 (kwds['vmin'], kwds['vmax']) = (- limit, limit)
-            else:
-                pass
         elif limits is not None:
             (kwds['vmin'], kwds['vmax']) = (limits[0], limits[1])
         else:
@@ -385,73 +229,20 @@ def _imshow_grid_values(grid, values, var_name=None, var_units=None,
         if var_name is not None:
             plt.title('%s (%s)' % (var_name, var_units))
 
-    return None
-
 
 def imshow_grid(grid, values, **kwds):
     show = kwds.pop('show', False)
     values_at = kwds.pop('values_at', 'node')
 
+    if isinstance(values, str):
+        values = grid.field_values(values_at, values)
+
     if values_at == 'node':
         imshow_node_grid(grid, values, **kwds)
     elif values_at == 'cell':
         imshow_cell_grid(grid, values, **kwds)
-    elif values_at == 'active_node':
-        imshow_active_node_grid(grid, values, **kwds)
-    elif values_at == 'active_cell':
-        imshow_active_cell_grid(grid, values, **kwds)
     else:
         raise TypeError('value location %s not understood' % values_at)
 
     if show:
         plt.show()
-
-
-def imshow_field(field, name, **kwds):
-    values_at = kwds['values_at']
-    imshow_grid(field, field.field_values(values_at, name), var_name=name,
-                var_units=field.field_units(values_at, name), **kwds)
-
-###
-# Added by Sai Nudurupati 29Oct2013
-# This function is exactly the same as imshow_grid but this function plots
-# arrays spread over cells rather than nodes
-# DEJH: Sai, this is duplicating what we already had I think. I deprecated it.
-
-
-def imshow_active_cells(grid, values, var_name=None, var_units=None,
-                        grid_units=(None, None), symmetric_cbar=False,
-                        cmap='pink'):
-    """
-    .. deprecated:: 0.6
-    Use :meth:`imshow_active_cell_grid`, above, instead.
-    """
-    data = values.view()
-    data.shape = (grid.shape[0] - 2, grid.shape[1] - 2)
-
-    y = np.arange(data.shape[0]) - grid.dx * .5
-    x = np.arange(data.shape[1]) - grid.dx * .5
-
-    if symmetric_cbar:
-        (var_min, var_max) = (data.min(), data.max())
-        limit = max(abs(var_min), abs(var_max))
-        limits = (-limit, limit)
-    else:
-        limits = (None, None)
-
-    plt.pcolormesh(x, y, data, vmin=limits[0], vmax=limits[1], cmap=cmap)
-
-    plt.gca().set_aspect(1.)
-    plt.autoscale(tight=True)
-
-    plt.colorbar()
-
-    plt.xlabel('X (%s)' % grid_units[1])
-    plt.ylabel('Y (%s)' % grid_units[0])
-
-    if var_name is not None:
-        plt.title('%s (%s)' % (var_name, var_units))
-
-    plt.show()
-
-###

--- a/landlab/plot/tests/test_imshow_grid.py
+++ b/landlab/plot/tests/test_imshow_grid.py
@@ -15,14 +15,9 @@ def test_imshow_grid():
     pp.savefig()
 
     plt.clf()
+    rmg.status_at_node[7] = landlab.CLOSED_BOUNDARY
     values = np.arange(rmg.number_of_cells)
     landlab.plot.imshow_grid(rmg, values, values_at='cell',
                              symmetric_cbar=True)
     pp.savefig()
-
-    plt.clf()
-    values = np.arange(rmg.number_of_cells)
-    landlab.plot.imshow_grid(rmg, values, values_at='active_cell')
-    pp.savefig()
-
     pp.close()


### PR DESCRIPTION
This pull request fixes #171. The main change is to the `_reset_lists_of_nodes_cells` method of `ModelGrid`. However, in fixing this I also removed arrays that used old terminology. These include:
- `activecell_node`
- `node_corecell`
- `corecell_node`
- `node_activecell`
- `active_cell_areas`

Many of these arrays were still being used in `VoronoiDelaunayGrid` so maybe @gregtucker you could have a look?

One bit of confusion is that I'm not sure if we have a name for a node that is either *core* or *open boundary*? It seems these used to be *active*.