### PR TITLE
Add neighbors_at_node property

### DIFF
--- a/landlab/components/craters/craters.py
+++ b/landlab/components/craters/craters.py
@@ -430,7 +430,7 @@ class impactor(object):
                     depth_excavated = (pre_elev-_new_z)
                     crater_vol_below_ground += depth_excavated
                     self.mass_balance_in_impact -= depth_excavated
-                    neighbors_active_node = grid.get_neighbor_list(active_node)
+                    neighbors_active_node = grid.get_active_neighbors_at_node(active_node)
                     for x in neighbors_active_node:
                         if not flag_already_in_the_list[x]:
                             if x!=-1: #Not an edge
@@ -465,7 +465,7 @@ class impactor(object):
                         self.mass_balance_in_impact += _thickness
 
                     if _thickness > self._minimum_ejecta_thickness:
-                        neighbors_active_node = grid.get_neighbor_list(active_node)
+                        neighbors_active_node = grid.get_active_neighbors_at_node(active_node)
                         for x in neighbors_active_node:
                             if not flag_already_in_the_list[x]:
                                 if x!=-1:

--- a/landlab/components/delta_front/delta_front.py
+++ b/landlab/components/delta_front/delta_front.py
@@ -15,7 +15,7 @@ class Littoral(object):
 
     def assign_Qs_to_littoral_cells(self, grid, dry_land_Qs_array, elev):
         self.dry_land_Qs = dry_land_Qs_array[dry_land_Qs_array>0]
-        cell_neighbors = grid.get_neighbor_list(self.dry_land_Qs)
+        cell_neighbors = grid.get_active_neighbors_at_node(self.dry_land_Qs)
         cell_neighbor_heights = elev[cell_neighbors]
         number_wet_cell_neighbors = np.sum(cell_neighbor_heights<0, axis=1)
         wet_neighbor_nonzero = np.where(number_wet_cell_neighbors>0)

--- a/landlab/components/flow_routing/flow_direction_DN.py
+++ b/landlab/components/flow_routing/flow_direction_DN.py
@@ -226,7 +226,7 @@ def flow_directions(elev, active_links, fromnode, tonode, link_slope,
             except NameError:
                 neighbor_nodes = np.empty((grid.active_nodes.size, 8), dtype=int)
                 #the target shape is (nnodes,4) & S,W,N,E,SW,NW,NE,SE
-                neighbor_nodes[:,:4] = grid.get_neighbor_list(bad_index=-1)[grid.active_nodes,:][:,::-1] # comes as (nnodes, 4), and E,N,W,S
+                neighbor_nodes[:,:4] = grid.get_active_neighbors_at_node(bad_index=-1)[grid.active_nodes,:][:,::-1] # comes as (nnodes, 4), and E,N,W,S
                 neighbor_nodes[:,4:] = grid.get_diagonal_list(bad_index=-1)[grid.active_nodes,:][:,[2,1,0,3]] #NE,NW,SW,SE
                 links_list = np.empty_like(neighbor_nodes)
                 links_list[:,:4] = grid.node_links().T[grid.active_nodes,:] #(n_active_nodes, SWNE)

--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -178,7 +178,7 @@ class DepressionFinderAndRouter(Component):
         # We'll also need a handy copy of the node neighbor lists
         # TODO: presently, this grid method seems to only exist for Raster
         # grids. We need it for *all* grids!
-        self._node_nbrs = self._grid.get_neighbor_list()
+        self._node_nbrs = self._grid.get_active_neighbors_at_node()
         dx = self._grid.dx
         dy = self._grid.dy
         if self._D8:
@@ -606,12 +606,12 @@ class DepressionFinderAndRouter(Component):
                 self.handle_outlet_node(outlet_node, nodes_in_lake)
                 while (len(nodes_in_lake) + 1) != len(nodes_routed):
                     if self._D8:
-                        all_nbrs = np.hstack((self._grid.get_neighbor_list(
+                        all_nbrs = np.hstack((self._grid.get_active_neighbors_at_node(
                             nodes_on_front),
                             self._grid.get_diagonal_list(
                             nodes_on_front)))
                     else:
-                        all_nbrs = self._grid.get_neighbor_list(nodes_on_front)
+                        all_nbrs = self._grid.get_active_neighbors_at_node(nodes_on_front)
                     outlake = np.logical_not(np.in1d(all_nbrs.flat,
                                                      nodes_in_lake))
                     all_nbrs[outlake.reshape(all_nbrs.shape)] = -1
@@ -676,12 +676,12 @@ class DepressionFinderAndRouter(Component):
         """
         if self._grid.status_at_node[outlet_node] == 0:  # it's not a BC
             if self._D8:
-                outlet_neighbors = np.hstack((self._grid.get_neighbor_list(
+                outlet_neighbors = np.hstack((self._grid.get_active_neighbors_at_node(
                     outlet_node),
                     self._grid.get_diagonal_list(
                     outlet_node)))
             else:
-                outlet_neighbors = self._grid.get_neighbor_list(
+                outlet_neighbors = self._grid.get_active_neighbors_at_node(
                     outlet_node).copy()
             inlake = np.in1d(outlet_neighbors.flat, nodes_in_lake)
             assert inlake.size > 0

--- a/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
+++ b/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
@@ -309,7 +309,7 @@ class PerronNLDiffuse(object):
         """
         extended_elevs = numpy.empty(self.grid.number_of_nodes+1, dtype=float)
         extended_elevs[-1] = numpy.nan
-        node_neighbors = self.grid.get_neighbor_list()
+        node_neighbors = self.grid.get_active_neighbors_at_node()
         extended_elevs[:-1] = new_grid['node'][self.values_to_diffuse]
         max_offset = numpy.nanmax(numpy.fabs(
             extended_elevs[:-1][node_neighbors] -
@@ -411,7 +411,7 @@ class PerronNLDiffuse(object):
             elev[right_nodes[1:-1]] = elev[right_nodes[1:-1]-1]
 
         # replacing loop:
-        cell_neighbors = grid.get_neighbor_list()  # E,N,W,S
+        cell_neighbors = grid.get_active_neighbors_at_node()  # E,N,W,S
         cell_diagonals = grid.get_diagonal_list()  # NE,NW,SW,SE
         cell_neighbors[cell_neighbors == BAD_INDEX_VALUE] = -1
         cell_diagonals[cell_diagonals == BAD_INDEX_VALUE] = -1

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -347,10 +347,10 @@ class SinkFiller(Component):
         the *routing* method (D4/D8) if applicable.
         """
         if self._D8 is True:
-            all_poss = np.union1d(self._grid.get_neighbor_list(lake_nodes),
+            all_poss = np.union1d(self._grid.get_active_neighbors_at_node(lake_nodes),
                                   self._grid.get_diagonal_list(lake_nodes))
         else:
-            all_poss = np.unique(self._grid.get_neighbor_list(lake_nodes))
+            all_poss = np.unique(self._grid.get_active_neighbors_at_node(lake_nodes))
         lake_ext_edge = np.setdiff1d(all_poss, lake_nodes)
         return lake_ext_edge[lake_ext_edge != BAD_INDEX_VALUE]
 
@@ -361,10 +361,10 @@ class SinkFiller(Component):
         """
         lee = lake_ext_edge
         if self._D8 is True:
-            all_poss_int = np.union1d(self._grid.get_neighbor_list(lee),
+            all_poss_int = np.union1d(self._grid.get_active_neighbors_at_node(lee),
                                       self._grid.get_diagonal_list(lee))
         else:
-            all_poss_int = np.unique(self._grid.get_neighbor_list(lee))
+            all_poss_int = np.unique(self._grid.get_active_neighbors_at_node(lee))
         lake_int_edge = np.intersect1d(all_poss_int, lake_nodes)
         return lake_int_edge[lake_int_edge != BAD_INDEX_VALUE]
 
@@ -399,11 +399,11 @@ class SinkFiller(Component):
         """
         ext_edge = self.get_lake_ext_margin(lake_nodes)
         if self._D8:
-            edge_neighbors = np.hstack((self._grid.get_neighbor_list(ext_edge),
+            edge_neighbors = np.hstack((self._grid.get_active_neighbors_at_node(ext_edge),
                                         self._grid.get_diagonal_list(
                                             ext_edge)))
         else:
-            edge_neighbors = self._grid.get_neighbor_list(ext_edge).copy()
+            edge_neighbors = self._grid.get_active_neighbors_at_node(ext_edge).copy()
         edge_neighbors[edge_neighbors == BAD_INDEX_VALUE] = -1
         # ^value irrelevant
         old_neighbor_elevs = old_elevs[edge_neighbors]

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_alt.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_alt.py
@@ -249,7 +249,7 @@ class TransportLimitedEroder(object):
         self.cell_areas[grid.node_at_cell] = grid.cell_areas
         self.dx2 = grid.dx ** 2
         self.dy2 = grid.dy ** 2
-        self.bad_neighbor_mask = np.equal(grid.get_neighbor_list(bad_index=-1),-1)
+        self.bad_neighbor_mask = np.equal(grid.get_active_neighbors_at_node(bad_index=-1),-1)
 
     def erode(self, grid, dt, node_drainage_areas='drainage_area',
                 node_elevs='topographic__elevation',
@@ -343,7 +343,7 @@ class TransportLimitedEroder(object):
 
         all_nodes_diffusivity = self.diffusivity_prefactor*node_A**self.diffusivity_power_on_A
         #########ALT
-        neighbor_nodes = grid.get_neighbor_list(bad_index=-1)
+        neighbor_nodes = grid.get_active_neighbors_at_node(bad_index=-1)
         #the -1 lets us get *some* value for all nodes, which we then mask:
         neighbor_diffusivities = np.ma.array(all_nodes_diffusivity[neighbor_nodes], mask=self.bad_neighbor_mask)
         #pylab.figure(1)

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_v3.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_monodirectional_v3.py
@@ -247,7 +247,7 @@ class TransportLimitedEroder(object):
             self.cell_areas = np.empty(grid.number_of_nodes)
             self.cell_areas.fill(np.mean(grid.cell_areas))
             self.cell_areas[grid.node_at_cell] = grid.cell_areas
-        self.bad_neighbor_mask = np.equal(grid.get_neighbor_list(bad_index=-1),-1)
+        self.bad_neighbor_mask = np.equal(grid.get_active_neighbors_at_node(bad_index=-1),-1)
 
         self.routing_code = """
             double sed_flux_into_this_node;

--- a/landlab/components/transport_limited_fluvial/tl_fluvial_polydirectional.py
+++ b/landlab/components/transport_limited_fluvial/tl_fluvial_polydirectional.py
@@ -249,7 +249,7 @@ class TransportLimitedEroder(object):
         self.cell_areas[grid.node_at_cell] = grid.cell_areas
         self.dx2 = grid.dx ** 2
         self.dy2 = grid.dy ** 2
-        self.bad_neighbor_mask = np.equal(grid.get_neighbor_list(bad_index=-1),-1)
+        self.bad_neighbor_mask = np.equal(grid.get_active_neighbors_at_node(bad_index=-1),-1)
 
     def erode(self, grid, dt, node_drainage_areas='drainage_area',
                 node_elevs='topographic__elevation',
@@ -340,7 +340,7 @@ class TransportLimitedEroder(object):
 
         all_nodes_diffusivity = self.diffusivity_prefactor*node_A**self.diffusivity_power_on_A
         #########ALT
-        neighbor_nodes = grid.get_neighbor_list(bad_index=-1)
+        neighbor_nodes = grid.get_active_neighbors_at_node(bad_index=-1)
         #the -1 lets us get *some* value for all nodes, which we then mask:
         neighbor_diffusivities = np.ma.array(all_nodes_diffusivity[neighbor_nodes], mask=self.bad_neighbor_mask)
         #pylab.figure(1)

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -560,6 +560,24 @@ class ModelGrid(ModelDataFields):
         self.update_links_nodes_cells_to_new_BCs()
 
     @property
+    def neighbors_at_node(self):
+        """Get neighboring nodes.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
+        >>> grid = RasterModelGrid((4, 3))
+        >>> neighbors = grid.neighbors_at_node
+        >>> neighbors[neighbors == BAD_INDEX_VALUE] = -1
+        >>> neighbors # doctest: +NORMALIZE_WHITESPACE
+        array([[ 1,  3, -1, -1], [ 2,  4,  0, -1], [-1,  5,  1, -1],
+               [ 4,  6, -1,  0], [ 5,  7,  3,  1], [-1,  8,  4,  2],
+               [ 7,  9, -1,  3], [ 8, 10,  6,  4], [-1, 11,  7,  5],
+               [10, -1, -1,  6], [11, -1,  9,  7], [-1, -1, 10,  8]])
+        """
+        return self._neighbors_at_node
+
+    @property
     def node_at_cell(self):
         """Node ID associated with grid cells.
         

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -560,6 +560,7 @@ class ModelGrid(ModelDataFields):
         self.update_links_nodes_cells_to_new_BCs()
 
     @property
+    @make_return_array_immutable
     def neighbors_at_node(self):
         """Get neighboring nodes.
 
@@ -567,7 +568,7 @@ class ModelGrid(ModelDataFields):
         --------
         >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
         >>> grid = RasterModelGrid((4, 3))
-        >>> neighbors = grid.neighbors_at_node
+        >>> neighbors = grid.neighbors_at_node.copy()
         >>> neighbors[neighbors == BAD_INDEX_VALUE] = -1
         >>> neighbors # doctest: +NORMALIZE_WHITESPACE
         array([[ 1,  3, -1, -1], [ 2,  4,  0, -1], [-1,  5,  1, -1],

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -572,6 +572,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self.active_cells = sgrid.active_cell_index(self.shape)
         self._core_cells = sgrid.core_cell_index(self.shape)
 
+        self._neighbors_at_node = sgrid.neighbor_node_ids(self.shape).T
+
         # Link lists:
         # For all links, we encode the "from" and "to" nodes, and the face
         # (if any) associated with the link. If the link does not intersect a

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -573,7 +573,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self.active_cells = sgrid.active_cell_index(self.shape)
         self._core_cells = sgrid.core_cell_index(self.shape)
 
-        self._neighbors_at_node = sgrid.neighbor_node_ids(self.shape).transpose()
+        self._neighbors_at_node = (
+            sgrid.neighbor_node_ids(self.shape).transpose().copy())
         self._diagonals_at_node = sgrid.diagonal_node_array(self.shape,
                                                             contiguous=True)
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -18,6 +18,7 @@ from .base import (CORE_NODE, FIXED_VALUE_BOUNDARY,
                    CLOSED_BOUNDARY, BAD_INDEX_VALUE, FIXED_LINK,
                    ACTIVE_LINK, INACTIVE_LINK)
 from landlab.field.scalar_data_fields import FieldError
+from landlab.utils.decorators import make_return_array_immutable
 from . import raster_funcs as rfuncs
 from ..io import write_esri_ascii
 from ..io.netcdf import write_netcdf
@@ -753,6 +754,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         return self._dy
 
     @property
+    @make_return_array_immutable
     def diagonals_at_node(self):
         """Get diagonally neighboring nodes.
 
@@ -760,7 +762,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         --------
         >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
         >>> grid = RasterModelGrid((4, 3))
-        >>> diagonals = grid.diagonals_at_node
+        >>> diagonals = grid.diagonals_at_node.copy()
         >>> diagonals[diagonals == BAD_INDEX_VALUE] = -1
         >>> diagonals # doctest: +NORMALIZE_WHITESPACE
         array([[ 4, -1, -1, -1], [ 5,  3, -1, -1], [-1,  4, -1, -1],

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -572,7 +572,9 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         self.active_cells = sgrid.active_cell_index(self.shape)
         self._core_cells = sgrid.core_cell_index(self.shape)
 
-        self._neighbors_at_node = sgrid.neighbor_node_ids(self.shape).T
+        self._neighbors_at_node = sgrid.neighbor_node_ids(self.shape).transpose()
+        self._diagonals_at_node = sgrid.diagonal_node_array(self.shape,
+                                                            contiguous=True)
 
         # Link lists:
         # For all links, we encode the "from" and "to" nodes, and the face
@@ -749,6 +751,24 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         2.0
         """
         return self._dy
+
+    @property
+    def diagonals_at_node(self):
+        """Get diagonally neighboring nodes.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
+        >>> grid = RasterModelGrid((4, 3))
+        >>> diagonals = grid.diagonals_at_node
+        >>> diagonals[diagonals == BAD_INDEX_VALUE] = -1
+        >>> diagonals # doctest: +NORMALIZE_WHITESPACE
+        array([[ 4, -1, -1, -1], [ 5,  3, -1, -1], [-1,  4, -1, -1],
+               [ 7, -1, -1,  1], [ 8,  6,  0,  2], [-1,  7,  1, -1],
+               [10, -1, -1,  4], [11,  9,  3,  5], [-1, 10,  4, -1],
+               [-1, -1, -1,  7], [-1, -1,  6,  8], [-1, -1,  7, -1]])
+        """
+        return self._diagonals_at_node
 
     def node_links(self, *args):
         """node_links([node_ids])

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -53,7 +53,7 @@ def node_has_boundary_neighbor(mg, id, method='d8'):
     boolean
         ``True`` if node has a neighbor on the boundary, ``False`` otherwise.
     """
-    for neighbor in mg.get_neighbor_list(id):
+    for neighbor in mg.get_active_neighbors_at_node(id):
         try:
             if mg.status_at_node[neighbor] != CORE_NODE:
                 return True
@@ -629,7 +629,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                                             actives=self.active_link_ids)
 
         # List of neighbors for each cell: we will start off with no
-        # list. If a caller requests it via get_neighbor_list or
+        # list. If a caller requests it via get_active_neighbors_at_node or
         # create_neighbor_list, we'll create it if necessary.
         self._neighbor_node_dict = {}
 
@@ -2080,7 +2080,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # return a null index ->  Now returns -1.
 
         # We have poor functionality if these are closed boundary nodes!
-        neighbor_nodes = self.get_neighbor_list(node_id)
+        neighbor_nodes = self.get_active_neighbors_at_node(node_id)
         neighbor_nodes.sort()
         diagonal_nodes = []
         # NG also think that this won't happen if you are always sending this
@@ -2194,7 +2194,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # return a null index ->  Now returns -1.
 
         # We have poor functionality if these are closed boundary nodes!
-        neighbor_nodes = self.get_neighbor_list(node_id)
+        neighbor_nodes = self.get_active_neighbors_at_node(node_id)
         neighbor_nodes.sort()
         slopes = []
         for a in neighbor_nodes:
@@ -2958,7 +2958,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         #...per fancy indexing
         # Assemble a node index array which corresponds to this gradients array
         # from which to draw the dstr IDs:
-        neighbors_ENWS = (self.get_neighbor_list()).T
+        neighbors_ENWS = (self.get_active_neighbors_at_node()).T
         dstr_id_source_array = np.vstack(
             (neighbors_ENWS[1][:], neighbors_ENWS[0][:],
              neighbors_ENWS[3][:], neighbors_ENWS[2][:], diagonal_nodes))
@@ -3210,8 +3210,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             data[ncols * i + offset:ncols *
                  (i + 1) - offset] = top_rows_to_move[i, :]
 
-    def get_neighbor_list(self, *args, **kwds):
-        """get_neighbor_list([ids], bad_index=BAD_INDEX_VALUE)
+    def get_active_neighbors_at_node(self, *args, **kwds):
+        """get_active_neighbors_at_node([ids], bad_index=BAD_INDEX_VALUE)
         Get list of neighbor node IDs.
 
         Return lists of neighbor nodes for nodes with given *ids*. If *ids*
@@ -3230,14 +3230,14 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> from landlab.grid.base import BAD_INDEX_VALUE as X
         >>> from landlab import RasterModelGrid
         >>> rmg = RasterModelGrid(4, 5)
-        >>> np.array_equal(rmg.get_neighbor_list([-1, 6, 2]),
+        >>> np.array_equal(rmg.get_active_neighbors_at_node([-1, 6, 2]),
         ...     [[X, X, X, X], [ 7, 11,  5,  1], [X,  7,  X, X]])
         True
-        >>> rmg.get_neighbor_list(7)
+        >>> rmg.get_active_neighbors_at_node(7)
         array([ 8, 12,  6,  2])
-        >>> rmg.get_neighbor_list(2, bad_index=-1)
+        >>> rmg.get_active_neighbors_at_node(2, bad_index=-1)
         array([-1,  7, -1, -1])
-        >>> np.array_equal(rmg.get_neighbor_list(2), [X, 7, X, X])
+        >>> np.array_equal(rmg.get_active_neighbors_at_node(2), [X, 7, X, X])
         True
 
         ..todo: could use inlink_matrix, outlink_matrix
@@ -3690,7 +3690,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # to calculate both
 
         # get the list of neighboring nodes for the nodes given by id
-        n = self.get_neighbor_list(id)
+        n = self.get_active_neighbors_at_node(id)
         a = []
 
         # for each node in id make a list with the node id and the ids of
@@ -3745,7 +3745,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # to calculate both
 
         # get the list of neighboring nodes for the nodes given by id
-        n = self.get_neighbor_list(id)
+        n = self.get_active_neighbors_at_node(id)
         s = []
 
         # for each node in id make a list with the node id and the ids of
@@ -3813,7 +3813,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         neighbors = np.zeros([ids.shape[0], 4], dtype=int)
         diagonals = np.zeros([ids.shape[0], 4], dtype=int)
         # [right, top, left, bottom]
-        neighbors[:, ] = self.get_neighbor_list(ids)
+        neighbors[:, ] = self.get_active_neighbors_at_node(ids)
         #[topright, topleft, bottomleft, bottomright]
         diagonals[:, ] = self.get_diagonal_list(ids)
 
@@ -3877,7 +3877,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # to calculate both
 
         # get the list of neighboring nodes for the nodes given by id
-        node_neighbors = self.get_neighbor_list(nodes)
+        node_neighbors = self.get_active_neighbors_at_node(nodes)
         aspects = []
         slopes = []
 

--- a/landlab/grid/raster_aspect.py
+++ b/landlab/grid/raster_aspect.py
@@ -234,7 +234,7 @@ def calculate_slope_aspect_at_nodes_horn(grid, ids=None,
             raise IndexError('*vals* was not of a compatible length!')
 
     # [right, top, left, bottom]
-    neighbors = grid.get_neighbor_list(ids)
+    neighbors = grid.get_active_neighbors_at_node(ids)
     # [topright, topleft, bottomleft, bottomright]
     diagonals = grid.get_diagonal_list(ids)
 

--- a/landlab/grid/raster_funcs.py
+++ b/landlab/grid/raster_funcs.py
@@ -81,7 +81,7 @@ def node_id_of_cell_neighbor(grid, inds, *args):
     """
     cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
     node_ids = grid.node_at_cell[cell_ids]
-    neighbors = grid.get_neighbor_list(node_ids)
+    neighbors = grid.get_active_neighbors_at_node(node_ids)
 
     if not isinstance(inds, np.ndarray):
         inds = np.array(inds)

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -187,7 +187,7 @@ def calculate_gradient_across_cell_faces(grid, node_values, *args, **kwds):
     cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
     node_ids = grid.node_at_cell[cell_ids]
 
-    neighbors = grid.get_neighbor_list(node_ids)
+    neighbors = grid.get_active_neighbors_at_node(node_ids)
     if BAD_INDEX_VALUE != -1:
         neighbors = np.where(neighbors == BAD_INDEX_VALUE, -1, neighbors)
     values_at_neighbors = padded_node_values[neighbors]
@@ -359,7 +359,7 @@ def calculate_gradient_along_node_links(grid, node_values, *args, **kwds):
     padded_node_values[:-1] = node_values
     node_ids = make_optional_arg_into_id_array(grid.number_of_nodes, *args)
 
-    neighbors = grid.get_neighbor_list(node_ids, bad_index=-1)
+    neighbors = grid.get_active_neighbors_at_node(node_ids, bad_index=-1)
     values_at_neighbors = padded_node_values[neighbors]
     masked_neighbor_values = np.ma.array(
         values_at_neighbors, mask=values_at_neighbors == BAD_INDEX_VALUE)

--- a/landlab/grid/raster_steepest_descent.py
+++ b/landlab/grid/raster_steepest_descent.py
@@ -340,7 +340,7 @@ def calculate_steepest_descent_across_cell_faces(grid, node_values, *args,
 
     if return_node:
         ind = np.argmin(grads, axis=1)
-        node_ids = grid.get_neighbor_list()[grid.node_at_cell[cell_ids], ind]
+        node_ids = grid.get_active_neighbors_at_node()[grid.node_at_cell[cell_ids], ind]
         # node_ids = grid.neighbor_nodes[grid.node_at_cell[cell_ids], ind]
         if 'out' not in kwds:
             out = np.empty(len(cell_ids), dtype=grads.dtype)

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -106,14 +106,14 @@ def test_nodes_around_point():
 
 @with_setup(setup_grid)
 def test_neighbor_list_with_scalar_arg():
-    assert_array_equal(rmg.get_neighbor_list(6), np.array([7, 11, 5, 1]))
-    assert_array_equal(rmg.get_neighbor_list(-1), np.array([X, X, X, X]))
-    assert_array_equal(rmg.get_neighbor_list(-2), np.array([X, X, X, 13]))
+    assert_array_equal(rmg.get_active_neighbors_at_node(6), np.array([7, 11, 5, 1]))
+    assert_array_equal(rmg.get_active_neighbors_at_node(-1), np.array([X, X, X, X]))
+    assert_array_equal(rmg.get_active_neighbors_at_node(-2), np.array([X, X, X, 13]))
 
 
 @with_setup(setup_grid)
 def test_neighbor_list_with_array_arg():
-    assert_array_equal(rmg.get_neighbor_list([6, -1]),
+    assert_array_equal(rmg.get_active_neighbors_at_node([6, -1]),
                        np.array([[7, 11, 5, 1], [X, X, X, X]]))
 
 
@@ -129,7 +129,7 @@ def test_neighbor_list_with_no_args():
         [X,  X,  X,  X], [X,  X,  X, 11], [X,  X,  X, 12], [X,  X,  X, 13],
         [X,  X,  X,  X]])
 
-    assert_array_equal(rmg.get_neighbor_list(), expected)
+    assert_array_equal(rmg.get_active_neighbors_at_node(), expected)
 
 
 @with_setup(setup_grid)

--- a/landlab/grid/tests/test_raster_grid/test_neighbor_nodes.py
+++ b/landlab/grid/tests/test_raster_grid/test_neighbor_nodes.py
@@ -3,12 +3,11 @@ from numpy.testing import assert_array_equal
 from nose.tools import with_setup
 
 from landlab import RasterModelGrid
-from landlab.grid.base import BAD_INDEX_VALUE
+from landlab.grid.base import BAD_INDEX_VALUE as X
 
 
-def test_all_neighbors():
+def test_all_active_neighbors():
     rmg = RasterModelGrid(5, 4)
-    X = BAD_INDEX_VALUE
     expected = np.array([
         [X, X, X, X], [X, 5, X, X], [X, 6, X, X], [X, X, X, X],
         [5, X, X, X], [6, 9, 4, 1], [7, 10, 5, 2], [X, X, 6, X],
@@ -16,34 +15,58 @@ def test_all_neighbors():
         [13, X, X, X], [14, 17, 12, 9], [15, 18, 13, 10], [X, X, 14, X],
         [X, X, X, X], [X, X, X, 13], [X, X, X, 14], [X, X, X, X],
     ])
-    assert_array_equal(rmg.get_neighbor_list(), expected)
+    assert_array_equal(rmg.get_active_neighbors_at_node(), expected)
+
+
+def test_all_neighbors():
+    rmg = RasterModelGrid((5, 4))
+    expected = np.array([
+        [ 1,  4, X,  X], [ 2,  5,  0,  X], [ 3,  6,  1,  X], [X,  7,  2,  X],
+        [ 5,  8, X,  0], [ 6,  9,  4,  1], [ 7, 10,  5,  2], [X, 11,  6,  3],
+        [ 9, 12, X,  4], [10, 13,  8,  5], [11, 14,  9,  6], [X, 15, 10,  7],
+        [13, 16, X,  8], [14, 17, 12,  9], [15, 18, 13, 10], [X, 19, 14, 11],
+        [17,  X, X, 12], [18,  X, 16, 13], [19,  X, 17, 14], [X,  X, 18, 15],
+    ])
+    assert_array_equal(rmg.neighbors_at_node, expected)
+
+
+def test_active_neighbor_list_with_scalar_arg():
+    rmg = RasterModelGrid(5, 4)
+
+    assert_array_equal(rmg.get_active_neighbors_at_node(6),
+                       np.array([7, 10, 5, 2]))
+    assert_array_equal(rmg.get_active_neighbors_at_node(-1),
+                       np.array([X, X, X, X]))
+    assert_array_equal(rmg.get_active_neighbors_at_node(-2),
+                       np.array([X, X, X, 14]))
 
 
 def test_neighbor_list_with_scalar_arg():
-    X = BAD_INDEX_VALUE
+    rmg = RasterModelGrid((5, 4))
+
+    assert_array_equal(rmg.neighbors_at_node[6], np.array([7, 10, 5, 2]))
+    assert_array_equal(rmg.neighbors_at_node[-1], np.array([X, X, 18, 15]))
+    assert_array_equal(rmg.neighbors_at_node[-2], np.array([19, X, 17, 14]))
+
+
+def test_active_neighbor_list_with_array_arg():
     rmg = RasterModelGrid(5, 4)
-
-    assert_array_equal(rmg.get_neighbor_list(6), np.array([7, 10, 5, 2]))
-    assert_array_equal(rmg.get_neighbor_list(-1), np.array([X, X, X, X]))
-    assert_array_equal(rmg.get_neighbor_list(-2), np.array([X, X, X, 14]))
-
-
-def test_neighbor_list_with_array_arg():
-    X = BAD_INDEX_VALUE
-    rmg = RasterModelGrid(5, 4)
-    assert_array_equal(rmg.get_neighbor_list([6, -1]),
+    assert_array_equal(rmg.get_active_neighbors_at_node([6, -1]),
                        np.array([[7, 10, 5, 2], [X, X, X, X]]))
 
 
+def test_neighbor_list_with_array_arg():
+    rmg = RasterModelGrid(5, 4)
+    assert_array_equal(rmg.neighbors_at_node[(6, -1), :],
+                       np.array([[7, 10, 5, 2], [X, X, 18, 15]]))
+
+
 def test_neighbor_list_boundary():
-    """
-    All of the neighbor IDs for a boundary cell are -1.
-    """
-    X = BAD_INDEX_VALUE
+    """All of the neighbor IDs for a boundary cell are -1."""
     rmg = RasterModelGrid(5, 4)
     import landlab.utils.structured_grid as sgrid
     rmg.set_closed_nodes([0, 1, 2, 3, 4, 7, 8, 11, 12, 15, 16, 17, 18, 19])
 
     for node_id in sgrid.boundary_iter(rmg.shape):
-        assert_array_equal(rmg.get_neighbor_list(node_id),
+        assert_array_equal(rmg.get_active_neighbors_at_node(node_id),
                            np.array([X, X, X, X]))

--- a/landlab/utils/fault_facet_finder.py
+++ b/landlab/utils/fault_facet_finder.py
@@ -238,8 +238,9 @@ class find_facets(object):
             patch_size = 1
             mean_slope = self.slopes[nodes_in_patch]
             while 1:
-                possible_neighbors = np.union1d(self.grid.get_neighbor_list(
-                    nodes_in_patch).flat, self.possible_core_nodes)
+                possible_neighbors = np.union1d(
+                    self.grid.get_active_neighbors_at_node(
+                        nodes_in_patch).flat, self.possible_core_nodes)
                 neighbor_slopes = self.slopes[possible_neighbors]
                 low_tol_condition = np.greater(
                     neighbor_slopes, mean_slope - tolerance)


### PR DESCRIPTION
The pull request adds a new property for getting node neighbors and renames an existing method that gets *active* neighbors.

A *neighbor* is the node on the other end of a link. An *active neighbor* is the node on the other end of an *active* link.

Added `ModelGrid.neighbors_at_node` attribute. Note that, thus far, this is only implemented for a `RasterModelGrid`. Other grids need to define their own `_neighbors_at_node` array. Until that's done, for those grids, using `neighbors_at_node` will raise an `AttributeError`.

Renamed `get_neighbor_list` method to `get_active_neighbor_at_node`.
