### PR TITLE
Fix the landlab testing script

### DIFF
--- a/landlab/testing/nosetester.py
+++ b/landlab/testing/nosetester.py
@@ -2,7 +2,10 @@ from __future__ import print_function
 
 import os
 import sys
+import doctest
 from numpy.testing import Tester
+from nose.plugins import doctests
+from nose.plugins.base import Plugin
 
 
 def show_system_info():
@@ -15,6 +18,21 @@ def show_system_info():
 
     print('Python version %s' % sys.version.replace('\n', ''))
     print('nose version %d.%d.%d' % nose.__versioninfo__)
+
+
+class LandlabDoctest(doctests.Doctest):
+    name = 'landlabdoctest'
+    score = 1000
+    doctest_ignore = ('setup.py', )
+
+    def options(self, parser, env=os.environ):
+        Plugin.options(self, parser, env)
+        self.doctest_tests = True
+        self._doctest_result_var = None
+
+    def configure(self, options, config):
+        options.doctestOptions = ["+ELLIPSIS", "+NORMALIZE_WHITESPACE"]
+        super(LandlabDoctest, self).configure(options, config)
 
 
 class LandlabTester(Tester):
@@ -47,6 +65,8 @@ class LandlabTester(Tester):
         # Set to "release" in constructor in maintenance branches.
         self.raise_warnings = raise_warnings
 
+    def _get_custom_doctester(self):
+        return LandlabDoctest()
 
     def test(self, **kwds):
         kwds.setdefault('verbose', 2)

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -41,8 +41,9 @@ def deprecated(func):
     """
     @wraps(func)
     def _wrapped(*args, **kwargs):
-        warnings.warn("Call to deprecated function {}.".format(func.__name__),
-                      category=DeprecationWarning)
+        warnings.warn(
+            "Call to deprecated function {name}.".format(name=func.__name__),
+            category=DeprecationWarning)
         return func(*args, **kwargs)
     _wrapped.__dict__.update(func.__dict__)
 

--- a/scripts/test-installed-landlab.py
+++ b/scripts/test-installed-landlab.py
@@ -26,7 +26,7 @@ import landlab
 
 result = landlab.test(label=options.mode, verbose=options.verbose,
                       doctests=options.doctests, coverage=options.coverage,
-                      extra_argv=args)
+                      extra_argv=args, raise_warnings='release')
 
 if result.wasSuccessful():
     sys.exit(0)


### PR DESCRIPTION
This pull request fixes the `test-installed-landlab.py` script. Doctests for functions that were decorated with a decorator defined in another module were not being run. This is fixed by creating a custom `LandlabDoctest` plugin for finding and running doctests.

Other changes:
* `+NORMALIZE_WHITESPACE` is now the default
* Warnings (including `DeprecationWarning`) are not turned into errors