### PR TITLE
Gt handle flooded nodes in stream power

### DIFF
--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -747,6 +747,13 @@ class DepressionFinderAndRouter(Component):
         Nodes not in a lake are labelled with BAD_INDEX_VALUE.
         """
         return self._lake_map
+    
+    @property
+    def lake_at_node(self):
+        """
+        Return a boolean array, True if the node is flooded, False otherwise.
+        """
+        return self._lake_map!=BAD_INDEX_VALUE
 
     @property
     def lake_areas(self):

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -148,7 +148,10 @@ class FastscapeEroder(object):
         K_if_used : string (field name) or ndarray of float x N (optional)
             Array containing value of erosion coefficient at each node
         flooded_nodes : ndarray of int (optional)
-            IDs of nodes that are flooded and should have no erosion
+            IDs of nodes that are flooded and should have no erosion. If not
+            provided but flow has still been routed across depressions, erosion
+            may still occur beneath the apparent water level (though will
+            always still be positive).
         """
         if dt:
             self.dt = dt
@@ -187,7 +190,11 @@ class FastscapeEroder(object):
 
         # Handle flooded nodes, if any (no erosion there)
         if flooded_nodes is not None:
-            alpha[flooded_nodes] = 0.0
+            alpha[flooded_nodes] = 0.
+        else:
+            reversed_flow = z < z[flow_receivers]
+            # this check necessary if flow has been routed across depressions
+            alpha[reversed_flow] = 0.
             
         method = 'cython'
 

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -189,22 +189,7 @@ class FastscapeEroder(object):
         if flooded_nodes is not None:
             alpha[flooded_nodes] = 0.0
             
-        # DEBUG
-        for i in upstream_order_IDs:
-            j = flow_receivers[i]
-            if i != j:
-                frog = (z[i] + alpha[i]*z[j])/(1.0+alpha[i])
-                if frog > z[i]:
-                    print('*')
-                    print(i)
-                    print(z[i])
-                    print(temp[i])
-                    print(j)
-                    print(z[j])
-                    print(alpha[i])
-                    print(frog)
-
-        method = 'not_cython'
+        method = 'cython'
 
         if self.nonlinear_flag == False: #n==1
             if method == 'cython':

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -1,9 +1,11 @@
+# -*- coding: utf-8 -*-
 from __future__ import print_function
 
 import numpy as np
 from landlab import ModelParameterDictionary, CLOSED_BOUNDARY
 
-from landlab.core.model_parameter_dictionary import MissingKeyError, ParameterValueError
+from landlab.core.model_parameter_dictionary import MissingKeyError, \
+    ParameterValueError
 from landlab.field.scalar_data_fields import FieldError
 from landlab.grid.base import BAD_INDEX_VALUE
 
@@ -23,14 +25,9 @@ class StreamPowerEroder(object):
 
     def __init__(self, grid, params):
         self.initialize(grid, params)
-
-#This draws attention to a potential problem. It will be easy to have modules update z, but because noone "owns" the data, to forget to also update dz/dx...
-#How about a built in grid utility that updates "derived" data (i.e., using only grid fns, e.g., slope, curvature) at the end of any given tstep loop?
-#Or an explicit flagging system for all variables in the modelfield indicating if they have been updated this timestep. (Currently implemented)
-#Or wipe the existance of any derived grid data at the end of a timestep entirely, so modules find they don't have it next timestep.
-
+        
     def initialize(self, grid, params_file):
-        '''
+        r"""
         params_file is the name of the text file containing the parameters
         needed for this stream power component.
 
@@ -83,8 +80,9 @@ class StreamPowerEroder(object):
             use_Q -> Bool. If true, the equation becomes E=K*Q**m*S**n.
                 Effectively sets c=1 in Wh&T's 1999 derivation, if you are
                 setting m and n through a, b, and c.
-
-        '''
+        """
+        
+        
         self.grid = grid
         self.fraction_gradient_change = 1.
         self.link_S_with_trailing_blank = np.zeros(grid.number_of_links+1) #needs to be filled with values in execution
@@ -92,7 +90,8 @@ class StreamPowerEroder(object):
         self.count_active_links[:-1] = 1
         inputs = ModelParameterDictionary(params_file)
         try:
-            self._K_unit_time = inputs.read_float('K_sp')
+            self._K_unit_time = np.full((grid.status_at_node!=4).sum(),
+                                        inputs.read_float('K_sp'))
         except ParameterValueError: #it was a string
             self.use_K = True
         else:
@@ -168,7 +167,8 @@ class StreamPowerEroder(object):
             slopes_at_nodes='topographic__steepest_slope',
             link_node_mapping='links_to_flow_receiver',
             link_slopes=None, slopes_from_elevs=None,
-            W_if_used=None, Q_if_used=None, K_if_used=None):
+            W_if_used=None, Q_if_used=None, K_if_used=None,
+            flooded_nodes=None):
         """
         A simple, explicit implementation of a stream power algorithm.
 
@@ -220,6 +220,12 @@ class StreamPowerEroder(object):
         *W_if_used* and *Q_if_used* must be provided if you set use_W and use_Q
         respectively in the component initialization. They can be either field
         names or nnodes arrays as in the other cases.
+        
+        If you are routing across flooded depressions in your flow routing
+        scheme, be sure to set *flooded_nodes* with a boolean array or array
+        of IDs to ensure erosion cannot occur in the lake. Erosion
+        is always zero if the gradient is adverse, but can still procede as
+        usual on the entry into the depression unless *flooded_nodes* is set.
 
         NB: If you want spatially or temporally variable runoff, pass the
         runoff values at each pixel to the flow router, then pass discharges
@@ -295,6 +301,10 @@ class StreamPowerEroder(object):
 
         if type(node_order_upstream)==str:
             node_order_upstream = grid.at_node[node_order_upstream]
+            
+        # Disable incision in flooded nodes, as appropriate
+        if flooded_nodes is not None:
+            self._K_unit_time[flooded_nodes[active_nodes]] = 0.
 
         #Operate the main function:
         if self.use_W==False and self.use_Q==False: #normal case
@@ -344,9 +354,9 @@ class StreamPowerEroder(object):
                 elev_dstr_node_after = elev_dstr[i] - erosion_increment[flow_receiver[i]]
                 if elev_this_node_after<elev_dstr_node_after:
                     erosion_increment[i] = (elev_this_node_before - elev_dstr_node_after)*0.999999 #we add a tiny elevation excess to prevent the module from ever totally severing its own flow paths
-
-        node_z -= erosion_increment
-
+        # clip the erosion increments one more time to remove regatives
+        # introduced by any pit filling algorithms or the above procedure:
+        node_z -= erosion_increment.clip(0.)
 
         self.grid = grid
 


### PR DESCRIPTION
Modified FastscapeStreamPower's erode method to optionally take a list of flooded nodes, and set their alpha values to zero, which forces them to have no erosion (which would actually be reverse erosion where the receiver node is higher than the donor)