### PR TITLE
Fix AppVeyor Deployment to PyPI

### DIFF
--- a/.ci/appveyor/deploy_to_pypi.ps1
+++ b/.ci/appveyor/deploy_to_pypi.ps1
@@ -1,4 +1,4 @@
-if (($env:appveyor_repo_tag -eq "true") -and ($env:appveyor_repo_tag_name.StartsWith("v")) -and ($env:appveyor_repo_branch -eq "release")) {
+if (($env:appveyor_repo_tag -eq "true") -and ($env:appveyor_repo_tag_name.StartsWith("v"))) {
     write-output "Deploying to PyPI..."
     Invoke-Expression "twine upload -u mcflugen -p $env:PYPI_PASS dist/*"
     write-output "OK"


### PR DESCRIPTION
Fixed an issue that caused wheels not to be built and deployed when a tag was created based on the release branch.

As before, a wheel will be created and deployed to PyPI if a tag is created that starts with "v" (regardless of the branch the tag was created on).
