### PR TITLE
Add func to strip grid from docstring if func is imported to grid

### DIFF
--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -250,12 +250,69 @@ def add_module_functions_to_class(cls, module, pattern=None):
     mod = imp.load_module(module, *imp.find_module(module, [path]))
 
     funcs = get_functions_from_module(mod, pattern=pattern)
+    strip_grid_from_method_docstring(funcs)
     add_functions_to_class(cls, funcs)
+
+
+def strip_grid_from_method_docstring(funcs):
+    """Remove 'grid' from the parameters of a dict of functions' docstrings.
+
+    Note that the docstring must be close to numpydoc standards for this to
+    work.
+
+    Parameters
+    ----------
+    funcs : dict
+        Dictionary of functions to modify. Keys are the function names,
+        values are the functions themselves.
+
+    Examples
+    --------
+    >>> from landlab.grid.mappers import dummy_func_to_demonstrate_docstring_modification as dummy_func
+    >>> funcs = {'dummy_func_to_demonstrate_docstring_modification':
+    ...          dummy_func}
+    >>> help(dummy_func)
+    Help on function dummy_func_to_demonstrate_docstring_modification in module landlab.grid.mappers:
+    <BLANKLINE>
+    dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
+        A dummy function to demonstrate automated docstring changes.
+    <BLANKLINE>
+        Parameters
+        ----------
+        grid : ModelGrid
+            A Landlab modelgrid.
+        some_arg : whatever
+            A dummy argument.
+    <BLANKLINE>
+        Examples
+        --------
+        ...
+    <BLANKLINE>
+    >>> strip_grid_from_method_docstring(funcs)
+    >>> help(dummy_func)
+    Help on function dummy_func_to_demonstrate_docstring_modification in module landlab.grid.mappers:
+    <BLANKLINE>
+    dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
+        A dummy function to demonstrate automated docstring changes.
+    <BLANKLINE>
+        Parameters
+        ----------
+        some_arg : whatever
+            A dummy argument.
+    <BLANKLINE>
+        Examples
+        --------
+        ...
+    <BLANKLINE>
+    """
+    import re
+    for name, func in funcs.items():
+        func.__doc__ = re.sub('grid *:.*?\n.*?\n *', '', func.__doc__)
 
 
 def argsort_points_by_x_then_y(pts):
     """Sort points by coordinates, first x then y, returning sorted indices.
-    
+
     Parameters
     ----------
     pts : Nx2 NumPy array of float

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -318,18 +318,19 @@ def strip_grid_from_method_docstring(funcs):
         # strip the entry under "Parameters":
         func.__doc__ = re.sub('grid *:.*?\n.*?\n *', '', func.__doc__)
         # # cosmetic magic to get a two-line signature to line up right:
-        # # ...for some reason this breaks doctests, so as it's not key,
-        # # leave it out for now
-        # match_2_lines = re.search(func.__name__+'\(grid,[^\)]*?\n.*?\)',
-        #                           func.__doc__)
-        # try:
-        #     lines_were = match_2_lines.group()
-        # except AttributeError:  # no successful match
-        #     pass
-        # else:
-        #     end_chars = re.search('    .*?\)', lines_were).group()[4:]
-        #     func.__doc__ = re.sub('    .*?\)', '         '+end_chars,
-        #                           func.__doc__)
+        match_2_lines = re.search(func.__name__+'\(grid,[^\)]*?\n.*?\)',
+                                  func.__doc__)
+        try:
+            lines_were = match_2_lines.group()
+        except AttributeError:  # no successful match
+            pass
+        else:
+            end_chars = re.search('    .*?\)', lines_were).group()[4:]
+            lines_are_now = re.sub('    .*?\)', '         '+end_chars,
+                                   lines_were)
+            func.__doc__ = (func.__doc__[:match_2_lines.start()] +
+                            lines_are_now +
+                            func.__doc__[match_2_lines.end():])
         # Move "grid" in signature from an arg to the class position
         func.__doc__ = re.sub(func.__name__+'\(grid, ',
                               'grid.'+func.__name__+'(',

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -277,6 +277,10 @@ def strip_grid_from_method_docstring(funcs):
     dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
         A dummy function to demonstrate automated docstring changes.
     <BLANKLINE>
+        Construction::
+    <BLANKLINE>
+            dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
+    <BLANKLINE>
         Parameters
         ----------
         grid : ModelGrid
@@ -295,6 +299,10 @@ def strip_grid_from_method_docstring(funcs):
     dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
         A dummy function to demonstrate automated docstring changes.
     <BLANKLINE>
+        Construction::
+    <BLANKLINE>
+            grid.dummy_func_to_demonstrate_docstring_modification(some_arg)
+    <BLANKLINE>
         Parameters
         ----------
         some_arg : whatever
@@ -307,7 +315,23 @@ def strip_grid_from_method_docstring(funcs):
     """
     import re
     for name, func in funcs.items():
+        # strip the entry under "Parameters":
         func.__doc__ = re.sub('grid *:.*?\n.*?\n *', '', func.__doc__)
+        # cosmetic magic to get a two-line signature to line up right:
+        match_2_lines = re.search(func.__name__+'\(grid,[^\)]*?\n.*?\)',
+                                  func.__doc__)
+        try:
+            lines_were = match_2_lines.group()
+        except AttributeError:  # no successful match
+            pass
+        else:
+            end_chars = re.search('    .*?\)', lines_were).group()[4:]
+            func.__doc__ = re.sub('    .*?\)', '         '+end_chars,
+                                  func.__doc__)
+        # Move "grid" in signature from an arg to the class position
+        func.__doc__ = re.sub(func.__name__+'\(grid, ',
+                              'grid.'+func.__name__+'(',
+                              func.__doc__)
 
 
 def argsort_points_by_x_then_y(pts):

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -317,17 +317,19 @@ def strip_grid_from_method_docstring(funcs):
     for name, func in funcs.items():
         # strip the entry under "Parameters":
         func.__doc__ = re.sub('grid *:.*?\n.*?\n *', '', func.__doc__)
-        # cosmetic magic to get a two-line signature to line up right:
-        match_2_lines = re.search(func.__name__+'\(grid,[^\)]*?\n.*?\)',
-                                  func.__doc__)
-        try:
-            lines_were = match_2_lines.group()
-        except AttributeError:  # no successful match
-            pass
-        else:
-            end_chars = re.search('    .*?\)', lines_were).group()[4:]
-            func.__doc__ = re.sub('    .*?\)', '         '+end_chars,
-                                  func.__doc__)
+        # # cosmetic magic to get a two-line signature to line up right:
+        # # ...for some reason this breaks doctests, so as it's not key,
+        # # leave it out for now
+        # match_2_lines = re.search(func.__name__+'\(grid,[^\)]*?\n.*?\)',
+        #                           func.__doc__)
+        # try:
+        #     lines_were = match_2_lines.group()
+        # except AttributeError:  # no successful match
+        #     pass
+        # else:
+        #     end_chars = re.search('    .*?\)', lines_were).group()[4:]
+        #     func.__doc__ = re.sub('    .*?\)', '         '+end_chars,
+        #                           func.__doc__)
         # Move "grid" in signature from an arg to the class position
         func.__doc__ = re.sub(func.__name__+'\(grid, ',
                               'grid.'+func.__name__+'(',

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -11,6 +11,10 @@ def calculate_gradients_at_active_links(grid, node_values, out=None):
     Calculates the gradient in *quantity* node values at each active link in
     the grid.
 
+    Construction::
+
+        calculate_gradients_at_active_links(grid, node_values, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -37,6 +41,10 @@ def calculate_gradients_at_links(grid, node_values, out=None):
     """Calculate gradients of node values over links.
 
     Calculates the gradient in *quantity* node_values at each link in the grid.
+
+    Construction::
+
+        calculate_gradients_at_links(grid, node_values, out=None)
 
     Parameters
     ----------
@@ -66,7 +74,11 @@ def calculate_gradients_at_faces(grid, node_values, out=None):
     Calculate and return gradient in *node_values* at each face in the grid.
     Gradients are calculated from the nodes at either end of the link that
     crosses each face.
-    
+
+    Construction::
+
+        calculate_gradients_at_faces(grid, node_values, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -80,7 +92,7 @@ def calculate_gradients_at_faces(grid, node_values, out=None):
     -------
     ndarray (x number of faces)
         Gradients across faces.
-    
+
     Examples
     --------
     >>> from landlab import RasterModelGrid
@@ -113,6 +125,10 @@ def calculate_diff_at_links(grid, node_values, out=None):
 
     Calculates the difference in quantity *node_values* at each link in the
     grid.
+
+    Construction::
+
+        calculate_diff_at_links(grid, node_values, out=None)
 
     Parameters
     ----------
@@ -151,6 +167,10 @@ def calculate_diff_at_active_links(grid, node_values, out=None):
 
     Calculates the difference in quantity *node_values* at each active link
     in the grid.
+
+    Construction::
+
+        calculate_diff_at_active_links(grid, node_values, out=None)
 
     Parameters
     ----------

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -44,6 +44,10 @@ def map_link_head_node_to_link(grid, var_name, out=None):
     In a RasterModelGrid, each one node has two adjacent "link heads". This
     means each node value is mapped to two corresponding links.
 
+    Construction::
+
+        map_link_head_node_to_link(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -99,6 +103,10 @@ def map_link_tail_node_to_link(grid, var_name, out=None):
     In a RasterModelGrid, each one node has two adjacent "link tails". This
     means each node value is mapped to two corresponding links.
 
+    Construction::
+
+        map_link_tail_node_to_link(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -152,6 +160,10 @@ def map_min_of_link_nodes_to_link(grid, var_name, out=None):
     This function evaluates the value of 'var_name' at both the "to" and
     "from" node. The minimum value of the two node values is then mapped to
     the link.
+
+    Construction::
+
+        map_min_of_link_nodes_to_link(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -210,6 +222,10 @@ def map_max_of_link_nodes_to_link(grid, var_name, out=None):
     "from" node. The maximum value of the two node values is then mapped to
     the link.
 
+    Construction::
+
+        map_max_of_link_nodes_to_link(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -267,6 +283,10 @@ def map_mean_of_link_nodes_to_link(grid, var_name, out=None):
     "to" and "from" node. The average value of the two node values of
     'var_name' is then mapped to the link.
 
+    Construction::
+
+        map_mean_of_link_nodes_to_link(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -323,6 +343,11 @@ def map_value_at_min_node_to_link(grid, control_name, value_name, out=None):
     This function evaluates the value of 'control_name' at both the "to" and
     "from" node. The value of 'value_name' at the node with the minimum value
     of the two values of 'control_name' is then mapped to the link.
+
+    Construction::
+
+        map_value_at_min_node_to_link(grid, control_name, value_name,
+                                      out=None)
 
     Parameters
     ----------
@@ -385,6 +410,11 @@ def map_value_at_max_node_to_link(grid, control_name, value_name, out=None):
     "from" node. The value of 'value_name' at the node with the maximum value
     of the two values of 'control_name' is then mapped to the link.
 
+    Construction::
+
+        map_value_at_max_node_to_link(grid, control_name, value_name,
+                                      out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -444,6 +474,10 @@ def map_node_to_cell(grid, var_name, out=None):
     This function takes node values of 'var_name' and mapes that value to the
     corresponding cell area for each node.
 
+    Construction::
+
+        map_node_to_cell(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -493,6 +527,10 @@ def map_min_of_node_links_to_node(grid, var_name, out=None):
     This function finds the minimum value of 'var_name' of each set
     of links, and then maps this value to the node. Note no attempt is made
     to honor the directionality of the links.
+
+    Construction::
+
+        map_min_of_node_links_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -549,6 +587,10 @@ def map_max_of_node_links_to_node(grid, var_name, out=None):
     This function finds the maximum value of 'var_name' of each set
     of links, and then maps this value to the node. Note no attempt is made
     to honor the directionality of the links.
+
+    Construction::
+
+        map_max_of_node_links_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -608,6 +650,10 @@ def map_upwind_node_link_max_to_node(grid, var_name, out=None):
     node, then maps the maximum magnitude of 'var_name' found on these links
     onto the node. If no upwind link is found, the value will be recorded as
     zero.
+
+    Construction::
+
+        map_upwind_node_link_max_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -673,6 +719,10 @@ def map_downwind_node_link_max_to_node(grid, var_name, out=None):
     onto the node. If no downwind link is found, the value will be recorded as
     zero.
 
+    Construction::
+
+        map_downwind_node_link_max_to_node(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -737,6 +787,10 @@ def map_upwind_node_link_mean_to_node(grid, var_name, out=None):
     node, then maps the mean magnitude of 'var_name' found on these links
     onto the node. Links with zero values are not included in the means,
     and zeros are returned if no upwind links are found.
+
+    Construction::
+
+        map_upwind_node_link_mean_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -806,6 +860,10 @@ def map_downwind_node_link_mean_to_node(grid, var_name, out=None):
     node, then maps the mean magnitude of 'var_name' found on these links
     onto the node. Links with zero values are not included in the means,
     and zeros are returned if no upwind links are found.
+
+    Construction::
+
+        map_downwind_node_link_mean_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -877,6 +935,11 @@ def map_value_at_upwind_node_link_max_to_node(grid, control_name,
     node, then identifies the link with the maximum magnitude. The value of the
     second field 'value_name' at these links is then mapped onto the node.
     If no upwind link is found, the value will be recorded as zero.
+
+    Construction::
+
+        map_value_at_upwind_node_link_max_to_node(grid, control_name,
+                                                  value_name, out=None)
 
     Parameters
     ----------
@@ -954,6 +1017,11 @@ def map_value_at_downwind_node_link_max_to_node(grid, control_name,
     second field 'value_name' at these links is then mapped onto the node.
     If no downwind link is found, the value will be recorded as zero.
 
+    Construction::
+
+        map_value_at_downwind_node_link_max_to_node(grid, control_name,
+                                                    value_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -1018,6 +1086,10 @@ def map_value_at_downwind_node_link_max_to_node(grid, control_name,
 
 def dummy_func_to_demonstrate_docstring_modification(grid, some_arg):
     """A dummy function to demonstrate automated docstring changes.
+
+    Construction::
+
+        dummy_func_to_demonstrate_docstring_modification(grid, some_arg)
 
     Parameters
     ----------

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -1014,3 +1014,20 @@ def map_value_at_downwind_node_link_max_to_node(grid, control_name,
                                         which_link]
 
     return out
+
+
+def dummy_func_to_demonstrate_docstring_modification(grid, some_arg):
+    """A dummy function to demonstrate automated docstring changes.
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        A Landlab modelgrid.
+    some_arg : whatever
+        A dummy argument.
+
+    Examples
+    --------
+    ...
+    """
+    pass

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -12,6 +12,10 @@ from landlab.utils.decorators import use_field_name_or_array
 def calculate_gradients_at_links(grid, node_values, out=None):
     """Calculate gradients over links.
 
+    Construction::
+
+        calculate_gradients_at_links(grid, node_values, out=None)
+
     Parameters
     ----------
     grid : RasterModelGrid
@@ -26,9 +30,6 @@ def calculate_gradients_at_links(grid, node_values, out=None):
     ndarray
         Gradients of the nodes values for each link.
 
-    .. deprecated:: 0.1
-        Use :func:`calculate_gradient_across_cell_faces`
-                or :func:`calculate_gradient_across_cell_corners` instead
     Examples
     --------
     >>> from landlab import RasterModelGrid
@@ -43,7 +44,7 @@ def calculate_gradients_at_links(grid, node_values, out=None):
     >>> rtn = grid.calculate_gradients_at_links(node_values, out=out)
     >>> rtn is out
     True
-    >>> out 
+    >>> out
     array([ 0.,  0.,  1.,  3.,  1.,  2., -2.,  1., -1.,  1.,  0.,  0.])
 
     >>> grid = RasterModelGrid((3, 3), spacing=(1, 2))
@@ -130,8 +131,7 @@ def calculate_gradients_at_active_links(grid, node_values, out=None):
 
 @use_field_name_or_array('node')
 def calculate_gradient_across_cell_faces(grid, node_values, *args, **kwds):
-    """calculate_gradient_across_cell_faces(grid, node_values, [cell_ids], out=None)
-    Get gradients across the faces of a cell.
+    """Get gradients across the faces of a cell.
 
     Calculate gradient of the value field provided by *node_values* across
     each of the faces of the cells of a grid. The returned gradients are
@@ -139,6 +139,11 @@ def calculate_gradient_across_cell_faces(grid, node_values, *args, **kwds):
 
     Note that the returned gradients are masked to exclude neighbor nodes which
     are closed. Beneath the mask is the value numpy.iinfo(numpy.int32).max.
+
+    Construction::
+
+        calculate_gradient_across_cell_faces(grid, node_values, [cell_ids],
+                                             out=None)
 
     Parameters
     ----------
@@ -155,7 +160,7 @@ def calculate_gradient_across_cell_faces(grid, node_values, *args, **kwds):
 
     Returns
     -------
-    (N, 4) ndarray
+    (N, 4) Masked ndarray
         Gradients for each face of the cell.
 
     Examples
@@ -211,12 +216,16 @@ def calculate_gradient_across_cell_faces(grid, node_values, *args, **kwds):
 
 @use_field_name_or_array('node')
 def calculate_gradient_across_cell_corners(grid, node_values, *args, **kwds):
-    """calculate_gradient_across_cell_corners(grid, node_values, [cell_ids], out=None)
-    Get gradients to diagonally opposite nodes.
+    """Get gradients to diagonally opposite nodes.
 
     Calculate gradient of the value field provided by *node_values* to
     the values at diagonally opposite nodes. The returned gradients are
     ordered as upper-right, upper-left, lower-left and lower-right.
+
+    Construction::
+
+        calculate_gradient_across_cell_corners(grid, node_values, [cell_ids],
+                                               out=None)
 
     Parameters
     ----------
@@ -272,8 +281,7 @@ def calculate_gradient_across_cell_corners(grid, node_values, *args, **kwds):
 
 @use_field_name_or_array('node')
 def calculate_gradient_along_node_links(grid, node_values, *args, **kwds):
-    """calculate_gradient_along_node_links(grid, node_values, [cell_ids], out=None)
-    Get gradients along links touching a node.
+    """Get gradients along links touching a node.
 
     Calculate gradient of the value field provided by *node_values* across
     each of the faces of the nodes of a grid. The returned gradients are
@@ -284,6 +292,11 @@ def calculate_gradient_along_node_links(grid, node_values, *args, **kwds):
 
     Note that the returned gradients are masked to exclude neighbor nodes which
     are closed. Beneath the mask is the value numpy.iinfo(numpy.int32).max.
+
+    Construction::
+
+        calculate_gradient_along_node_links(grid, node_values, [cell_ids],
+                                            out=None)
 
     Parameters
     ----------
@@ -300,7 +313,7 @@ def calculate_gradient_along_node_links(grid, node_values, *args, **kwds):
 
     Returns
     -------
-    (N, 4) ndarray
+    (N, 4) Masked ndarray
         Gradients for each link of the node. Ordering is E,N,W,S.
 
     Examples

--- a/landlab/grid/raster_mappers.py
+++ b/landlab/grid/raster_mappers.py
@@ -19,6 +19,10 @@ def map_sum_of_inlinks_to_node(grid, var_name, out=None):
 
         This considers all inactive links to have a value of 0.
 
+    Construction::
+
+        map_sum_of_inlinks_to_node(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -67,6 +71,10 @@ def map_mean_of_inlinks_to_node(grid, var_name, out=None):
     as the link field.
 
     This considers all inactive links to have a value of 0.
+
+    Construction::
+
+        map_mean_of_inlinks_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -117,6 +125,10 @@ def map_max_of_inlinks_to_node(grid, var_name, out=None):
     .. note::
 
         This considers all inactive links to have a value of 0.
+
+    Construction::
+
+        map_max_of_inlinks_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -169,6 +181,10 @@ def map_min_of_inlinks_to_node(grid, var_name, out=None):
 
         This considers all inactive links to have a value of 0.
 
+    Construction::
+
+        map_min_of_inlinks_to_node(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -216,6 +232,10 @@ def map_sum_of_outlinks_to_node(grid, var_name, out=None):
     .. note::
 
         This considers all inactive links to have a value of 0.
+
+    Construction::
+
+        map_sum_of_outlinks_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -267,6 +287,10 @@ def map_mean_of_outlinks_to_node(grid, var_name, out=None):
 
         This considers all inactive links to have a value of 0.
 
+    Construction::
+
+        map_mean_of_outlinks_to_node(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -316,6 +340,10 @@ def map_max_of_outlinks_to_node(grid, var_name, out=None):
     .. note::
 
         This considers all inactive links to have a value of 0.
+
+    Construction::
+
+        map_max_of_outlinks_to_node(grid, var_name, out=None)
 
     Parameters
     ----------
@@ -367,6 +395,10 @@ def map_min_of_outlinks_to_node(grid, var_name, out=None):
 
         This considers all inactive links to have a value of 0.
 
+    Construction::
+
+        map_min_of_outlinks_to_node(grid, var_name, out=None)
+
     Parameters
     ----------
     grid : ModelGrid
@@ -415,6 +447,10 @@ def map_mean_of_links_to_node(grid, var_name, out=None):
     .. note::
 
         This considers all inactive links to have a value of 0.
+
+    Construction::
+
+        map_mean_of_links_to_node(grid, var_name, out=None)
 
     Parameters
     ----------


### PR DESCRIPTION
Resolve documentation booboo where funcs that get automatically imported from mappers.py and gradients.py into the grid retain “grid” as the first entry in their Parameters in the docstrings.