### PR TITLE
SiccarPoint/enhance mappers

### DIFF
--- a/landlab/grid/__init__.py
+++ b/landlab/grid/__init__.py
@@ -6,11 +6,12 @@ from .voronoi import VoronoiDelaunayGrid
 
 from .base import (BAD_INDEX_VALUE, CORE_NODE, FIXED_VALUE_BOUNDARY,
                    FIXED_GRADIENT_BOUNDARY, TRACKS_CELL_BOUNDARY,
-                   CLOSED_BOUNDARY, )
+                   CLOSED_BOUNDARY, ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK)
 from .create import create_and_initialize_grid
 
 __all__ = ['ModelGrid', 'HexModelGrid', 'RadialModelGrid', 'RasterModelGrid',
            'VoronoiDelaunayGrid', 'BAD_INDEX_VALUE', 'CORE_NODE',
            'FIXED_VALUE_BOUNDARY', 'FIXED_GRADIENT_BOUNDARY',
            'TRACKS_CELL_BOUNDARY', 'CLOSED_BOUNDARY',
+           'ACTIVE_LINK', 'FIXED_LINK', 'INACTIVE_LINK',
            'create_and_initialize_grid']

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -250,9 +250,6 @@ class VoronoiDelaunayGrid(ModelGrid):
         self._link_length = calculate_link_lengths(pts, self.node_at_link_tail,
                                                    self.node_at_link_head)
 
-        # NODES & LINKS: IDs and directions of links at each node
-        self.make_links_and_link_dirs_at_node()
-
         # LINKS: inlink and outlink matrices
         # SOON TO BE DEPRECATED
         self._setup_inlink_and_outlink_matrices()
@@ -260,6 +257,9 @@ class VoronoiDelaunayGrid(ModelGrid):
         # ACTIVE LINKS: Create list of active links, as well as "from" and "to"
         # nodes of active links.
         self._reset_link_status_list()
+
+        # NODES & LINKS: IDs and directions of links at each node
+        self.make_links_and_link_dirs_at_node()
 
         # LINKS: set up link unit vectors and node unit-vector sums
         self._make_link_unit_vectors()


### PR DESCRIPTION
Adds ability to map only horizontal and vertical links separately, if using a raster.

Also enables a new data structure active_link_dirs_at_node, alongside GT’s link_dis_at_node. It does the same thing, but lets you work only on active links (necessary for cases with lots of internal closed nodes). Also added a couple of mappers capable of mapping only active nodes. Lots more clearly needed.