### PR TITLE
SiccarPoint/slopes

### DIFF
--- a/landlab/components/craters/craters.py
+++ b/landlab/components/craters/craters.py
@@ -409,7 +409,7 @@ class impactor(object):
                 break
             else:
                 pre_elev = data.elev[active_node]
-                _r_to_center, _theta = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=active_node)
+                _r_to_center, _theta = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=active_node)
 
                 ##We need to account for deposition depth elevating the crater rim, i.e., we need to deposit *before* we cut the cavity. We do this by defining three domains for the node to lie in: 1. r<r_calc, i.e., below the pre-impact surface. No risk of intersecting the surface here. 2. r_calc < r; Th>z_new. this is the domain in the inward sloping rim of the crater ejecta. 3. Th<z_new and beyond. out on the ejecta proper. Note - (1) is not hard & fast rule if the surface dips. Safer is just (Th-lowering)<z_new
                 ##So, calc the excavation depth for all nodes, just to be on the safe side for strongly tilted geometries:
@@ -568,11 +568,11 @@ class impactor(object):
         six.print_('max_radius_ejecta: ', max_radius_ejecta_on_flat)
         footprint_center_x = self._xcoord+sin(_azimuth_of_travel)*max_radius_ejecta_on_flat*tan_beta
         footprint_center_y = self._ycoord+cos(_azimuth_of_travel)*max_radius_ejecta_on_flat*tan_beta
-        distances_to_footprint_center = grid.get_distances_of_nodes_to_point((footprint_center_x,footprint_center_y))
+        distances_to_footprint_center = grid.calc_distances_of_nodes_to_point((footprint_center_x,footprint_center_y))
 
         #There's currently issues doing this "properly" - and would also extend anyway as by moving the ejecta field, it's also possible to chop off part of the actual crater.
         #Resolve by also doing a full distance map for the actual impact site, and making a union of the two distance thresholds as the footprint:
-        distances_to_crater_center, azimuths_to_crater_center = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az=1)
+        distances_to_crater_center, azimuths_to_crater_center = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az=1)
         footprint_nodes = numpy.logical_or(distances_to_footprint_center<=max_radius_ejecta_on_flat, distances_to_crater_center<=max_radius_ejecta_on_flat)
 
         #Define a shortcut identity for the elev[footprint_nodes] patch, so we don't have to keep looking it up:

--- a/landlab/components/craters/dig_craters.py
+++ b/landlab/components/craters/dig_craters.py
@@ -656,7 +656,7 @@ class impactor(object):
 #        crater_center_offset_iterator = self.center_offset_list_for_looped_BCs((self._xcoord,self._ycoord), crater_edge_type_flag, crater_num_repeats)
 #        excavated_volume = 0.
 #        for i,j in izip(crater_footprint_iterator,crater_center_offset_iterator):
-#            _vec_r_to_center_excav,_vec_theta_excav = grid.get_distances_of_nodes_to_point(j, get_az='angles', node_subset=i)
+#            _vec_r_to_center_excav,_vec_theta_excav = grid.calc_distances_of_nodes_to_point(j, get_az='angles', node_subset=i)
 #            slope_offsets_rel_to_center_excav = -_vec_r_to_center_excav*numpy.tan(self._surface_slope)*numpy.cos(_vec_theta_excav-self._surface_dip_direction) #node leading negative - downslopes are +ve!!
 #            _vec_new_z_excav = slope_offsets_rel_to_center_excav + self.closest_node_elev - 1.*self._depth #Arbitrary assumed scaling: rim is 0.1 of total depth
 #            _vec_new_z_excav += self._depth * (_vec_r_to_center_excav/_radius)**crater_bowl_exp #note there's another fix here - we've relaxed the constraint that slopes outside one radius are at repose. It will keep curling up, so poke out quicker
@@ -700,7 +700,7 @@ class impactor(object):
 #
 #        for footprint_nodes,center_tuple in izip(footprint_iterator, center_offset_iterator):
 #            elev = self.elev
-#            _vec_r_to_center, _vec_theta = grid.get_distances_of_nodes_to_point(center_tuple, get_az='angles') #, node_subset=footprint_nodes)
+#            _vec_r_to_center, _vec_theta = grid.calc_distances_of_nodes_to_point(center_tuple, get_az='angles') #, node_subset=footprint_nodes)
 #            _vec_r_to_center = _vec_r_to_center[footprint_nodes]
 #            _vec_theta = _vec_theta[footprint_nodes]
 #
@@ -893,7 +893,7 @@ class impactor(object):
         for footprint_tuple,j in six.moves.zip(crater_footprint_iterator,crater_center_offset_iterator):
             i = footprint_tuple[0]
             self.crater_footprint_max = footprint_tuple[1]
-            grid.get_distances_of_nodes_to_point(j, get_az='angles', node_subset=self.crater_footprint_max[:i], out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
+            grid.calc_distances_of_nodes_to_point(j, get_az='angles', node_subset=self.crater_footprint_max[:i], out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
             numpy.subtract(self._vec_theta[:i], self._surface_dip_direction, out=self.dummy_1[:i])
             numpy.cos(self.dummy_1[:i], out=self.dummy_2[:i])
             numpy.multiply(self.dummy_2[:i], self._vec_r_to_center[:i], out=self.dummy_1[:i])
@@ -945,7 +945,7 @@ class impactor(object):
                 i = footprint_tuple[0]
                 self.crater_footprint_max = footprint_tuple[1]
                 footprint_nodes = self.crater_footprint_max[:i]
-                grid.get_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes, out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
+                grid.calc_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes, out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
                 self._vec_new_z[:i].fill(self.closest_node_elev + thickness_at_rim - self._depth)
                 numpy.divide(self._vec_r_to_center[:i], _radius, out=self.dummy_2[:i])
                 numpy.power(self.dummy_2[:i], crater_bowl_exp, out=self.dummy_3[:i])
@@ -1000,8 +1000,8 @@ class impactor(object):
             six.print_('looping... effective center is at ', center_tuple)
             footprint_nodes = self.crater_footprint_max[:i]
             #print footprint_nodes
-            #self._vec_r_to_center[:i], self._vec_theta[:i] = grid.get_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes)
-            grid.get_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes, out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
+            #self._vec_r_to_center[:i], self._vec_theta[:i] = grid.calc_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes)
+            grid.calc_distances_of_nodes_to_point(center_tuple, get_az='angles', node_subset=footprint_nodes, out_distance=self._vec_r_to_center[:i], out_azimuth=self._vec_theta[:i])
             #_vec_r_to_center = _vec_r_to_center[footprint_nodes]
             #_vec_theta = _vec_theta[footprint_nodes]
 

--- a/landlab/components/craters/dig_craters_copy.py
+++ b/landlab/components/craters/dig_craters_copy.py
@@ -426,7 +426,7 @@ class impactor(object):
         #    closest_node_to_footprint_center = grid.snap_coords_to_grid(footprint_center_x, footprint_center_y)
         #    footprint_nodes = self.all_node_distances_map[closest_node_to_footprint_center,:] < max_radius_ejecta_on_flat
         #else:
-        #    footprint_nodes = grid.get_distances_of_nodes_to_point((footprint_center_x, footprint_center_y)) < max_radius_ejecta_on_flat
+        #    footprint_nodes = grid.calc_distances_of_nodes_to_point((footprint_center_x, footprint_center_y)) < max_radius_ejecta_on_flat
         #if excess_excavation_radius:
         #    dist_to_center = self.all_node_distances_map[self.closest_node_index,:]
         #    footprint_nodes = numpy.logical_or(dist_to_center<_radius, footprint_nodes)
@@ -437,7 +437,7 @@ class impactor(object):
             cavity_footprint = self.create_square_footprint((self._xcoord,self._ycoord),_radius)
             footprint_nodes = numpy.unique(numpy.concatenate((footprint_nodes,cavity_footprint))) #combine the two footprints into array of unique IDs
 
-        _vec_r_to_center, _vec_theta = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
+        _vec_r_to_center, _vec_theta = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
         #Disabled, 112713
         #slope_offsets_rel_to_center = _vec_r_to_center*numpy.tan(self._surface_slope)*numpy.cos(_vec_theta-self._surface_dip_direction)
 
@@ -587,7 +587,7 @@ class impactor(object):
         ###Here's the oh-so-ugly ad-hoc fix to address the mass balance problems
         #We're calculating the approx excavated volume directly to feed the ejecta thickness calculator...
         excavation_nodes = self.create_square_footprint((self._xcoord,self._ycoord),4.*_radius) #Arbitrary increase in radius to try to catch the additional excavated material
-        _vec_r_to_center_excav = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), node_subset=excavation_nodes)
+        _vec_r_to_center_excav = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), node_subset=excavation_nodes)
         _vec_new_z_excav = numpy.empty_like(_vec_r_to_center_excav)
         _vec_new_z_excav.fill(self.closest_node_elev - 0.9*self._depth) #Arbitrary assumed scaling: rim is 0.1 of total depth
         _vec_new_z_excav += self._depth * (_vec_r_to_center_excav/_radius)**crater_bowl_exp #note there's another fix here - we've relaxed the constraint that slopes outside one radius are at repose. It will keep curling up, so poke out quicker
@@ -620,7 +620,7 @@ class impactor(object):
         #    closest_node_to_footprint_center = grid.snap_coords_to_grid(footprint_center_x, footprint_center_y)
         #    footprint_nodes = self.all_node_distances_map[closest_node_to_footprint_center,:] < max_radius_ejecta_on_flat
         #else:
-        #    footprint_nodes = grid.get_distances_of_nodes_to_point((footprint_center_x, footprint_center_y)) < max_radius_ejecta_on_flat
+        #    footprint_nodes = grid.calc_distances_of_nodes_to_point((footprint_center_x, footprint_center_y)) < max_radius_ejecta_on_flat
         #if excess_excavation_radius:
         #    dist_to_center = self.all_node_distances_map[self.closest_node_index,:]
         #    footprint_nodes = numpy.logical_or(dist_to_center<_radius, footprint_nodes)
@@ -631,7 +631,7 @@ class impactor(object):
             cavity_footprint = self.create_square_footprint((self._xcoord,self._ycoord),_radius)
             footprint_nodes = numpy.unique(numpy.concatenate((footprint_nodes,cavity_footprint))) #combine the two footprints into array of unique IDs
 
-        _vec_r_to_center, _vec_theta = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
+        _vec_r_to_center, _vec_theta = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
         ###Might be worth exploring doing this by reading off the distances_map, then correcting for offset from grid
 
         #Define a shortcut identity for the elev[footprint_nodes] patch, so we don't have to keep looking it up:
@@ -775,7 +775,7 @@ class impactor(object):
         max_ejecta_multiple = 1./numpy.cos(_surface_slope)*(1.+numpy.tan(_surface_slope)*numpy.tan(ejection_angle)) #...in the direction of max dip
 
         footprint_nodes = self.create_square_footprint((self._xcoord,self._ycoord),max_radius_ejecta_on_flat*max_ejecta_multiple)
-        _vec_r_to_center, _vec_theta = grid.get_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
+        _vec_r_to_center, _vec_theta = grid.calc_distances_of_nodes_to_point((self._xcoord,self._ycoord), get_az='angles', node_subset=footprint_nodes)
         #Disabled, 112713
         #slope_offsets_rel_to_center = _vec_r_to_center*numpy.tan(self._surface_slope)*numpy.cos(_vec_theta-self._surface_dip_direction)
 

--- a/landlab/components/sed_trp_shallow_flow/examples/sed_trp_basin_flow_driver.py
+++ b/landlab/components/sed_trp_shallow_flow/examples/sed_trp_basin_flow_driver.py
@@ -29,7 +29,7 @@ mg.set_inactive_boundaries(True, False, True, False)
 #print sgrid.node_tolink_index(mg.shape)[1]
 #mg.reset_list_of_active_links()
 
-#node_distances_to_inlet = mg.get_distances_of_nodes_to_point((mg.node_x[0], mg.node_y[0]))
+#node_distances_to_inlet = mg.calc_distances_of_nodes_to_point((mg.node_x[0], mg.node_y[0]))
 #z0 = initial_slope*(np.amax(node_distances_to_inlet) - node_distances_to_inlet)
 #z0[sgrid.boundary_nodes(mg.shape)] = 10.
 #z0[inlet_nodes] = z0[inlet_nodes]+0.05

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -336,7 +336,7 @@ class SinkFiller(Component):
         lake_nodes = np.where(self._lf.lake_map == lake_code)[0]
         lake_nodes = np.setdiff1d(lake_nodes, self.lake_nodes_treated)
         lake_ext_margin = self.get_lake_ext_margin(lake_nodes)
-        d = self._grid.get_distances_of_nodes_to_point(outlet_coord,
+        d = self._grid.calc_distances_of_nodes_to_point(outlet_coord,
                                                        node_subset=lake_nodes)
         add_vals = slope*d
         new_elevs[lake_nodes] += add_vals

--- a/landlab/components/sink_fill/tests/test_sink_filler.py
+++ b/landlab/components/sink_fill/tests/test_sink_filler.py
@@ -267,7 +267,7 @@ def test_add_slopes():
     lake_map[lake] = lake_code
     hf._lf._lake_map = lake_map
     hf.lake_nodes_treated = np.array([], dtype=int)
-    dists = mg.get_distances_of_nodes_to_point((mg.node_x[outlet],
+    dists = mg.calc_distances_of_nodes_to_point((mg.node_x[outlet],
                                                 mg.node_y[outlet]))
     new_z[lake] = outlet_elev
     new_z[lake] += dists[lake]*slope_to_add

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1934,10 +1934,18 @@ class ModelGrid(ModelDataFieldsMixIn):
                                   unit='degrees', return_components=False):
         """Array of slopes at nodes, averaged over neighboring patches.
 
-        Produces a value for slope at each node in a manner analogous to a
-        GIS-style slope map. It averages the gradient on each of the
+        Produces a value for node slope (i.e., mean gradient magnitude)
+        at each node in a manner analogous to a GIS-style slope map.
+        It averages the gradient on each of the
         patches surrounding the node, creating a value for node slope that
-        better incorporates nonlocal elevation information.
+        better incorporates nonlocal elevation information. Directional
+        information can still be returned through use of the return_components
+        keyword.
+
+        Note that under these definitions, it is not always true that::
+
+            mag, cmp = mg.slope_of_node(z)
+            mag**2 == cmp[0]**2 + cmp[1]**2  # not always true
 
         Parameters
         ----------
@@ -1974,7 +1982,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         True
         >>> numpy.allclose(cmp[0], 0.)
         True
-        >>> numpy.allclose(cmp[1], -1.)
+        >>> numpy.allclose(cmp[1], -np.pi/4.)
         True
         >>> mg = RadialModelGrid(num_shells=9)
         >>> z = mg.radius_at_node
@@ -2033,8 +2041,8 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         if return_components:
             theta = numpy.arctan2(nhat[:, 1], nhat[:, 0])
-            x_slope_patches = numpy.cos(theta)
-            y_slope_patches = numpy.sin(theta)
+            x_slope_patches = numpy.cos(theta)*slopes_at_patch
+            y_slope_patches = numpy.sin(theta)*slopes_at_patch
             x_slope_unmasked = x_slope_patches[self.patches_at_node()]
             x_slope_masked = numpy.ma.array(x_slope_unmasked,
                                             mask=self.patches_at_node().mask)

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1930,8 +1930,8 @@ class ModelGrid(ModelDataFieldsMixIn):
                 num_faces[cell] += 1
         self.sort_faces_at_cell_by_angle()
 
-    def slope_of_node(self, elevs='topographic__elevation',
-                                  unit='degrees', return_components=False):
+    def calc_slope_of_node(self, elevs='topographic__elevation',
+                           unit='degrees', return_components=False):
         """Array of slopes at nodes, averaged over neighboring patches.
 
         Produces a value for node slope (i.e., mean gradient magnitude)
@@ -1944,7 +1944,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         Note that under these definitions, it is not always true that::
 
-            mag, cmp = mg.slope_of_node(z)
+            mag, cmp = mg.calc_slope_of_node(z)
             mag**2 == cmp[0]**2 + cmp[1]**2  # not always true
 
         Parameters
@@ -1972,12 +1972,13 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> from landlab import RadialModelGrid, RasterModelGrid
         >>> mg = RasterModelGrid((4, 5), 1.)
         >>> z = mg.node_x
-        >>> slopes = mg.slope_of_node(elevs=z, unit='radians')
+        >>> slopes = mg.calc_slope_of_node(elevs=z, unit='radians')
         >>> numpy.allclose(slopes, 45./180.*numpy.pi)
         True
         >>> mg = RasterModelGrid((4, 5), 1.)
         >>> z = mg.node_y
-        >>> slope_mag, cmp = mg.slope_of_node(elevs=z, return_components=True)
+        >>> slope_mag, cmp = mg.calc_slope_of_node(elevs=z,
+        ...                                        return_components=True)
         >>> numpy.allclose(slope_mag, 45.)
         True
         >>> numpy.allclose(cmp[0], 0.)
@@ -1986,7 +1987,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         True
         >>> mg = RadialModelGrid(num_shells=9)
         >>> z = mg.radius_at_node
-        >>> slopes = mg.slope_of_node(elevs=z)
+        >>> slopes = mg.calc_slope_of_node(elevs=z)
         >>> mean_ring_slope = []
         >>> for i in xrange(10):
         ...     mean_ring_slope.append(slopes[np.isclose(mg.radius_at_node,
@@ -2051,7 +2052,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             y_slope_masked = numpy.ma.array(y_slope_unmasked,
                                             mask=self.patches_at_node().mask)
             y_slope = numpy.mean(y_slope_masked, axis=1).data
-            mean_grad_x  = x_slope
+            mean_grad_x = x_slope
             mean_grad_y = y_slope
         if unit == 'radians':
             if not return_components:

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1992,7 +1992,8 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> for i in xrange(10):
         ...     mean_ring_slope.append(slopes[np.isclose(mg.radius_at_node,
         ...                                              i)].mean())
-        >>> mean_ring_slope  # notice the small amounts of numerical error
+        >>> # notice the small amounts of numerical error here:
+        >>> mean_ring_slope  # doctest: +NORMALIZE_WHITESPACE
         [49.106605350869103,
          45.471738628700471,
          44.646123806208116,

--- a/landlab/grid/radial.py
+++ b/landlab/grid/radial.py
@@ -100,6 +100,8 @@ class RadialModelGrid(VoronoiDelaunayGrid):
         20
         """
         # Set number of nodes, and initialize if caller has given dimensions
+        self._origin_x = origin_x
+        self._origin_y = origin_y
         if num_shells > 0:
             self._initialize(num_shells, dr, origin_x, origin_y)
         super(RadialModelGrid, self).__init__(**kwds)
@@ -192,18 +194,6 @@ class RadialModelGrid(VoronoiDelaunayGrid):
             return self._nnodes_inshell
 
     @property
-    def radius_to_shell(self):
-        """Distance from central node to each shell.
-
-        Returns
-        -------
-        ndarray of float
-            The distance from the central node to each shell.
-        """
-        return ((numpy.arange(self.number_of_shells, dtype=float) + 1.) *
-                self.shell_spacing)
-
-    @property
     def radius_at_node(self):
         """Distance for center node to each node.
 
@@ -211,16 +201,17 @@ class RadialModelGrid(VoronoiDelaunayGrid):
         -------
         ndarray of float
             The distance from the center node of each node.
+
+        >>> mg = RadialModelGrid(num_shells=2)
+        >>> mg.radius_at_node
+        array([ 2.,  2.,  2.,  2.,  2.,  1.,  1.,  2.,  0.,  1.,  1.,  2.,  2.,
+                1.,  1.,  2.,  2.,  2.,  2.,  2.])
         """
         try:
             return self._node_radii
         except AttributeError:
-            self._node_radii = numpy.empty(self.number_of_nodes, dtype=float)
-            self._node_radii[0] = 0
-            start_index = 1
-            for i in range(self.number_of_shells):
-                end_index = start_index + self.number_of_nodes_in_shell[i]
-                self._node_radii[start_index:
-                                 end_index] = self.radius_to_shell[i]
-                start_index = end_index
+            self._node_radii = numpy.sqrt(numpy.square(self.node_x -
+                                                       self._origin_x) +
+                                          numpy.square(self.node_y -
+                                                       self._origin_y))
             return self._node_radii

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3775,8 +3775,12 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> np.allclose(cmp[0].reshape((4, 4))[:, 0],
         ...             cmp[1].reshape((4, 4))[0, :])  # test radial symmetry
         True
-
         """
+        try:
+            patches_at_node = self.patches_at_node()
+        except TypeError:  # was a property, not a fn (=> new style)
+            patches_at_node = numpy.ma.masked_where(
+                self.patches_at_node == -1, self.patches_at_node, copy=False)
         try:
             z = self.at_node[elevs]
         except TypeError:
@@ -3850,16 +3854,16 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         diag_upright_mean_patch = (slopes_at_patch_topright +
                                    slopes_at_patch_bottomleft) / 2.
         slopes_at_node1_unmasked = diag_upleft_mean_patch[
-            self.patches_at_node()[:, [0, 2]]]
+            patches_at_node[:, [0, 2]]]
         slopes_at_node2_unmasked = diag_upright_mean_patch[
-            self.patches_at_node()[:, [1, 3]]]
-        slopes_at_allnode_masked = np.ma.empty_like(self.patches_at_node(),
+            patches_at_node[:, [1, 3]]]
+        slopes_at_allnode_masked = np.ma.empty_like(patches_at_node,
                                                     dtype=float)
         slopes_at_allnode_masked[:, :2] = np.ma.array(
-            slopes_at_node1_unmasked, mask=self.patches_at_node()[
+            slopes_at_node1_unmasked, mask=patches_at_node[
                 :, [0, 2]].mask)
         slopes_at_allnode_masked[:, 2:] = np.ma.array(
-            slopes_at_node2_unmasked, mask=self.patches_at_node()[
+            slopes_at_node2_unmasked, mask=patches_at_node[
                 :, [1, 3]].mask)
         slope_mag = np.mean(slopes_at_allnode_masked, axis=1).data
 
@@ -3883,29 +3887,29 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             x_slope_upright_diag = (x_slope_patches_TR + x_slope_patches_BL)/2.
             y_slope_upright_diag = (y_slope_patches_TR + y_slope_patches_BL)/2.
 
-            x_slope1_unmasked = x_slope_upleft_diag[self.patches_at_node()[
+            x_slope1_unmasked = x_slope_upleft_diag[patches_at_node[
                 :, [0, 2]]]
-            y_slope1_unmasked = y_slope_upleft_diag[self.patches_at_node()[
+            y_slope1_unmasked = y_slope_upleft_diag[patches_at_node[
                 :, [0, 2]]]
-            x_slope2_unmasked = x_slope_upright_diag[self.patches_at_node()[
+            x_slope2_unmasked = x_slope_upright_diag[patches_at_node[
                 :, [1, 3]]]
-            y_slope2_unmasked = y_slope_upright_diag[self.patches_at_node()[
+            y_slope2_unmasked = y_slope_upright_diag[patches_at_node[
                 :, [1, 3]]]
             xslopes_at_allnode_masked = np.ma.empty_like(
-                self.patches_at_node(), dtype=float)
+                patches_at_node, dtype=float)
             yslopes_at_allnode_masked = np.ma.empty_like(
-                self.patches_at_node(), dtype=float)
+                patches_at_node, dtype=float)
             xslopes_at_allnode_masked[:, :2] = np.ma.array(
-                x_slope1_unmasked, mask=self.patches_at_node()[
+                x_slope1_unmasked, mask=patches_at_node[
                     :, [0, 2]].mask)
             xslopes_at_allnode_masked[:, 2:] = np.ma.array(
-                x_slope2_unmasked, mask=self.patches_at_node()[
+                x_slope2_unmasked, mask=patches_at_node[
                     :, [1, 3]].mask)
             yslopes_at_allnode_masked[:, :2] = np.ma.array(
-                y_slope1_unmasked, mask=self.patches_at_node()[
+                y_slope1_unmasked, mask=patches_at_node[
                     :, [0, 2]].mask)
             yslopes_at_allnode_masked[:, 2:] = np.ma.array(
-                y_slope2_unmasked, mask=self.patches_at_node()[
+                y_slope2_unmasked, mask=patches_at_node[
                     :, [1, 3]].mask)
             x_slope = np.mean(xslopes_at_allnode_masked, axis=1).data
             y_slope = np.mean(yslopes_at_allnode_masked, axis=1).data

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3978,6 +3978,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # return aspect alone
         return a
 
+    @deprecated(use='calc_slope_of_node', version=1.0)
     def calculate_slope_at_nodes_bestFitPlane(self, id, val):
         """Slope of best-fit plane at nodes.
 
@@ -4034,6 +4035,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         # return slope alone
         return s
 
+    @deprecated(use='calc_slope_of_node', version=1.0)
     def calculate_slope_aspect_at_nodes_burrough(self, ids=None,
                                                  vals='Elevation'):
         """Calculate topographic slope.

--- a/landlab/grid/tests/test_raster_grid/test_patches.py
+++ b/landlab/grid/tests/test_raster_grid/test_patches.py
@@ -99,14 +99,15 @@ class TestSlopesAtPatches():
     def test_slopes_at_patches(self):
         rmg = RasterModelGrid((4, 5))
         rmg.at_node['topographic__elevation'] = rmg.node_x.copy()
-        slopes_out = rmg.calc_slope_of_node(unit='degrees')
-        assert_array_almost_equal(slopes_out, np.full(20, 45., dtype=float))
+        slopes_out = rmg.calc_slope_of_node()
+        assert_array_almost_equal(slopes_out, np.full(20, np.pi/4.,
+                                  dtype=float))
 
     def test_slopes_at_patches_comps(self):
         rmg = RasterModelGrid((4, 5))
         rmg.at_node['topographic__elevation'] = rmg.node_y.copy()
         slopes_out = rmg.calc_slope_of_node(
-            rmg.at_node['topographic__elevation'], unit='radians',
+            rmg.at_node['topographic__elevation'],
             return_components=True)
         assert_array_almost_equal(slopes_out[0],
                                   np.full(20, np.pi/4., dtype=float))

--- a/landlab/grid/tests/test_raster_grid/test_patches.py
+++ b/landlab/grid/tests/test_raster_grid/test_patches.py
@@ -99,16 +99,18 @@ class TestSlopesAtPatches():
     def test_slopes_at_patches(self):
         rmg = RasterModelGrid((4, 5))
         rmg.at_node['topographic__elevation'] = rmg.node_x.copy()
-        slopes_out = rmg.node_slopes(unit='degrees')
+        slopes_out = rmg.calc_slope_of_node(unit='degrees')
         assert_array_almost_equal(slopes_out, np.full(20, 45., dtype=float))
 
     def test_slopes_at_patches_comps(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.at_node['topographic__elevation'] = rmg.node_x.copy()
-        slopes_out = rmg.node_slopes(unit='radians', return_components=True)
-        assert_array_almost_equal(slopes_out[0].data,
-                                  np.full(20, np.pi / 4., dtype=float))
-        assert_array_almost_equal(slopes_out[1][0].data,
-                                  np.ones(20, dtype=float))
-        assert_array_almost_equal(slopes_out[1][1].data,
+        rmg.at_node['topographic__elevation'] = rmg.node_y.copy()
+        slopes_out = rmg.calc_slope_of_node(
+            rmg.at_node['topographic__elevation'], unit='radians',
+            return_components=True)
+        assert_array_almost_equal(slopes_out[0],
+                                  np.full(20, np.pi/4., dtype=float))
+        assert_array_almost_equal(slopes_out[1][1],
+                                  np.full(20, -np.pi/4., dtype=float))
+        assert_array_almost_equal(slopes_out[1][0],
                                   np.zeros(20, dtype=float))

--- a/landlab/utils/fault_facet_finder.py
+++ b/landlab/utils/fault_facet_finder.py
@@ -133,7 +133,7 @@ class find_facets(object):
         distance_to_ft.fill(sys.float_info.max)
         new_distance_to_ft = np.empty_like(closest_ft_node, dtype=float)
         for i in self.ft_trace_node_ids:
-            grid.get_distances_of_nodes_to_point((grid.node_x[i], grid.node_y[i]),
+            grid.calc_distances_of_nodes_to_point((grid.node_x[i], grid.node_y[i]),
                                                  node_subset=grid.core_nodes[
                                                      subset], get_az='angles',
                                                  out_distance=new_distance_to_ft, out_azimuth=new_angle_to_ft)
@@ -297,7 +297,7 @@ class find_facets(object):
             count += 1
             print("Running ", count, " of ", unique_starting_pts.size)
             # set the local angle of the ft trace:
-            ft_pt_distances_to_node = self.grid.get_distances_of_nodes_to_point((grid.node_x[i], grid.node_y[i]),
+            ft_pt_distances_to_node = self.grid.calc_distances_of_nodes_to_point((grid.node_x[i], grid.node_y[i]),
                                                                                 node_subset=self.ft_trace_node_ids)
             close_ft_nodes = np.less(
                 ft_pt_distances_to_node, 5. * grid.node_spacing)
@@ -323,9 +323,9 @@ class find_facets(object):
                 y_ref = grid.node_y[
                     i] + cmp(grid.node_y[i], np.mean(grid.node_y[grid.core_nodes[nodes_possible]])) * multiplier
                 # get new absolute distances
-                dist_to_ft = self.grid.get_distances_of_nodes_to_point(
+                dist_to_ft = self.grid.calc_distances_of_nodes_to_point(
                     (x_ref, y_ref), node_subset=np.array([i]))
-                dists_along_profile = self.grid.get_distances_of_nodes_to_point(
+                dists_along_profile = self.grid.calc_distances_of_nodes_to_point(
                     (x_ref, y_ref), node_subset=grid.core_nodes[nodes_possible]) - dist_to_ft
                 # note the ft is now the origin, but pts might be back-to-front (consistently, though)
                 # sort the distances. Remove any pts that aren't in a "cluster".


### PR DESCRIPTION
Mends and modernises functionality to find GIS-style spatially averaged slopes at nodes.

Note the main method has changed name, mg.node_slopes() -> mg.calc_slope_of_node().