### PR TITLE
SiccarPoint/last minute deprecation

### DIFF
--- a/landlab/ca/celllab_cts.py
+++ b/landlab/ca/celllab_cts.py
@@ -394,8 +394,8 @@ class CellLabCTSModel(object):
 
         # Keep a copy of the model grid; remember how many active links in it
         self.grid = model_grid
-        ###self.active_links_at_node = self.grid.active_links_at_node()
-        self.active_links_at_node = self.grid.active_links_at_node2()
+        ###self._active_links_at_node = self.grid._active_links_at_node()
+        self._active_links_at_node = self.grid._active_links_at_node2()
 
         # Create an array that knows which links are connected to a boundary
         # node
@@ -696,8 +696,8 @@ class CellLabCTSModel(object):
         """
 
         # Find out the states of the two nodes, and the orientation
-        ###tail_node_state = self.node_state[self.grid.activelink_fromnode[link_id]]
-        ###head_node_state = self.node_state[self.grid.activelink_tonode[link_id]]
+        ###tail_node_state = self.node_state[self.grid._activelink_fromnode[link_id]]
+        ###head_node_state = self.node_state[self.grid._activelink_tonode[link_id]]
         ###orientation = self.active_link_orientation[link_id]
         tail_node_state = self.node_state[self.grid.node_at_link_tail[link_id]]
         head_node_state = self.node_state[self.grid.node_at_link_head[link_id]]
@@ -971,7 +971,7 @@ class CellLabCTSModel(object):
                 if _DEBUG:
                     print(' fromnode has changed state, so updating its links')
 
-                for link in self.active_links_at_node[:, tail_node]:
+                for link in self._active_links_at_node[:, tail_node]:
 
                     if _DEBUG:
                         print('f checking link', link)
@@ -997,7 +997,7 @@ class CellLabCTSModel(object):
                 if _DEBUG:
                     print(' tonode has changed state, so updating its links')
 
-                for link in self.active_links_at_node[:, head_node]:
+                for link in self._active_links_at_node[:, head_node]:
 
                     if _DEBUG:
                         print('t checking link', link)

--- a/landlab/ca/tests/test_celllab_cts.py
+++ b/landlab/ca/tests/test_celllab_cts.py
@@ -91,7 +91,7 @@ def test_raster_cts():
     assert (ca.num_link_states==4), 'wrong number of link states'
     assert (ca.prop_data[5]==50), 'error in property data'
     assert (ca.xn_rate[2][0]==0.1), 'error in transition rate array'
-    assert (ca.active_links_at_node[1][6]==8), 'error in active link array'
+    assert (ca._active_links_at_node[1][6]==8), 'error in active link array'
     assert (ca.num_node_states==2), 'error in num_node_states'
     assert (ca.link_orientation[-1]==0), 'error in link orientation array'
     assert (ca.link_state_dict[(1, 0, 0)]==2), 'error in link state dict'

--- a/landlab/components/flow_routing/route_flow_dn.py
+++ b/landlab/components/flow_routing/route_flow_dn.py
@@ -141,8 +141,8 @@ class FlowRouter(Component):
             # needs modifying in the loop if D4 (now done)
         else:
             self._active_links = grid.active_links
-            self._activelink_from = grid.activelink_fromnode
-            self._activelink_to = grid.activelink_tonode
+            self._activelink_from = grid._activelink_fromnode
+            self._activelink_to = grid._activelink_tonode
 
         # test input variables are present:
         grid.at_node['topographic__elevation']

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -3224,7 +3224,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the inlink arrays
         tonodes = self.node_at_link_head
-        self.node_numinlink = numpy.bincount(tonodes,
+        self._node_numinlink = numpy.bincount(tonodes,
                                              minlength=self.number_of_nodes)
 
         counts = count_repeated_values(self.node_at_link_head)
@@ -3233,7 +3233,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the outlink arrays
         fromnodes = self.node_at_link_tail
-        self.node_numoutlink = numpy.bincount(fromnodes,
+        self._node_numoutlink = numpy.bincount(fromnodes,
                                               minlength=self.number_of_nodes)
         counts = count_repeated_values(self.node_at_link_tail)
         for (count, (fromnodes, link_ids)) in enumerate(counts):
@@ -3252,7 +3252,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         --------
         >>> from landlab import HexModelGrid
         >>> hg = HexModelGrid(3, 2)
-        >>> hg.node_numactiveinlink
+        >>> hg._node_numactiveinlink
         array([0, 0, 0, 3, 1, 1, 1])
         >>> hg.node_active_inlink_matrix2
         array([[-1, -1, -1,  2,  6,  8,  9],
@@ -3261,7 +3261,7 @@ class ModelGrid(ModelDataFieldsMixIn):
                [-1, -1, -1, -1, -1, -1, -1],
                [-1, -1, -1, -1, -1, -1, -1],
                [-1, -1, -1, -1, -1, -1, -1]])
-        >>> hg.node_numactiveoutlink
+        >>> hg._node_numactiveoutlink
         array([1, 1, 1, 3, 0, 0, 0])
         >>> hg.node_active_outlink_matrix2
         array([[ 2,  3,  5,  6, -1, -1, -1],
@@ -3279,7 +3279,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the inlink arrays
         tonodes = self.activelink_tonode
-        self.node_numactiveinlink = as_id_array(numpy.bincount(
+        self._node_numactiveinlink = as_id_array(numpy.bincount(
             tonodes, minlength=self.number_of_nodes))
 
         counts = count_repeated_values(self.activelink_tonode)
@@ -3288,7 +3288,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the outlink arrays
         fromnodes = self.activelink_fromnode
-        self.node_numactiveoutlink = as_id_array(numpy.bincount(
+        self._node_numactiveoutlink = as_id_array(numpy.bincount(
             fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
@@ -3312,7 +3312,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the inlink arrays
         tonodes = self.node_at_link_head[self.active_links]
-        self.node_numactiveinlink = as_id_array(numpy.bincount(
+        self._node_numactiveinlink = as_id_array(numpy.bincount(
             tonodes, minlength=self.number_of_nodes))
 
         # OK, HERE WE HAVE TO MAKE A CHANGE, BECAUSE THE INDICES RETURNED BY
@@ -3329,7 +3329,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         # Set up the outlink arrays
         fromnodes = self.node_at_link_tail[self.active_links]
-        self.node_numactiveoutlink = as_id_array(numpy.bincount(
+        self._node_numactiveoutlink = as_id_array(numpy.bincount(
             fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -750,9 +750,9 @@ class ModelGrid(ModelDataFieldsMixIn):
     at_active_face = {}  # : Values defined at active faces
 
     # : Nodes on the other end of links pointing into a node.
-    node_inlink_matrix = numpy.array([], dtype=numpy.int32)
+    _node_inlink_matrix = numpy.array([], dtype=numpy.int32)
     # : Nodes on the other end of links pointing out of a node.
-    node_outlink_matrix = numpy.array([], dtype=numpy.int32)
+    _node_outlink_matrix = numpy.array([], dtype=numpy.int32)
 
     def __init__(self, **kwds):
         super(ModelGrid, self).__init__()
@@ -1813,7 +1813,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             The ids of active links attached to grid nodes with
             *node_ids*. If *node_ids* is not given, return links for all of
             the nodes in the grid. M is the number of rows in the grid's
-            node_active_inlink_matrix, which can vary depending on the type
+            _node_active_inlink_matrix, which can vary depending on the type
             and structure of the grid; in a hex grid, for example, it is 6.
 
         Notes
@@ -1821,14 +1821,14 @@ class ModelGrid(ModelDataFieldsMixIn):
         On it's way to being obsolete. **Deprecated**.
         """
         if len(args) == 0:
-            return numpy.vstack((self.node_active_inlink_matrix,
-                                 self.node_active_outlink_matrix))
+            return numpy.vstack((self._node_active_inlink_matrix,
+                                 self._node_active_outlink_matrix))
         elif len(args) == 1:
             node_ids = numpy.broadcast_arrays(args[0])[0]
             return numpy.vstack(
-                (self.node_active_inlink_matrix[:, node_ids],
-                 self.node_active_outlink_matrix[:, node_ids])
-            ).reshape(2 * numpy.size(self.node_active_inlink_matrix, 0), -1)
+                (self._node_active_inlink_matrix[:, node_ids],
+                 self._node_active_outlink_matrix[:, node_ids])
+            ).reshape(2 * numpy.size(self._node_active_inlink_matrix, 0), -1)
         else:
             raise ValueError('only zero or one arguments accepted')
 
@@ -1850,7 +1850,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             The link IDs of active links attached to grid nodes with
             *node_ids*. If *node_ids* is not given, return links for all of
             the nodes in the grid. M is the number of rows in the grid's
-            node_active_inlink_matrix, which can vary depending on the type
+            _node_active_inlink_matrix, which can vary depending on the type
             and structure of the grid; in a hex grid, for example, it is 6.
 
         Examples
@@ -1885,14 +1885,14 @@ class ModelGrid(ModelDataFieldsMixIn):
                [-1, -1, -1, -1, -1, -1, -1]])
         """
         if len(args) == 0:
-            return numpy.vstack((self.node_active_inlink_matrix2,
-                                 self.node_active_outlink_matrix2))
+            return numpy.vstack((self._node_active_inlink_matrix2,
+                                 self._node_active_outlink_matrix2))
         elif len(args) == 1:
             node_ids = numpy.broadcast_arrays(args[0])[0]
             return numpy.vstack(
-                (self.node_active_inlink_matrix2[:, node_ids],
-                 self.node_active_outlink_matrix2[:, node_ids])
-            ).reshape(2 * numpy.size(self.node_active_inlink_matrix2, 0), -1)
+                (self._node_active_inlink_matrix2[:, node_ids],
+                 self._node_active_outlink_matrix2[:, node_ids])
+            ).reshape(2 * numpy.size(self._node_active_inlink_matrix2, 0), -1)
         else:
             raise ValueError('only zero or one arguments accepted')
 
@@ -3190,7 +3190,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         as its "from".
 
         We store the inlinks in an NM-row by num_nodes-column matrix called
-        node_inlink_matrix. NM is the maximum number of neighbors for any node.
+        _node_inlink_matrix. NM is the maximum number of neighbors for any node.
 
         We also keep track of the total number of inlinks and outlinks at each
         node in the num_inlinks and num_outlinks arrays.
@@ -3217,9 +3217,9 @@ class ModelGrid(ModelDataFieldsMixIn):
         self.max_num_nbrs = numpy.amax(num_nbrs)
 
         # Create active in-link and out-link matrices.
-        self.node_inlink_matrix = - numpy.ones(
+        self._node_inlink_matrix = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
-        self.node_outlink_matrix = - numpy.ones(
+        self._node_outlink_matrix = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
 
         # Set up the inlink arrays
@@ -3229,7 +3229,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         counts = count_repeated_values(self.node_at_link_head)
         for (count, (tonodes, link_ids)) in enumerate(counts):
-            self.node_inlink_matrix[count][tonodes] = link_ids
+            self._node_inlink_matrix[count][tonodes] = link_ids
 
         # Set up the outlink arrays
         fromnodes = self.node_at_link_tail
@@ -3237,7 +3237,7 @@ class ModelGrid(ModelDataFieldsMixIn):
                                               minlength=self.number_of_nodes)
         counts = count_repeated_values(self.node_at_link_tail)
         for (count, (fromnodes, link_ids)) in enumerate(counts):
-            self.node_outlink_matrix[count][fromnodes] = link_ids
+            self._node_outlink_matrix[count][fromnodes] = link_ids
 
     @deprecated(use='no replacement', version=1.0)
     def _setup_active_inlink_and_outlink_matrices(self):
@@ -3254,7 +3254,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> hg = HexModelGrid(3, 2)
         >>> hg._node_numactiveinlink
         array([0, 0, 0, 3, 1, 1, 1])
-        >>> hg.node_active_inlink_matrix2
+        >>> hg._node_active_inlink_matrix2
         array([[-1, -1, -1,  2,  6,  8,  9],
                [-1, -1, -1,  3, -1, -1, -1],
                [-1, -1, -1,  5, -1, -1, -1],
@@ -3263,7 +3263,7 @@ class ModelGrid(ModelDataFieldsMixIn):
                [-1, -1, -1, -1, -1, -1, -1]])
         >>> hg._node_numactiveoutlink
         array([1, 1, 1, 3, 0, 0, 0])
-        >>> hg.node_active_outlink_matrix2
+        >>> hg._node_active_outlink_matrix2
         array([[ 2,  3,  5,  6, -1, -1, -1],
                [-1, -1, -1,  8, -1, -1, -1],
                [-1, -1, -1,  9, -1, -1, -1],
@@ -3272,9 +3272,9 @@ class ModelGrid(ModelDataFieldsMixIn):
                [-1, -1, -1, -1, -1, -1, -1]])
         """
         # Create active in-link and out-link matrices.
-        self.node_active_inlink_matrix = - numpy.ones(
+        self._node_active_inlink_matrix = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
-        self.node_active_outlink_matrix = - numpy.ones(
+        self._node_active_outlink_matrix = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
 
         # Set up the inlink arrays
@@ -3284,7 +3284,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         counts = count_repeated_values(self.activelink_tonode)
         for (count, (tonodes, active_link_ids)) in enumerate(counts):
-            self.node_active_inlink_matrix[count][tonodes] = active_link_ids
+            self._node_active_inlink_matrix[count][tonodes] = active_link_ids
 
         # Set up the outlink arrays
         fromnodes = self.activelink_fromnode
@@ -3292,7 +3292,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
-            self.node_active_outlink_matrix[count][fromnodes] = active_link_ids
+            self._node_active_outlink_matrix[count][fromnodes] = active_link_ids
 
         # THE FOLLOWING IS MEANT TO REPLACE THE ABOVE CODE, USING LINK IDS
         # FOR ACTIVE LINKS (ONLY), INSTEAD OF "ACTIVE LINK IDS". THE POINT IS
@@ -3305,9 +3305,9 @@ class ModelGrid(ModelDataFieldsMixIn):
         # matrices, WHICH WILL EVENTUALLY REPLACE THE ONE ABOVE (AND BE
         # RENAMED TO GET RID OF THE "2")
         # TODO: MAKE THIS CHANGE ONCE CODE THAT USES IT HAS BEEN PREPPED
-        self.node_active_inlink_matrix2 = - numpy.ones(
+        self._node_active_inlink_matrix2 = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
-        self.node_active_outlink_matrix2 = - numpy.ones(
+        self._node_active_outlink_matrix2 = - numpy.ones(
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
 
         # Set up the inlink arrays
@@ -3324,7 +3324,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         counts = count_repeated_values(
             self.node_at_link_head[self.active_links])
         for (count, (tonodes, active_link_ids)) in enumerate(counts):
-            self.node_active_inlink_matrix2[count][
+            self._node_active_inlink_matrix2[count][
                 tonodes] = self.active_links[active_link_ids]
 
         # Set up the outlink arrays
@@ -3333,7 +3333,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             fromnodes, minlength=self.number_of_nodes))
         counts = count_repeated_values(self.activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
-            self.node_active_outlink_matrix2[count][
+            self._node_active_outlink_matrix2[count][
                 fromnodes] = self.active_links[active_link_ids]
 
     def _create_link_unit_vectors(self):
@@ -3394,8 +3394,8 @@ class ModelGrid(ModelDataFieldsMixIn):
         """
         # Create the arrays for unit vectors for each link. These each get an
         # additional array element at the end with the value zero. This allows
-        # any references to "link ID -1" in the node_inlink_matrix and
-        # node_outlink_matrix to refer to the zero value in this extra element,
+        # any references to "link ID -1" in the _node_inlink_matrix and
+        # _node_outlink_matrix to refer to the zero value in this extra element,
         # so that when we're summing up link unit vectors, or multiplying by a
         # nonexistent unit vector, we end up just treating these as zero.
         self._link_unit_vec_x = numpy.zeros(self.number_of_links + 1)
@@ -3414,16 +3414,16 @@ class ModelGrid(ModelDataFieldsMixIn):
         # These will be useful in averaging link-based vectors at the nodes.
         self._node_unit_vector_sum_x = numpy.zeros(self.number_of_nodes)
         self._node_unit_vector_sum_y = numpy.zeros(self.number_of_nodes)
-        max_num_inlinks_per_node = numpy.size(self.node_inlink_matrix, 0)
+        max_num_inlinks_per_node = numpy.size(self._node_inlink_matrix, 0)
         for i in range(max_num_inlinks_per_node):
             self._node_unit_vector_sum_x += abs(
-                self._link_unit_vec_x[self.node_inlink_matrix[i, :]])
+                self._link_unit_vec_x[self._node_inlink_matrix[i, :]])
             self._node_unit_vector_sum_y += abs(
-                self._link_unit_vec_y[self.node_inlink_matrix[i, :]])
+                self._link_unit_vec_y[self._node_inlink_matrix[i, :]])
             self._node_unit_vector_sum_x += abs(
-                self._link_unit_vec_x[self.node_outlink_matrix[i, :]])
+                self._link_unit_vec_x[self._node_outlink_matrix[i, :]])
             self._node_unit_vector_sum_y += abs(
-                self._link_unit_vec_y[self.node_outlink_matrix[i, :]])
+                self._link_unit_vec_y[self._node_outlink_matrix[i, :]])
 
     @property
     def unit_vector_xcomponent_at_link(self):
@@ -3621,7 +3621,7 @@ class ModelGrid(ModelDataFieldsMixIn):
 
         To do this calculation efficiently, we use the following algorithm::
 
-            FOR each row in node_inlink_matrix (representing one inlink @ each
+            FOR each row in _node_inlink_matrix (representing one inlink @ each
             node)
                 Multiply the link's q value by its unit x component ...
                 ... divide by node's unit vector sum in x ...
@@ -3698,16 +3698,16 @@ class ModelGrid(ModelDataFieldsMixIn):
         qy[:self.number_of_links] = q * \
             self.link_unit_vec_y[:self.number_of_links]
 
-        # Loop over each row in the node_inlink_matrix and node_outlink_matrix.
+        # Loop over each row in the _node_inlink_matrix and _node_outlink_matrix.
         # This isn't a big loop! In a raster grid, these have only two rows
         # each; in an unstructured grid, it depends on the grid geometry;
         # for a hex grid, there are up to 6 rows.
-        n_matrix_rows = numpy.size(self.node_inlink_matrix, 0)
+        n_matrix_rows = numpy.size(self._node_inlink_matrix, 0)
         for i in range(n_matrix_rows):
-            node_vec_x += qx[self.node_inlink_matrix[i, :]]
-            node_vec_x += qx[self.node_outlink_matrix[i, :]]
-            node_vec_y += qy[self.node_inlink_matrix[i, :]]
-            node_vec_y += qy[self.node_outlink_matrix[i, :]]
+            node_vec_x += qx[self._node_inlink_matrix[i, :]]
+            node_vec_x += qx[self._node_outlink_matrix[i, :]]
+            node_vec_y += qy[self._node_inlink_matrix[i, :]]
+            node_vec_y += qy[self._node_outlink_matrix[i, :]]
         node_vec_x /= self.node_unit_vector_sum_x
         node_vec_y /= self.node_unit_vector_sum_y
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -373,8 +373,8 @@ Other Grid Methods
     ~landlab.grid.base.ModelGrid.axis_name
     ~landlab.grid.base.ModelGrid.number_of_links_at_node
     ~landlab.grid.base.ModelGrid._create_links_and_link_dirs_at_node
-    ~landlab.grid.base.ModelGrid.active_links_at_node
-    ~landlab.grid.base.ModelGrid.active_links_at_node2
+    ~landlab.grid.base.ModelGrid._active_links_at_node
+    ~landlab.grid.base.ModelGrid._active_links_at_node2
     ~landlab.grid.base.ModelGrid.angle_of_link
     ~landlab.grid.base.ModelGrid.resolve_values_on_links
     ~landlab.grid.base.ModelGrid.resolve_values_on_active_links
@@ -394,7 +394,7 @@ Other Grid Methods
     ~landlab.grid.base.ModelGrid.face_width
     ~landlab.grid.base.ModelGrid.get_active_link_connecting_node_pair
     ~landlab.grid.base.ModelGrid.length_of_link
-    ~landlab.grid.base.ModelGrid.assign_upslope_vals_to_active_links
+    ~landlab.grid.base.ModelGrid._assign_upslope_vals_to_active_links
     ~landlab.grid.base.ModelGrid.set_nodata_nodes_to_closed
     ~landlab.grid.base.ModelGrid.set_nodata_nodes_to_fixed_gradient
     ~landlab.grid.base.ModelGrid.max_of_link_end_node_values
@@ -1798,8 +1798,8 @@ class ModelGrid(ModelDataFieldsMixIn):
 
     @deprecated(use='vals[links_at_node]*active_link_dirs_at_node',
                 version=1.0)
-    def active_links_at_node(self, *args):
-        """active_links_at_node([node_ids])
+    def _active_links_at_node(self, *args):
+        """_active_links_at_node([node_ids])
         Active links of a node.
 
         Parameters
@@ -1834,8 +1834,8 @@ class ModelGrid(ModelDataFieldsMixIn):
 
     @deprecated(use='vals[links_at_node]*active_link_dirs_at_node',
                 version=1.0)
-    def active_links_at_node2(self, *args):
-        """active_links_at_node2([node_ids])
+    def _active_links_at_node2(self, *args):
+        """_active_links_at_node2([node_ids])
         Get active links attached to nodes.
 
         Parameters
@@ -1857,7 +1857,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         --------
         >>> from landlab import HexModelGrid
         >>> hmg = HexModelGrid(3, 2)
-        >>> hmg.active_links_at_node2(3)
+        >>> hmg._active_links_at_node2(3)
         array([[ 2],
                [ 3],
                [ 5],
@@ -1870,7 +1870,7 @@ class ModelGrid(ModelDataFieldsMixIn):
                [-1],
                [-1],
                [-1]])
-        >>> hmg.active_links_at_node2()
+        >>> hmg._active_links_at_node2()
         array([[-1, -1, -1,  2,  6,  8,  9],
                [-1, -1, -1,  3, -1, -1, -1],
                [-1, -1, -1,  5, -1, -1, -1],
@@ -2670,10 +2670,10 @@ class ModelGrid(ModelDataFieldsMixIn):
         active_link = BAD_INDEX_VALUE
         for alink in range(0, self.number_of_active_links):
             link_connects_nodes = (
-                (self.activelink_fromnode[alink] == node1 and
-                 self.activelink_tonode[alink] == node2) or
-                (self.activelink_tonode[alink] == node1 and
-                 self.activelink_fromnode[alink] == node2))
+                (self._activelink_fromnode[alink] == node1 and
+                 self._activelink_tonode[alink] == node2) or
+                (self._activelink_tonode[alink] == node1 and
+                 self._activelink_fromnode[alink] == node2))
             if link_connects_nodes:
                 active_link = alink
                 break
@@ -2742,7 +2742,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         return self._link_length
 
     @deprecated(use='map_max_of_link_nodes_to_link', version=1.0)
-    def assign_upslope_vals_to_active_links(self, u, v=None):
+    def _assign_upslope_vals_to_active_links(self, u, v=None):
         """Assign upslope node value to link.
 
         Assigns to each active link the value of *u* at whichever of its
@@ -2767,7 +2767,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> import numpy as np
         >>> grid = RasterModelGrid((3, 3))
         >>> u = np.arange(9.)
-        >>> grid.assign_upslope_vals_to_active_links(u)
+        >>> grid._assign_upslope_vals_to_active_links(u)
         array([ 4.,  4.,  5.,  7.])
         """
         if v is None:
@@ -2776,15 +2776,15 @@ class ModelGrid(ModelDataFieldsMixIn):
         fv = numpy.zeros(self.number_of_active_links)
         if len(v) < len(u):
             for i in range(0, self.number_of_active_links):
-                fv[i] = max(u[self.activelink_fromnode[i]],
-                            u[self.activelink_tonode[i]])
+                fv[i] = max(u[self._activelink_fromnode[i]],
+                            u[self._activelink_tonode[i]])
         else:
             for i in range(0, self.number_of_active_links):
-                if (v[self.activelink_fromnode[i]] >
-                        v[self.activelink_tonode[i]]):
-                    fv[i] = u[self.activelink_fromnode[i]]
+                if (v[self._activelink_fromnode[i]] >
+                        v[self._activelink_tonode[i]]):
+                    fv[i] = u[self._activelink_fromnode[i]]
                 else:
-                    fv[i] = u[self.activelink_tonode[i]]
+                    fv[i] = u[self._activelink_tonode[i]]
         return fv
 
     def _reset_link_status_list(self):
@@ -2882,8 +2882,8 @@ class ModelGrid(ModelDataFieldsMixIn):
         self._active_links = as_id_array(self._active_links)
         self._fixed_links = as_id_array(self._fixed_links)
 
-        self.activelink_fromnode = self.node_at_link_tail[active_links]
-        self.activelink_tonode = self.node_at_link_head[active_links]
+        self._activelink_fromnode = self.node_at_link_tail[active_links]
+        self._activelink_tonode = self.node_at_link_head[active_links]
 
         # Set up active inlink and outlink matrices
         self._setup_active_inlink_and_outlink_matrices()
@@ -3154,8 +3154,8 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> mg.max_of_link_end_node_values(h)
         array([ 2.,  8.,  8.,  3.,  3.,  6.,  8.])
         """
-        return numpy.maximum(node_data[self.activelink_fromnode],
-                             node_data[self.activelink_tonode])
+        return numpy.maximum(node_data[self._activelink_fromnode],
+                             node_data[self._activelink_tonode])
 
     def _calc_numbers_of_node_neighbors(self):
         """Number of neighbor nodes.
@@ -3278,19 +3278,19 @@ class ModelGrid(ModelDataFieldsMixIn):
             (self.max_num_nbrs, self.number_of_nodes), dtype=numpy.int)
 
         # Set up the inlink arrays
-        tonodes = self.activelink_tonode
+        tonodes = self._activelink_tonode
         self._node_numactiveinlink = as_id_array(numpy.bincount(
             tonodes, minlength=self.number_of_nodes))
 
-        counts = count_repeated_values(self.activelink_tonode)
+        counts = count_repeated_values(self._activelink_tonode)
         for (count, (tonodes, active_link_ids)) in enumerate(counts):
             self._node_active_inlink_matrix[count][tonodes] = active_link_ids
 
         # Set up the outlink arrays
-        fromnodes = self.activelink_fromnode
+        fromnodes = self._activelink_fromnode
         self._node_numactiveoutlink = as_id_array(numpy.bincount(
             fromnodes, minlength=self.number_of_nodes))
-        counts = count_repeated_values(self.activelink_fromnode)
+        counts = count_repeated_values(self._activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
             self._node_active_outlink_matrix[count][fromnodes] = active_link_ids
 
@@ -3331,7 +3331,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         fromnodes = self.node_at_link_tail[self.active_links]
         self._node_numactiveoutlink = as_id_array(numpy.bincount(
             fromnodes, minlength=self.number_of_nodes))
-        counts = count_repeated_values(self.activelink_fromnode)
+        counts = count_repeated_values(self._activelink_fromnode)
         for (count, (fromnodes, active_link_ids)) in enumerate(counts):
             self._node_active_outlink_matrix2[count][
                 fromnodes] = self.active_links[active_link_ids]

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -105,8 +105,8 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     """
     if out is None:
         out = grid.empty(centering='active_link')
-    return np.divide(node_values[grid.activelink_tonode] -
-                     node_values[grid.activelink_fromnode],
+    return np.divide(node_values[grid._activelink_tonode] -
+                     node_values[grid._activelink_fromnode],
                      grid.length_of_link[grid.active_links], out=out)
 
 
@@ -242,8 +242,8 @@ def calculate_diff_at_active_links(grid, node_values, out=None):
     if out is None:
         out = grid.empty(centering='active_link')
     node_values = np.asarray(node_values)
-    return np.subtract(node_values[grid.activelink_tonode],
-                       node_values[grid.activelink_fromnode], out=out)
+    return np.subtract(node_values[grid._activelink_tonode],
+                       node_values[grid._activelink_fromnode], out=out)
 
 
 def calc_unit_normal_at_patch(grid, elevs='topographic__elevation'):

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -26,11 +26,11 @@ def resolve_values_on_active_links(grid, active_link_values):
     """
     link_lengths = grid.length_of_link[grid.active_links]
     return (
-        np.multiply(((grid.node_x[grid.activelink_tonode] -
-                      grid.node_x[grid.activelink_fromnode]) /
+        np.multiply(((grid.node_x[grid._activelink_tonode] -
+                      grid.node_x[grid._activelink_fromnode]) /
                      link_lengths), active_link_values),
-        np.multiply(((grid.node_y[grid.activelink_tonode] -
-                      grid.node_y[grid.activelink_fromnode]) /
+        np.multiply(((grid.node_y[grid._activelink_tonode] -
+                      grid.node_y[grid._activelink_fromnode]) /
                      link_lengths), active_link_values))
 
 

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -132,9 +132,9 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     #       attached to a node, so should be of order 6 or 7 and won't
     #       generally increase with the number of nodes in the grid.
     #
-    for i in range(np.size(grid.node_active_inlink_matrix, 0)):
-        net_unit_flux += flux[grid.node_active_outlink_matrix[i][:]]
-        net_unit_flux -= flux[grid.node_active_inlink_matrix[i][:]]
+    for i in range(np.size(grid._node_active_inlink_matrix, 0)):
+        net_unit_flux += flux[grid._node_active_outlink_matrix[i][:]]
+        net_unit_flux -= flux[grid._node_active_inlink_matrix[i][:]]
 
     # Now divide by cell areas ... where there are core cells.
     node_at_active_cell = grid.node_at_cell[grid.core_cells]

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -467,7 +467,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                1, 2, 2, 2, 2,
                1, 2, 2, 2, 2,
                1, 2, 2, 2, 2])
-        >>> rmg.node_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1, -1, -1, -1, -1,  4,  5,  6,  7,  8, 13, 14, 15, 16, 17, 22,
                 23, 24, 25, 26],
                [-1,  0,  1,  2,  3, -1,  9, 10, 11, 12, -1, 18, 19, 20, 21, -1,
@@ -477,7 +477,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                2, 2, 2, 2, 1,
                2, 2, 2, 2, 1,
                1, 1, 1, 1, 0])
-        >>> rmg.node_outlink_matrix[0] # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_outlink_matrix[0] # doctest: +NORMALIZE_WHITESPACE
         array([ 4,  5,  6,  7,  8, 13, 14, 15, 16, 17, 22, 23, 24, 25, 26,
                -1, -1, -1, -1, -1])
         >>> rmg._node_numactiveinlink # doctest: +NORMALIZE_WHITESPACE
@@ -485,7 +485,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                0, 2, 2, 2, 1,
                0, 2, 2, 2, 1,
                0, 1, 1, 1, 0])
-        >>> rmg.node_active_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_active_inlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1, -1, -1, -1, -1, -1,  0,  1,  2, -1, -1,  3,  4,  5, -1, -1,
                  6, 7,  8, -1],
                [-1, -1, -1, -1, -1, -1,  9, 10, 11, 12, -1, 13, 14, 15, 16, -1,
@@ -495,7 +495,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                1, 2, 2, 2, 0,
                1, 2, 2, 2, 0,
                0, 0, 0, 0, 0])
-        >>> rmg.node_active_outlink_matrix # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_active_outlink_matrix # doctest: +NORMALIZE_WHITESPACE
         array([[-1,  0,  1,  2, -1, -1,  3,  4,  5, -1, -1,  6,  7,  8, -1, -1,
                 -1, -1, -1, -1],
                [-1, -1, -1, -1, -1,  9, 10, 11, 12, -1, 13, 14, 15, 16, -1, -1,
@@ -989,13 +989,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                [-1, -1, -1, -1,  4,  5,  6, -1, -1, -1, -1, -1]])
         """
         if len(args) == 0:
-            return np.vstack((self.node_active_inlink_matrix2,
-                              self.node_active_outlink_matrix2))
+            return np.vstack((self._node_active_inlink_matrix2,
+                              self._node_active_outlink_matrix2))
         elif len(args) == 1:
             node_ids = np.broadcast_arrays(args[0])[0]
             return (
-                np.vstack((self.node_active_inlink_matrix2[:, node_ids],
-                           self.node_active_outlink_matrix2[:, node_ids])
+                np.vstack((self._node_active_inlink_matrix2[:, node_ids],
+                           self._node_active_outlink_matrix2[:, node_ids])
                           ).reshape(4, -1))
         else:
             raise ValueError('only zero or one arguments accepted')
@@ -1287,7 +1287,7 @@ XXXXXXeric should be killing this with graphs.
         "from".
 
         We store the inlinks in a 2-row by num_nodes-column matrix called
-        node_inlink_matrix. It has two rows because we know that the nodes in
+        _node_inlink_matrix. It has two rows because we know that the nodes in
         our raster grid will never have more than two inlinks an two outlinks
         each (a given node could also have zero or one of either). The outlinks
         are stored in a similar matrix.
@@ -1326,10 +1326,10 @@ XXXXXXeric should be killing this with graphs.
         >>> rmg = RasterModelGrid((4, 5), 1.0)
         """
 
-        (self.node_inlink_matrix,
+        (self._node_inlink_matrix,
          self._node_numinlink) = sgrid.setup_inlink_matrix(self.shape)
 
-        (self.node_outlink_matrix,
+        (self._node_outlink_matrix,
          self._node_numoutlink) = sgrid.setup_outlink_matrix(self.shape)
 
     @deprecated(use='no replacement', version=1.0)
@@ -1343,19 +1343,19 @@ XXXXXXeric should be killing this with graphs.
         """
         node_status = self._node_status != CLOSED_BOUNDARY
 
-        (self.node_active_inlink_matrix,
+        (self._node_active_inlink_matrix,
          self._node_numactiveinlink) = sgrid.setup_active_inlink_matrix(
              self.shape, node_status=node_status)
 
-        (self.node_active_outlink_matrix,
+        (self._node_active_outlink_matrix,
          self._node_numactiveoutlink) = sgrid.setup_active_outlink_matrix(
              self.shape, node_status=node_status)
 
-        (self.node_active_inlink_matrix2,
+        (self._node_active_inlink_matrix2,
          self._node_numactiveinlink) = sgrid.setup_active_inlink_matrix2(
              self.shape, node_status=node_status)
 
-        (self.node_active_outlink_matrix2,
+        (self._node_active_outlink_matrix2,
          self._node_numactiveoutlink) = sgrid.setup_active_outlink_matrix2(
              self.shape, node_status=node_status)
 
@@ -1562,24 +1562,24 @@ XXXXXXeric should be killing this with graphs.
         self._node_unit_vector_sum_y = np.zeros(self.number_of_nodes)
         # x-component contribution from inlinks
         self._node_unit_vector_sum_x += np.abs(
-            self._link_unit_vec_x[self.node_inlink_matrix[0, :]])
+            self._link_unit_vec_x[self._node_inlink_matrix[0, :]])
         self._node_unit_vector_sum_x += np.abs(
-            self._link_unit_vec_x[self.node_inlink_matrix[1, :]])
+            self._link_unit_vec_x[self._node_inlink_matrix[1, :]])
         # x-component contribution from outlinks
         self._node_unit_vector_sum_x += np.abs(
-            self._link_unit_vec_x[self.node_outlink_matrix[0, :]])
+            self._link_unit_vec_x[self._node_outlink_matrix[0, :]])
         self._node_unit_vector_sum_x += np.abs(
-            self._link_unit_vec_x[self.node_outlink_matrix[1, :]])
+            self._link_unit_vec_x[self._node_outlink_matrix[1, :]])
         # y-component contribution from inlinks
         self._node_unit_vector_sum_y += np.abs(
-            self._link_unit_vec_y[self.node_inlink_matrix[0, :]])
+            self._link_unit_vec_y[self._node_inlink_matrix[0, :]])
         self._node_unit_vector_sum_y += np.abs(
-            self._link_unit_vec_y[self.node_inlink_matrix[1, :]])
+            self._link_unit_vec_y[self._node_inlink_matrix[1, :]])
         # y-component contribution from outlinks
         self._node_unit_vector_sum_y += np.abs(
-            self._link_unit_vec_y[self.node_outlink_matrix[0, :]])
+            self._link_unit_vec_y[self._node_outlink_matrix[0, :]])
         self._node_unit_vector_sum_y += np.abs(
-            self._link_unit_vec_y[self.node_outlink_matrix[1, :]])
+            self._link_unit_vec_y[self._node_outlink_matrix[1, :]])
 
     def _make_faces_at_cell(self, *args):
         """faces_at_cell([cell_id])
@@ -1623,8 +1623,8 @@ XXXXXXeric should be killing this with graphs.
             raise ValueError()
 
         node_ids = self.node_at_cell[cell_ids]
-        inlinks = self.node_inlink_matrix[:, node_ids].T
-        outlinks = self.node_outlink_matrix[:, node_ids].T
+        inlinks = self._node_inlink_matrix[:, node_ids].T
+        outlinks = self._node_outlink_matrix[:, node_ids].T
         self._faces_at_link = np.squeeze(np.concatenate(
             (self._face_at_link[inlinks], 
              self._face_at_link[outlinks]), axis=1))
@@ -3108,10 +3108,10 @@ XXXXXXeric should be killing this with graphs.
         # Make a matrix of the links. Need to append to this the gradients *on
         # the diagonals*.
         node_links = np.vstack(
-            (gradients[self.node_active_outlink_matrix2[0][:]],
-             gradients[self.node_active_outlink_matrix2[1][:]],
-             - gradients[self.node_active_inlink_matrix2[0][:]],
-             - gradients[self.node_active_inlink_matrix2[1][:]]))
+            (gradients[self._node_active_outlink_matrix2[0][:]],
+             gradients[self._node_active_outlink_matrix2[1][:]],
+             - gradients[self._node_active_inlink_matrix2[0][:]],
+             - gradients[self._node_active_inlink_matrix2[1][:]]))
 
         # calc the gradients on the diagonals:
         diagonal_nodes = (sgrid.diagonal_node_array(

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -678,7 +678,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
         # List of second ring looped neighbor cells (all 16 neighbors) for
         # given *cell ids* can be created if requested by the user.
-        self.looped_second_ring_cell_neighbor_list_created = False
+        self._looped_second_ring_cell_neighbor_list_created = False
 
     def _setup_nodes(self):
         self._nodes = np.arange(self.number_of_nodes,
@@ -920,7 +920,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     @property
     @deprecated(use='_diagonal_neighbors_at_node', version=1.0)
     @make_return_array_immutable
-    def get__diagonal_neighbors_at_node(self):
+    def get_diagonal_neighbors_at_node(self):
         return self._diagonal_neighbors_at_node
 
     @property
@@ -949,8 +949,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
     @deprecated(use='vals[links_at_node]*active_link_dirs_at_node',
                 version=1.0)
-    def active_links_at_node(self, *args):
-        """active_links_at_node([node_ids])
+    def _active_links_at_node(self, *args):
+        """_active_links_at_node([node_ids])
         Active links of a node.
 
         Parameters
@@ -972,12 +972,12 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg = RasterModelGrid((3, 4))
         >>> rmg.links_at_node[5]
         array([ 8, 11,  7,  4])
-        >>> rmg.active_links_at_node((5, 6))
+        >>> rmg._active_links_at_node((5, 6))
         array([[ 4,  5],
                [ 7,  8],
                [11, 12],
                [ 8,  9]])
-        >>> rmg.active_links_at_node()
+        >>> rmg._active_links_at_node()
         array([[-1, -1, -1, -1, -1,  4,  5, -1, -1, 11, 12, -1],
                [-1, -1, -1, -1, -1,  7,  8,  9, -1, -1, -1, -1],
                [-1,  4,  5, -1, -1, 11, 12, -1, -1, -1, -1, -1],
@@ -2277,9 +2277,9 @@ XXXXXXeric should be killing this with graphs.
 
         return (
             np.concatenate((self.active_links, self._diag_active_links)),
-            np.concatenate((self.activelink_fromnode,
+            np.concatenate((self._activelink_fromnode,
                             self._diag_activelink_fromnode)),
-            np.concatenate((self.activelink_tonode,
+            np.concatenate((self._activelink_tonode,
                             self._diag_activelink_tonode))
         )
 
@@ -3026,8 +3026,8 @@ XXXXXXeric should be killing this with graphs.
         horizontal_links = squad_links.is_horizontal_link(
             self.shape, active_links)
 
-        diffs = (node_values[self.activelink_tonode] -
-                 node_values[self.activelink_fromnode])
+        diffs = (node_values[self._activelink_tonode] -
+                 node_values[self._activelink_fromnode])
 
         diffs[vertical_links] /= self.dy
         diffs[horizontal_links] /= self.dx
@@ -4274,7 +4274,7 @@ XXXXXXeric should be killing this with graphs.
         [ 8,  9, 10, 11, 12, 13, 14, 15]
         [ 0,  1,  2,  3,  4,  5,  6,  7]
         """
-        if self.looped_second_ring_cell_neighbor_list_created:
+        if self._looped_second_ring_cell_neighbor_list_created:
             return self.second_ring_looped_cell_neighbor_list
         else:
             self.second_ring_looped_cell_neighbor_list = \
@@ -4300,7 +4300,7 @@ XXXXXXeric should be killing this with graphs.
                                       inf[cell4][0:2]))[order]
             second_ring[cell] = ring_tw
 
-        self.looped_second_ring_cell_neighbor_list_created = True
+        self._looped_second_ring_cell_neighbor_list_created = True
         return second_ring
 
     def set_fixed_link_boundaries_at_grid_edges(

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -462,7 +462,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                1, 0, 0, 0, 1,
                1, 0, 0, 0, 1,
                1, 1, 1, 1, 1], dtype=int8)
-        >>> rmg.node_numinlink # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_numinlink # doctest: +NORMALIZE_WHITESPACE
         array([0, 1, 1, 1, 1,
                1, 2, 2, 2, 2,
                1, 2, 2, 2, 2,
@@ -472,7 +472,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                 23, 24, 25, 26],
                [-1,  0,  1,  2,  3, -1,  9, 10, 11, 12, -1, 18, 19, 20, 21, -1,
                 27, 28, 29, 30]])
-        >>> rmg.node_numoutlink # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_numoutlink # doctest: +NORMALIZE_WHITESPACE
         array([2, 2, 2, 2, 1,
                2, 2, 2, 2, 1,
                2, 2, 2, 2, 1,
@@ -480,7 +480,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> rmg.node_outlink_matrix[0] # doctest: +NORMALIZE_WHITESPACE
         array([ 4,  5,  6,  7,  8, 13, 14, 15, 16, 17, 22, 23, 24, 25, 26,
                -1, -1, -1, -1, -1])
-        >>> rmg.node_numactiveinlink # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_numactiveinlink # doctest: +NORMALIZE_WHITESPACE
         array([0, 0, 0, 0, 0,
                0, 2, 2, 2, 1,
                0, 2, 2, 2, 1,
@@ -490,7 +490,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                  6, 7,  8, -1],
                [-1, -1, -1, -1, -1, -1,  9, 10, 11, 12, -1, 13, 14, 15, 16, -1,
                 -1, -1, -1, -1]])
-        >>> rmg.node_numactiveoutlink # doctest: +NORMALIZE_WHITESPACE
+        >>> rmg._node_numactiveoutlink # doctest: +NORMALIZE_WHITESPACE
         array([0, 1, 1, 1, 0,
                1, 2, 2, 2, 0,
                1, 2, 2, 2, 0,
@@ -1327,10 +1327,10 @@ XXXXXXeric should be killing this with graphs.
         """
 
         (self.node_inlink_matrix,
-         self.node_numinlink) = sgrid.setup_inlink_matrix(self.shape)
+         self._node_numinlink) = sgrid.setup_inlink_matrix(self.shape)
 
         (self.node_outlink_matrix,
-         self.node_numoutlink) = sgrid.setup_outlink_matrix(self.shape)
+         self._node_numoutlink) = sgrid.setup_outlink_matrix(self.shape)
 
     @deprecated(use='no replacement', version=1.0)
     def _setup_active_inlink_and_outlink_matrices(self):
@@ -1344,19 +1344,19 @@ XXXXXXeric should be killing this with graphs.
         node_status = self._node_status != CLOSED_BOUNDARY
 
         (self.node_active_inlink_matrix,
-         self.node_numactiveinlink) = sgrid.setup_active_inlink_matrix(
+         self._node_numactiveinlink) = sgrid.setup_active_inlink_matrix(
              self.shape, node_status=node_status)
 
         (self.node_active_outlink_matrix,
-         self.node_numactiveoutlink) = sgrid.setup_active_outlink_matrix(
+         self._node_numactiveoutlink) = sgrid.setup_active_outlink_matrix(
              self.shape, node_status=node_status)
 
         (self.node_active_inlink_matrix2,
-         self.node_numactiveinlink) = sgrid.setup_active_inlink_matrix2(
+         self._node_numactiveinlink) = sgrid.setup_active_inlink_matrix2(
              self.shape, node_status=node_status)
 
         (self.node_active_outlink_matrix2,
-         self.node_numactiveoutlink) = sgrid.setup_active_outlink_matrix2(
+         self._node_numactiveoutlink) = sgrid.setup_active_outlink_matrix2(
              self.shape, node_status=node_status)
 
     def _reset_list_of_active_diagonal_links(self):

--- a/landlab/grid/raster_funcs.py
+++ b/landlab/grid/raster_funcs.py
@@ -252,10 +252,10 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     flux[horiz_links] = active_link_flux[~ is_vert_link] * grid.dx
 
     net_unit_flux[:] = (
-        (flux[grid.node_active_outlink_matrix2[0][:]] +
-         flux[grid.node_active_outlink_matrix2[1][:]]) -
-        (flux[grid.node_active_inlink_matrix2[0][:]] +
-         flux[grid.node_active_inlink_matrix2[1][:]])) / grid.cellarea
+        (flux[grid._node_active_outlink_matrix2[0][:]] +
+         flux[grid._node_active_outlink_matrix2[1][:]]) -
+        (flux[grid._node_active_inlink_matrix2[0][:]] +
+         flux[grid._node_active_inlink_matrix2[1][:]])) / grid.cellarea
 
     return net_unit_flux
 

--- a/landlab/grid/raster_funcs.py
+++ b/landlab/grid/raster_funcs.py
@@ -27,7 +27,7 @@ def neighbor_active_link_at_cell(grid, inds, *args):
     """
     cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
     node_ids = grid.node_at_cell[cell_ids]
-    links = grid.active_links_at_node(node_ids).T
+    links = grid._active_links_at_node(node_ids).T
 
     if not isinstance(inds, np.ndarray):
         inds = np.array(inds)

--- a/landlab/grid/tests/test_raster_grid/test_inactive_nodes.py
+++ b/landlab/grid/tests/test_raster_grid/test_inactive_nodes.py
@@ -9,18 +9,18 @@ def test_inactive_boundaries():
     assert_array_equal(rmg.active_links,
                        np.array([4,  5,  7,  8,  9, 11, 12]))
     assert_array_equal(
-        rmg.node_active_inlink_matrix2,
+        rmg._node_active_inlink_matrix2,
         np.array([[-1, -1, -1, -1, -1,  4,  5, -1, -1, 11, 12, -1],
                   [-1, -1, -1, -1, -1,  7,  8,  9, -1, -1, -1, -1]]))
 
     rmg.set_inactive_boundaries(True, True, True, True)
     assert_array_equal(rmg.active_links, np.array([8]))
     assert_array_equal(
-        rmg.node_active_inlink_matrix2,
+        rmg._node_active_inlink_matrix2,
         np.array([[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                   [-1, -1, -1, -1, -1, -1,  8, -1, -1, -1, -1, -1]]))
     assert_array_equal(
-        rmg.node_active_outlink_matrix2,
+        rmg._node_active_outlink_matrix2,
         np.array([[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                   [-1, -1, -1, -1, -1,  8, -1, -1, -1, -1, -1, -1]]))
     assert_array_equal(

--- a/landlab/grid/tests/test_raster_grid/test_inactive_nodes.py
+++ b/landlab/grid/tests/test_raster_grid/test_inactive_nodes.py
@@ -24,7 +24,7 @@ def test_inactive_boundaries():
         np.array([[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                   [-1, -1, -1, -1, -1,  8, -1, -1, -1, -1, -1, -1]]))
     assert_array_equal(
-        rmg.active_links_at_node(),
+        rmg._active_links_at_node(),
         np.array([[-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
                   [-1, -1, -1, -1, -1, -1,  8, -1, -1, -1, -1, -1],
                   [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1],
@@ -34,7 +34,7 @@ def test_inactive_boundaries():
 def test_inactive_interiors():
     rmg = RasterModelGrid(4, 5, 1.)
     rmg.set_closed_nodes([6, 12])
-    assert_array_equal(rmg.active_links_at_node(),
+    assert_array_equal(rmg._active_links_at_node(),
                        np.array([[-1, -1, -1, -1, -1,
                                   -1, -1,  6,  7, -1,
                                   -1, -1, -1, 16, -1,

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -220,14 +220,14 @@ def test_active_links():
 
 #@with_setup(setup_grid)
 #def test_active_link_fromnode():
-#    assert_array_equal(rmg.activelink_fromnode,
+#    assert_array_equal(rmg._activelink_fromnode,
 #                       np.array([1, 2, 3, 6, 7, 8, 11, 12, 13,
 #                                 5, 6, 7, 8, 10, 11, 12, 13]))
 #
 #
 #@with_setup(setup_grid)
 #def test_active_link_tonode():
-#    assert_array_equal(rmg.activelink_tonode,
+#    assert_array_equal(rmg._activelink_tonode,
 #                       np.array([6, 7, 8, 11, 12, 13, 16, 17, 18,
 #                                 6, 7, 8, 9, 11, 12, 13, 14]))
 
@@ -277,28 +277,28 @@ def test_active_outlink_matrix():
 
 
 @with_setup(setup_grid)
-def test_active_links_at_node_scalar_interior():
-    assert_array_equal(rmg.active_links_at_node([6]),
+def test__active_links_at_node_scalar_interior():
+    assert_array_equal(rmg._active_links_at_node([6]),
                        np.array([[5, 9, 14, 10]]).T)
 
 
 @with_setup(setup_grid)
-def test_active_links_at_node_scalar_boundary():
-    assert_array_equal(rmg.active_links_at_node([1]),
+def test__active_links_at_node_scalar_boundary():
+    assert_array_equal(rmg._active_links_at_node([1]),
                        np.array([[-1, -1,  5, -1]]).T)
 
 
 @with_setup(setup_grid)
 def test_active_node_with_array_arg():
-    assert_array_equal(rmg.active_links_at_node([6, 7]),
+    assert_array_equal(rmg._active_links_at_node([6, 7]),
                        np.array([[5,  9, 14, 10],
                                  [6, 10, 15, 11]]).T)
 
 
 @with_setup(setup_grid)
-def test_active_links_at_node_with_no_args():
+def test__active_links_at_node_with_no_args():
     assert_array_equal(
-        rmg.active_links_at_node(),
+        rmg._active_links_at_node(),
         np.array([[-1, -1, -1, -1, -1, -1,  5,  6,  7, -1,
                    -1, 14, 15, 16, -1, -1, 23, 24, 25, -1],
                   [-1, -1, -1, -1, -1, -1,  9, 10, 11, 12,

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -251,7 +251,7 @@ def test_active_link_num_outlink():
 
 @with_setup(setup_grid)
 def test_active_inlink_matrix():
-    assert_array_equal(rmg.node_active_inlink_matrix,
+    assert_array_equal(rmg._node_active_inlink_matrix,
                        np.array([[-1, -1, -1, -1, -1,
                                   -1,  0,  1,  2, -1,
                                   -1,  3,  4,  5, -1,
@@ -265,7 +265,7 @@ def test_active_inlink_matrix():
 @with_setup(setup_grid)
 def test_active_outlink_matrix():
     assert_array_equal(
-        rmg.node_active_outlink_matrix,
+        rmg._node_active_outlink_matrix,
         np.array([[-1,  0,  1,  2, -1,
                    -1,  3,  4,  5, -1,
                    -1,  6,  7,  8, -1,
@@ -353,8 +353,8 @@ def test_link_num_outlink():
 
 
 @with_setup(setup_grid)
-def test_node_inlink_matrix():
-    assert_array_equal(rmg.node_inlink_matrix,
+def test__node_inlink_matrix():
+    assert_array_equal(rmg._node_inlink_matrix,
                        np.array([[-1, -1, -1, -1, -1,
                                    4,  5,  6,  7,  8,
                                   13, 14, 15, 16, 17,
@@ -366,8 +366,8 @@ def test_node_inlink_matrix():
 
 
 @with_setup(setup_grid)
-def test_node_outlink_matrix():
-    assert_array_equal(rmg.node_outlink_matrix,
+def test__node_outlink_matrix():
+    assert_array_equal(rmg._node_outlink_matrix,
                        np.array([[ 4,  5,  6,  7,  8,
                                   13, 14, 15, 16, 17,
                                   22, 23, 24, 25, 26,

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -234,7 +234,7 @@ def test_active_links():
 
 @with_setup(setup_grid)
 def test_active_link_num_inlink():
-    assert_array_equal(rmg.node_numactiveinlink,
+    assert_array_equal(rmg._node_numactiveinlink,
                        np.array([0, 0, 0, 0, 0,
                                  0, 2, 2, 2, 1,
                                  0, 2, 2, 2, 1,
@@ -243,7 +243,7 @@ def test_active_link_num_inlink():
 
 @with_setup(setup_grid)
 def test_active_link_num_outlink():
-    assert_array_equal(rmg.node_numactiveoutlink, np.array([0, 1, 1, 1, 0,
+    assert_array_equal(rmg._node_numactiveoutlink, np.array([0, 1, 1, 1, 0,
                                                             1, 2, 2, 2, 0,
                                                             1, 2, 2, 2, 0,
                                                             0, 0, 0, 0, 0]))
@@ -337,7 +337,7 @@ def test_node_at_link_head():
 
 @with_setup(setup_grid)
 def test_link_num_inlink():
-    assert_array_equal(rmg.node_numinlink,
+    assert_array_equal(rmg._node_numinlink,
                        np.array([0, 1, 1, 1, 1,
                                  1, 2, 2, 2, 2,
                                  1, 2, 2, 2, 2,
@@ -346,7 +346,7 @@ def test_link_num_inlink():
 
 @with_setup(setup_grid)
 def test_link_num_outlink():
-    assert_array_equal(rmg.node_numoutlink, np.array([2, 2, 2, 2, 1,
+    assert_array_equal(rmg._node_numoutlink, np.array([2, 2, 2, 2, 1,
                                                       2, 2, 2, 2, 1,
                                                       2, 2, 2, 2, 1,
                                                       1, 1, 1, 1, 0]))

--- a/landlab/grid/tests/testing_hex_grid/testing_flux_divergence_hex_grid.py
+++ b/landlab/grid/tests/testing_hex_grid/testing_flux_divergence_hex_grid.py
@@ -78,7 +78,7 @@ def make_links_at_node_array(grid):
     grid.gt_link_dirs_at_node = np.zeros((MAX_NUM_LINKS, grid.number_of_nodes), dtype=np.int8)
     grid.gt_active_link_dirs_at_node = np.zeros((MAX_NUM_LINKS, grid.number_of_nodes), dtype=np.int8)
     grid.gt_num_links_at_node = np.zeros(grid.number_of_nodes, dtype=np.uint8)  # assume <256 links at any node
-    grid.gt_num_active_links_at_node = np.zeros(grid.number_of_nodes, dtype=np.uint8)  # assume <256 links at any node
+    grid.gt_num__active_links_at_node = np.zeros(grid.number_of_nodes, dtype=np.uint8)  # assume <256 links at any node
     
     # Sweep over all links
     for lk in range(grid.number_of_links):

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -235,7 +235,7 @@ class VoronoiDelaunayGrid(ModelGrid):
         # "from" and "to" nodes.
         (self._node_at_link_tail,
          self._node_at_link_head,
-         self.active_links_ids,
+         _,
          self._face_width) = \
             self._create_links_and_faces_from_voronoi_diagram(vor)
         self._status_at_link = numpy.full(len(self._node_at_link_tail),


### PR DESCRIPTION
This PR goes through the most obvious grid types and ensures anything that doesn’t look like it should be exposed to users, isn’t.

Exceptions are:
1. anything with calculate_, get_, or find_ at its start (these are decorated as deprecated, but not underscored)
2. vmg.active_links_ids, which I can’t find in the inheritance structure.