### PR TITLE
Remove usages of deprecated functions

### DIFF
--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -541,13 +541,13 @@ class ChiFinder(Component):
         """
         Returns a masked array version of the 'channel__chi_index' field.
         This enables easier plotting of the values with
-        :func:`landlab.imshow_node_grid` or similar.
+        :func:`landlab.imshow_grid_at_node` or similar.
 
         Examples
         --------
         Make a topographic map with an overlay of chi values:
 
-        >>> from landlab import imshow_node_grid
+        >>> from landlab import imshow_grid_at_node
         >>> from landlab import RasterModelGrid, CLOSED_BOUNDARY
         >>> from landlab.components import FlowRouter, FastscapeEroder
         >>> mg = RasterModelGrid((5, 5), 100.)
@@ -570,9 +570,9 @@ class ChiFinder(Component):
         >>> _ = fr.route_flow()
         >>> cf.calculate_chi()
 
-        >>> imshow_node_grid(mg, 'topographic__elevation',
-        ...                  allow_colorbar=False)
-        >>> imshow_node_grid(mg, cf.masked_chi_indices,
-        ...                  color_for_closed=None, cmap='winter')
+        >>> imshow_grid_at_node(mg, 'topographic__elevation',
+        ...                     allow_colorbar=False)
+        >>> imshow_grid_at_node(mg, cf.masked_chi_indices,
+        ...                     color_for_closed=None, cmap='winter')
         """
         return np.ma.array(self.chi_indices, mask=self.hillslope_mask)

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -252,8 +252,7 @@ class LinearDiffuser(Component):
                                                self.g[self.grid.active_links])
 
             # Calculate the net deposition/erosion rate at each node
-            self.dqsds = self.grid.calculate_flux_divergence_at_nodes(
-                self.qs[self.grid.active_links])
+            self.dqsds = self.grid.calc_flux_div_at_node(self.qs)
             # Calculate the total rate of elevation change
             dzdt = - self.dqsds
 

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -246,7 +246,7 @@ class LinearDiffuser(Component):
         for i in range(repeats+1):
             # Calculate the gradients and sediment fluxes
             self.g[self.grid.active_links] = \
-                self.grid.calc_grad_at_active_link(z)
+                    self.grid.calc_grad_at_link(z)[self.grid.active_links]
             # if diffusivity is an array, self.kd is already active_links-long
             self.qs[self.grid.active_links] = (-kd_activelinks *
                                                self.g[self.grid.active_links])

--- a/landlab/components/overland_flow/generate_overland_flow_Bates.py
+++ b/landlab/components/overland_flow/generate_overland_flow_Bates.py
@@ -169,7 +169,8 @@ class OverlandFlowBates(Component):
         hflow = wmax[self._grid.active_links] - zmax[self._grid.active_links]
 
         # Now we calculate the slope of the water surface elevation at active links
-        water_surface_slope = self._grid.calc_grad_of_active_link(w)
+        water_surface_slope = self._grid.calc_grad_at_link(w)
+        water_surface_slope = water_surface_slope[self._grid.active_links]
 
         # Here we calculate discharge at all active links using Eq. 11 from Bates et al., 2010
         self.q[self.active_links] = ((self.q[self.active_links] - self.g *

--- a/landlab/components/overland_flow/generate_overland_flow_Bates.py
+++ b/landlab/components/overland_flow/generate_overland_flow_Bates.py
@@ -163,10 +163,10 @@ class OverlandFlowBates(Component):
 
         # Per Bates et al., 2010, this solution needs to find the difference between the highest
         # water surface in the two cells and the highest bed elevation
-        zmax = self._grid.max_of_link_end_node_values(self.z)
+        zmax = self._grid.map_max_of_link_nodes_to_link(self.z)
         w = self.h + self.z
-        wmax = self._grid.max_of_link_end_node_values(w)
-        hflow = wmax - zmax
+        wmax = self._grid.map_max_of_link_nodes_to_link(w)
+        hflow = wmax[self._grid.active_links] - zmax[self._grid.active_links]
 
         # Now we calculate the slope of the water surface elevation at active links
         water_surface_slope = self._grid.calc_grad_of_active_link(w)

--- a/landlab/components/overland_flow/generate_overland_flow_Bates.py
+++ b/landlab/components/overland_flow/generate_overland_flow_Bates.py
@@ -169,8 +169,8 @@ class OverlandFlowBates(Component):
         hflow = wmax[self._grid.active_links] - zmax[self._grid.active_links]
 
         # Now we calculate the slope of the water surface elevation at active links
-        water_surface_slope = self._grid.calc_grad_at_link(w)
-        water_surface_slope = water_surface_slope[self._grid.active_links]
+        water_surface_slope = (
+            self._grid.calc_grad_at_link(w)[self._grid.active_links])
 
         # Here we calculate discharge at all active links using Eq. 11 from Bates et al., 2010
         self.q[self.active_links] = ((self.q[self.active_links] - self.g *

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -369,10 +369,10 @@ class OverlandFlow(Component):
         # Per Bates et al., 2010, this solution needs to find the difference
         # between the highest water surface in the two cells and the
         # highest bed elevation
-        zmax = self.grid.max_of_link_end_node_values(self.z)
+        zmax = self._grid.map_max_of_link_nodes_to_link(self.z)
         w = self.h + self.z
-        wmax = self.grid.max_of_link_end_node_values(w)
-        hflow = wmax - zmax
+        wmax = self._grid.map_max_of_link_nodes_to_link(w)
+        hflow = wmax[self._grid.active_links] - zmax[self._grid.active_links]
 
         # Insert this water depth into an array of water depths at the links.
         self.h_links[self.active_links] = hflow

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -204,7 +204,7 @@ class OverlandFlow(Component):
         # For water discharge
         try:
             self.water__discharge = grid.add_zeros(
-                'link', 'water__discharge',
+                'water__discharge', at='link',
                 units=self._var_units['water__discharge'])
         except FieldError:
             # Field was already set; still, fill it with zeros
@@ -213,7 +213,7 @@ class OverlandFlow(Component):
 
         # For water depths calculated at links
         try:
-            self.h_links = grid.add_zeros('link', 'water__depth',
+            self.h_links = grid.add_zeros('water__depth', at='link',
                                           units=self._var_units[
                                               'water__depth'])
         except FieldError:
@@ -223,7 +223,7 @@ class OverlandFlow(Component):
 
         # For water surface slopes at links
         try:
-            self.slope = grid.add_zeros('link', 'water_surface__gradient')
+            self.slope = grid.add_zeros('water_surface__gradient', at='link')
         except FieldError:
             self.slope = grid.at_link['water_surface__gradient']
             self.slope.fill(0.)
@@ -379,11 +379,11 @@ class OverlandFlow(Component):
 
         # Now we calculate the slope of the water surface elevation at
         # active links
-        water_surface__gradient = \
-            self.grid.calc_grad_of_active_link(w)
+        water_surface_gradient = self.grid.calc_grad_at_link(w)
+        water_surface_gradient = water_surface_gradient[self.grid.active_links]
 
         # And insert these values into an array of all links
-        self.slope[self.active_links] = water_surface__gradient
+        self.slope[self.active_links] = water_surface_gradient
 
         # If the user chooses to set boundary links to the neighbor value, we
         # set the discharge array to have the boundary links set to their

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -379,8 +379,8 @@ class OverlandFlow(Component):
 
         # Now we calculate the slope of the water surface elevation at
         # active links
-        water_surface_gradient = self.grid.calc_grad_at_link(w)
-        water_surface_gradient = water_surface_gradient[self.grid.active_links]
+        water_surface_gradient = (
+            self.grid.calc_grad_at_link(w)[self.grid.active_links])
 
         # And insert these values into an array of all links
         self.slope[self.active_links] = water_surface_gradient

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -498,13 +498,13 @@ class SteepnessFinder(Component):
         """
         Returns a masked array version of the 'channel__steepness_index' field.
         This enables easier plotting of the values with
-        :func:`landlab.imshow_node_grid` or similar.
+        :func:`landlab.imshow_grid_at_node` or similar.
 
         Examples
         --------
         Make a topographic map with an overlay of steepness values:
 
-        >>> from landlab import imshow_node_grid
+        >>> from landlab import imshow_grid_at_node
         >>> from landlab import RasterModelGrid, CLOSED_BOUNDARY
         >>> from landlab.components import FlowRouter, FastscapeEroder
         >>> mg = RasterModelGrid((5, 5), 100.)
@@ -527,9 +527,9 @@ class SteepnessFinder(Component):
         >>> _ = fr.route_flow()
         >>> cf.calculate_steepnesses()
 
-        >>> imshow_node_grid(mg, 'topographic__elevation',
-        ...                  allow_colorbar=False)
-        >>> imshow_node_grid(mg, cf.masked_steepness_indices,
-        ...                  color_for_closed=None, cmap='winter')
+        >>> imshow_grid_at_node(mg, 'topographic__elevation',
+        ...                     allow_colorbar=False)
+        >>> imshow_grid_at_node(mg, cf.masked_steepness_indices,
+        ...                     color_for_closed=None, cmap='winter')
         """
         return np.ma.array(self.steepness_indices, mask=self.hillslope_mask)

--- a/landlab/components/stream_power/tests/test_voronoi_sp.py
+++ b/landlab/components/stream_power/tests/test_voronoi_sp.py
@@ -9,7 +9,6 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from landlab import VoronoiDelaunayGrid
 from landlab.components.flow_routing import FlowRouter
 from landlab.components.stream_power import StreamPowerEroder
-from landlab.plot.imshow import imshow_node_grid
 from pylab import show
 
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -2688,7 +2688,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> hg.link_at_face
         array([ 3,  4,  5,  6,  8,  9, 10, 12, 13, 14, 15])
         """
-        num_faces = len(self.face_width)
+        num_faces = len(self.width_of_face)
         self._link_at_face = numpy.empty(num_faces, dtype=int)
         face_id = 0
         for link in range(self.number_of_links):

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -2531,11 +2531,11 @@ class ModelGrid(ModelDataFieldsMixIn):
         ...      0., 1., 2., 1., 2.,
         ...      0., 0., 2., 2., 0.]
         >>> u = np.array(u)
-        >>> grad = rmg.calc_grad_at_active_link(u)
+        >>> grad = rmg.calc_grad_at_link(u)[rmg.active_links]
         >>> grad
         array([ 1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1.,  1.,  1., -1.,
                 1., -1.,  0.,  1.])
-        >>> flux = -grad    # downhill flux proportional to gradient
+        >>> flux = - grad    # downhill flux proportional to gradient
         >>> divflux = rmg.calculate_flux_divergence_at_core_nodes(flux)
         >>> divflux
         array([ 2.,  4., -2.,  0.,  1., -4.])

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -3214,12 +3214,21 @@ class ModelGrid(ModelDataFieldsMixIn):
         Examples
         --------
         >>> import numpy as np
-        >>> import landlab as ll
-        >>> mg = ll.RasterModelGrid((3, 4), spacing=(1., 1.))
+        >>> from landlab import RasterModelGrid
+
+        >>> grid = RasterModelGrid((3, 4), spacing=(1., 1.))
         >>> h = np.array([ 2., 2., 8., 0.,
         ...                8., 0., 3., 0.,
         ...                5., 6., 8., 3.])
-        >>> mg.max_of_link_end_node_values(h)
+
+        >>> grid.max_of_link_end_node_values(h)
+        array([ 2.,  8.,  8.,  3.,  3.,  6.,  8.])
+
+        Note that this method is *deprecatd*. The alternative is to use
+        ``map_max_of_link_nodes_to_link``.
+
+        >>> vals = grid.map_max_of_link_nodes_to_link(h)
+        >>> vals[grid.active_links]
         array([ 2.,  8.,  8.,  3.,  3.,  6.,  8.])
         """
         return numpy.maximum(node_data[self._activelink_fromnode],

--- a/landlab/grid/divergence.py
+++ b/landlab/grid/divergence.py
@@ -67,8 +67,13 @@ def calc_flux_div_at_node(grid, unit_flux, out=None):
     -----
     Performs a numerical flux divergence operation on nodes.
     """
+    if unit_flux.size not in (grid.number_of_links, grid.number_of_faces):
+        raise ValueError('Parameter unit_flux must be num links or num faces '
+                         'long')
     if out is None:
         out = grid.zeros(at='node')
+    elif out.size != grid.number_of_nodes:
+        raise ValueError('output buffer length mismatch with number of nodes')
 
     if unit_flux.size == grid.number_of_links:
         out[grid.node_at_cell] = _calc_net_face_flux_at_cell(grid, 
@@ -77,10 +82,7 @@ def calc_flux_div_at_node(grid, unit_flux, out=None):
     elif unit_flux.size == grid.number_of_faces:
         out[grid.node_at_cell] = _calc_net_face_flux_at_cell(grid, unit_flux) \
                                 / grid.area_of_cell
-    else:
-        assert (unit_flux.size == grid.number_of_links or
-                unit_flux.size == grid.number_of_faces), \
-                'Parameter unit_flux must be num links or num faces long'
+
     return out
 
 

--- a/landlab/grid/divergence.py
+++ b/landlab/grid/divergence.py
@@ -232,7 +232,7 @@ def _calc_net_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
     """
     if out is None:
         out = grid.empty(at='cell')
-    total_flux = unit_flux_at_faces * grid.face_width
+    total_flux = unit_flux_at_faces * grid.width_of_face
     out = np.zeros(grid.number_of_cells)
     fac = grid.faces_at_cell
     for c in range(grid.link_dirs_at_node.shape[1]):
@@ -357,7 +357,7 @@ def _calc_net_active_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
     """
     if out is None:
         out = grid.empty(at='cell')
-    total_flux = unit_flux_at_faces * grid.face_width
+    total_flux = unit_flux_at_faces * grid.width_of_face
     out = np.zeros(grid.number_of_cells)
     fac = grid.faces_at_cell
     for c in range(grid.active_link_dirs_at_node.shape[1]):

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -140,7 +140,7 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     array([ 1.,  1.,  0.,  0.,  0.,  2.,  2.])
     """
     if out is None:
-        out = grid.empty(centering='active_link')
+        out = grid.empty(at='active_link')
     return np.divide(node_values[grid._activelink_tonode] -
                      node_values[grid._activelink_fromnode],
                      grid.length_of_link[grid.active_links], out=out)
@@ -192,7 +192,7 @@ def calculate_gradients_at_faces(grid, node_values, out=None):
     array([ 5. ,  5. ,  3.6,  3.6,  5. , -1.4, -3.6, -5. , -5. , -3.6, -3.6])
     """
     if out is None:
-        out = grid.empty(centering='face')
+        out = grid.empty(at='face')
     laf = grid.link_at_face
     return np.divide(node_values[grid.node_at_link_head[laf]] -
                      node_values[grid.node_at_link_tail[laf]],
@@ -235,7 +235,7 @@ def calc_diff_at_link(grid, node_values, out=None):
     array([ 0.,  0.,  0.,  1.,  0.,  1., -1.,  0., -1.,  0.,  0.,  0.])
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
     node_values = np.asarray(node_values)
     return np.subtract(node_values[grid.node_at_link_head],
                        node_values[grid.node_at_link_tail], out=out)
@@ -275,7 +275,7 @@ def calculate_diff_at_active_links(grid, node_values, out=None):
         Differences across active links.
     """
     if out is None:
-        out = grid.empty(centering='active_link')
+        out = grid.empty(at='active_link')
     node_values = np.asarray(node_values)
     return np.subtract(node_values[grid._activelink_tonode],
                        node_values[grid._activelink_fromnode], out=out)

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -74,6 +74,25 @@ def calc_grad_at_link(grid, node_values, out=None):
 
 @deprecated(use='calc_grad_at_link', version='1.0beta')
 def calc_grad_of_active_link(grid, node_values, out=None):
+    """Calculate gradients at active links.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from landlab import RasterModelGrid
+    >>> grid = RasterModelGrid((3, 4))
+    >>> z = np.array([0., 0., 0., 0.,
+    ...               1., 1., 1., 1.,
+    ...               3., 3., 3., 3.])
+    >>> grid.calc_grad_of_active_link(z)
+    array([ 1.,  1.,  0.,  0.,  0.,  2.,  2.])
+
+    This method is *deprecated*. Instead, use ``calc_grad_at_link``.
+
+    >>> vals = grid.calc_grad_at_link(z)
+    >>> vals[grid.active_links]
+    array([ 1.,  1.,  0.,  0.,  0.,  2.,  2.])
+    """
     return calc_grad_at_active_link(grid, node_values, out)
 
 
@@ -102,6 +121,23 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     -------
     ndarray
         Gradients across active links.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from landlab import RasterModelGrid
+    >>> grid = RasterModelGrid((3, 4))
+    >>> z = np.array([0., 0., 0., 0.,
+    ...               1., 1., 1., 1.,
+    ...               3., 3., 3., 3.])
+    >>> grid.calc_grad_at_active_link(z)
+    array([ 1.,  1.,  0.,  0.,  0.,  2.,  2.])
+
+    This method is *deprecated*. Instead, use ``calc_grad_at_link``.
+
+    >>> vals = grid.calc_grad_at_link(z)
+    >>> vals[grid.active_links]
+    array([ 1.,  1.,  0.,  0.,  0.,  2.,  2.])
     """
     if out is None:
         out = grid.empty(centering='active_link')
@@ -208,8 +244,7 @@ def calc_diff_at_link(grid, node_values, out=None):
 @deprecated(use='calc_diff_at_link', version='1.0beta')
 @use_field_name_or_array('node')
 def calculate_diff_at_links(grid, node_values, out=None):
-    """Calculate differences of node values over links.
-    """
+    """Calculate differences of node values over links."""
     return calc_diff_at_link(grid, node_values, out)
 
 

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -208,7 +208,7 @@ def calc_diff_at_link(grid, node_values, out=None):
 
     Construction::
 
-        calculate_diff_at_links(grid, node_values, out=None)
+        calc_diff_at_link(grid, node_values, out=None)
 
     Parameters
     ----------
@@ -231,7 +231,7 @@ def calc_diff_at_link(grid, node_values, out=None):
     >>> rmg = RasterModelGrid((3, 3))
     >>> z = np.zeros(9)
     >>> z[4] = 1.
-    >>> rmg.calculate_diff_at_links(z)
+    >>> rmg.calc_diff_at_link(z)
     array([ 0.,  0.,  0.,  1.,  0.,  1., -1.,  0., -1.,  0.,  0.,  0.])
     """
     if out is None:
@@ -244,7 +244,23 @@ def calc_diff_at_link(grid, node_values, out=None):
 @deprecated(use='calc_diff_at_link', version='1.0beta')
 @use_field_name_or_array('node')
 def calculate_diff_at_links(grid, node_values, out=None):
-    """Calculate differences of node values over links."""
+    """Calculate differences of node values over links.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from landlab import RasterModelGrid
+
+    >>> grid = RasterModelGrid((3, 3))
+    >>> z = np.zeros(9)
+    >>> z[4] = 1.
+
+    >>> grid.calculate_diff_at_links(z)
+    array([ 0.,  0.,  0.,  1.,  0.,  1., -1.,  0., -1.,  0.,  0.,  0.])
+
+    >>> grid.calc_diff_at_link(z)
+    array([ 0.,  0.,  0.,  1.,  0.,  1., -1.,  0., -1.,  0.,  0.,  0.])
+    """
     return calc_diff_at_link(grid, node_values, out)
 
 

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -120,7 +120,7 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     # active link, so we are multiplying the unit flux at each link by the
     # width of its corresponding face.
     flux = np.zeros(len(active_link_flux) + 1)
-    flux[:len(active_link_flux)] = active_link_flux * grid.face_width
+    flux[:len(active_link_flux)] = active_link_flux * grid.width_of_face
 
     # Next, we need to add up the incoming and outgoing fluxes.
     #

--- a/landlab/grid/grid_funcs.py
+++ b/landlab/grid/grid_funcs.py
@@ -94,21 +94,41 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.grid_funcs import calculate_flux_divergence_at_nodes
+
     >>> grid = RasterModelGrid((4, 5))
     >>> link_flux = np.ones(grid.number_of_active_links, dtype=float)
-    >>> calculate_flux_divergence_at_nodes(grid, link_flux)
+    >>> flux_at_node = calculate_flux_divergence_at_nodes(grid, link_flux)
     ...     # doctest: +NORMALIZE_WHITESPACE
+    >>> flux_at_node
     array([ 0.,  1.,  1.,  1.,  0.,
             1.,  0.,  0.,  0., -1.,
             1.,  0.,  0.,  0., -1.,
             0., -1., -1., -1.,  0.])
+    >>> flux_at_node[grid.core_nodes]
+    array([ 0., 0., 0., 0., 0., 0.])
+
+    This is *deprecated*. Instead use ``calc_flux_div_at_node`. Notice that
+    fluxes at non-core nodes are handled differently. However, these boundary
+    nodes don't have "flux" anyway and so should be ignored.
+
+    >>> grid = RasterModelGrid((4, 5))
+    >>> link_flux = grid.zeros(at='link')
+    >>> link_flux[grid.active_links] = 1.
+    >>> flux_at_node = grid.calc_flux_div_at_node(link_flux)
+    >>> flux_at_node
+    array([ 0.,  0.,  0.,  0.,  0.,
+            0.,  0.,  0.,  0.,  0.,
+            0.,  0.,  0.,  0.,  0.,
+            0.,  0.,  0.,  0.,  0.])
+    >>> flux_at_node[grid.core_nodes]
+    array([ 0., 0., 0., 0., 0., 0.])
     """
     assert len(active_link_flux) == grid.number_of_active_links, (
         "incorrect length of active_link_flux array")
 
     # If needed, create net_unit_flux array
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
     out.fill(0.)
     net_unit_flux = out
 

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -100,7 +100,7 @@ def map_link_head_node_to_link(grid, var_name, out=None):
     array([  1.,   2.,   3.,   4.,   5.,   6.,   7.,   5.,   6.,   7.,   8.,
              9.,  10.,  11.,   9.,  10.,  11.])
 
-    >>> values_at_links = rmg.empty(centering='link')
+    >>> values_at_links = rmg.empty(at='link')
     >>> rtn = map_link_head_node_to_link(rmg, 'z', out=values_at_links)
     >>> values_at_links
     array([  1.,   2.,   3.,   4.,   5.,   6.,   7.,   5.,   6.,   7.,   8.,
@@ -111,7 +111,7 @@ def map_link_head_node_to_link(grid, var_name, out=None):
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
     out[:] = var_name[grid.node_at_link_head]
 
     return out
@@ -160,7 +160,7 @@ def map_link_tail_node_to_link(grid, var_name, out=None):
     array([  0.,   1.,   2.,   0.,   1.,   2.,   3.,   4.,   5.,   6.,   4.,
              5.,   6.,   7.,   8.,   9.,  10.])
 
-    >>> values_at_links = rmg.empty(centering='link')
+    >>> values_at_links = rmg.empty(at='link')
     >>> rtn = map_link_tail_node_to_link(rmg, 'z', out=values_at_links)
     >>> values_at_links
     array([  0.,   1.,   2.,   0.,   1.,   2.,   3.,   4.,   5.,   6.,   4.,
@@ -169,7 +169,7 @@ def map_link_tail_node_to_link(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
@@ -220,7 +220,7 @@ def map_min_of_link_nodes_to_link(grid, var_name, out=None):
     array([  0.,   1.,   2.,   0.,   1.,   2.,   3.,   6.,   5.,   4.,   7.,
              6.,   5.,   4.,   8.,   9.,  10.])
 
-    >>> values_at_links = rmg.empty(centering='link')
+    >>> values_at_links = rmg.empty(at='link')
     >>> rtn = map_min_of_link_nodes_to_link(rmg, 'z', out=values_at_links)
     >>> values_at_links
     array([  0.,   1.,   2.,   0.,   1.,   2.,   3.,   6.,   5.,   4.,   7.,
@@ -229,7 +229,7 @@ def map_min_of_link_nodes_to_link(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
@@ -281,7 +281,7 @@ def map_max_of_link_nodes_to_link(grid, var_name, out=None):
     array([  1.,   2.,   3.,   7.,   6.,   5.,   4.,   7.,   6.,   5.,   8.,
              9.,  10.,  11.,   9.,  10.,  11.])
 
-    >>> values_at_links = rmg.empty(centering='link')
+    >>> values_at_links = rmg.empty(at='link')
     >>> rtn = map_max_of_link_nodes_to_link(rmg, 'z', out=values_at_links)
     >>> values_at_links
     array([  1.,   2.,   3.,   7.,   6.,   5.,   4.,   7.,   6.,   5.,   8.,
@@ -290,7 +290,7 @@ def map_max_of_link_nodes_to_link(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
@@ -341,7 +341,7 @@ def map_mean_of_link_nodes_to_link(grid, var_name, out=None):
     array([  0.5,   1.5,   2.5,   2. ,   3. ,   4. ,   5. ,   4.5,   5.5,
              6.5,   6. ,   7. ,   8. ,   9. ,   8.5,   9.5,  10.5])
 
-    >>> values_at_links = rmg.empty(centering='link')
+    >>> values_at_links = rmg.empty(at='link')
     >>> rtn = map_mean_of_link_nodes_to_link(rmg, 'z', out=values_at_links)
     >>> values_at_links
     array([  0.5,   1.5,   2.5,   2. ,   3. ,   4. ,   5. ,   4.5,   5.5,
@@ -350,7 +350,7 @@ def map_mean_of_link_nodes_to_link(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
@@ -414,7 +414,7 @@ def map_value_at_min_node_to_link(grid, control_name, value_name, out=None):
              40.,   70.,   60.,   50.,   40.,   80.,   90.,  100.])
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(control_name) is str:
         control_name = grid.at_node[control_name]
@@ -483,7 +483,7 @@ def map_value_at_max_node_to_link(grid, control_name, value_name, out=None):
              50.,   80.,   90.,  100.,  110.,   90.,  100.,  110.])
     """
     if out is None:
-        out = grid.empty(centering='link')
+        out = grid.empty(at='link')
 
     if type(control_name) is str:
         control_name = grid.at_node[control_name]
@@ -536,7 +536,7 @@ def map_node_to_cell(grid, var_name, out=None):
     >>> map_node_to_cell(rmg, 'z')
     array([ 5.,  6.])
 
-    >>> values_at_cells = rmg.empty(centering='cell')
+    >>> values_at_cells = rmg.empty(at='cell')
     >>> rtn = map_node_to_cell(rmg, 'z', out=values_at_cells)
     >>> values_at_cells
     array([ 5.,  6.])
@@ -544,7 +544,7 @@ def map_node_to_cell(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='cell')
+        out = grid.empty(at='cell')
 
     if type(var_name) is str:
         var_name = grid.at_node[var_name]
@@ -603,7 +603,7 @@ def map_min_of_node_links_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     values_at_linksX = np.empty(grid.number_of_links+1, dtype=float)
     values_at_linksX[-1] = np.finfo(dtype=float).max
@@ -666,7 +666,7 @@ def map_max_of_node_links_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     values_at_linksX = np.empty(grid.number_of_links+1, dtype=float)
     values_at_linksX[-1] = np.finfo(dtype=float).min
@@ -737,7 +737,7 @@ def map_upwind_node_link_max_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(var_name) is str:
         var_name = grid.at_link[var_name]
@@ -806,7 +806,7 @@ def map_downwind_node_link_max_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(var_name) is str:
         var_name = grid.at_link[var_name]
@@ -876,7 +876,7 @@ def map_upwind_node_link_mean_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(var_name) is str:
         var_name = grid.at_link[var_name]
@@ -950,7 +950,7 @@ def map_downwind_node_link_mean_to_node(grid, var_name, out=None):
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(var_name) is str:
         var_name = grid.at_link[var_name]
@@ -1032,7 +1032,7 @@ def map_value_at_upwind_node_link_max_to_node(grid, control_name,
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(control_name) is str:
         control_name = grid.at_link[control_name]
@@ -1116,7 +1116,7 @@ def map_value_at_downwind_node_link_max_to_node(grid, control_name,
     True
     """
     if out is None:
-        out = grid.empty(centering='node')
+        out = grid.empty(at='node')
 
     if type(control_name) is str:
         control_name = grid.at_link[control_name]

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3058,7 +3058,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         ...               9., 3., 9.,
         ...               6., 9., 6.])
         >>> grid = RasterModelGrid((3, 3), spacing=(3, 4))
-        >>> grads = grid.calc_grad_at_active_link(z)
+        >>> grads = grid.calc_grad_at_link(z)[grid.active_links]
         >>> max_grad, dest_node = (
         ...     grid._calculate_steepest_descent_on_nodes(z, grads))
         >>> max_grad # doctest: +NORMALIZE_WHITESPACE
@@ -3162,7 +3162,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         ...      0., 1., 2., 1., 2.,
         ...      0., 0., 2., 2., 0.]
         >>> u = np.array(u)
-        >>> grad = rmg.calc_grad_at_active_link(u)
+        >>> grad = rmg.calc_grad_at_link(u)[rmg.active_links]
         >>> grad
         array([ 1.,  1., -1.,  1.,  1., -1.,  1., -1., -1., -1.,  1.,  1., -1.,
                 1., -1.,  0.,  1.])

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3953,6 +3953,32 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         (slope, aspect) : tuple of float
             *slope*, a len(ids) array of slopes at each node provided.
             *aspect*, a len(ids) array of aspects at each node provided.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> grid = RasterModelGrid((3, 4), (4, 4))
+        >>> z = np.array([0., 0., 0., 0.,
+        ...               3., 3., 3., 3,
+        ...               6., 6., 6., 6.])
+        >>> (slope,
+        ...  aspect) = grid.calculate_slope_aspect_at_nodes_burrough(vals=z)
+        >>> np.tan(slope)
+        array([ 0.75,  0.75])
+        >>> np.degrees(aspect)
+        array([ 180.,  180.])
+
+        This method is *deprecated*. Use ``calc_slope_at_node`` and
+        ``calc_aspect_at_node`` instead. Notice that ``calc_slope_at_node``
+        and ``calc_aspect_at_node`` return values for all nodes, not just
+        core nodes. In addition, ``calc_aspect_at_node`` returns compass-style
+        angles in degrees.
+
+        >>> np.tan(grid.calc_slope_at_node(elevs=z)[grid.core_nodes])
+        array([ 0.75,  0.75])
+        >>> grid.calc_aspect_at_node(elevs=z)[grid.core_nodes]
+        array([ 180.,  180.])
         """
         if ids is None:
             ids = self.node_at_cell

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -295,7 +295,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     (4, 5)
     >>> rmg.number_of_active_links
     17
-    >>> vals = rmg.add_zeros('active_link', 'vals')
+    >>> vals = rmg.add_zeros('vals', at='active_link')
     >>> vals.size
     17
 
@@ -307,7 +307,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     (4, 5)
     >>> rmg.number_of_active_links
     14
-    >>> vals = rmg.add_zeros('active_link', 'vals')
+    >>> vals = rmg.add_zeros('vals', at='active_link')
     >>> vals.size
     14
 
@@ -3186,6 +3186,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
         In this case, the function will not have to create the df array.
         """
+        if out is None:
+            out = self.zeros(at='node')
         return rfuncs.calculate_flux_divergence_at_nodes(
             self, active_link_flux, out=out)
 
@@ -3572,7 +3574,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                     self.closed_boundary_nodes)] = bad_index
         return self.diagonal_cells
 
-    @deprecated(use='is_core', version='0.5')
+    @deprecated(use='node_is_core', version='0.5')
     def is_interior(self, *args):
         """is_interior([ids])
         Check of a node is an interior node.

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -32,7 +32,7 @@ from . import gradients
 
 
 @deprecated(use='grid.node_has_boundary_neighbor', version='0.2')
-def node_has_boundary_neighbor(mg, id, method='d8'):
+def _node_has_boundary_neighbor(mg, id, method='d8'):
     """Test if a node is next to a boundary.
 
     Test if one of the neighbors of node *id* is a boundary node.
@@ -106,8 +106,8 @@ def _make_arg_into_array(arg):
     return ids
 
 
-node_has_boundary_neighbor = np.vectorize(node_has_boundary_neighbor,
-                                     excluded=['mg'])
+_node_has_boundary_neighbor = np.vectorize(_node_has_boundary_neighbor,
+                                           excluded=['mg'])
 
 
 class RasterModelGridPlotter(object):
@@ -3484,7 +3484,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             ...
         IndexError: index 25 is out of bounds for axis 0 with size 25
         """
-        ans = node_has_boundary_neighbor(self, ids, method=method)
+        ans = _node_has_boundary_neighbor(self, ids, method=method)
 
         if ans.ndim == 0:
             return bool(ans)

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3787,7 +3787,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         --------
         >>> from landlab import RasterModelGrid
         >>> grid = RasterModelGrid((3, 3))
-        >>> grid.face_width
+        >>> grid.width_of_face
         array([ 1.,  1.,  1.,  1.])
         """
         n_horizontal_faces = (self.shape[0] - 2) * (self.shape[1] - 1)

--- a/landlab/grid/raster_funcs.py
+++ b/landlab/grid/raster_funcs.py
@@ -179,12 +179,12 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     Calculate the gradient of values at a grid's nodes.
 
     >>> from landlab import RasterModelGrid
-    >>> rmg = RasterModelGrid(4, 5, 1.0)
+    >>> rmg = RasterModelGrid((4, 5), spacing=1.0)
     >>> u = np.array([0., 1., 2., 3., 0.,
     ...               1., 2., 3., 2., 3.,
     ...               0., 1., 2., 1., 2.,
     ...               0., 0., 2., 2., 0.])
-    >>> grad = rmg.calc_grad_at_active_link(u)
+    >>> grad = rmg.calc_grad_at_link(u)[rmg.active_links]
     >>> grad # doctest: +NORMALIZE_WHITESPACE
     array([ 1.,  1., -1.,
             1.,  1., -1.,  1.,
@@ -216,9 +216,12 @@ def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     >>> df = rmg.calculate_flux_divergence_at_nodes(flux, out=df)
 
     >>> grid = RasterModelGrid((4, 5), spacing=(1, 2))
-    >>> grad = grid.calc_grad_at_active_link(2 * u)
-    >>> grad
-    ...     # doctest: +NORMALIZE_WHITESPACE
+    >>> u = np.array([0., 1., 2., 3., 0.,
+    ...               1., 2., 3., 2., 3.,
+    ...               0., 1., 2., 1., 2.,
+    ...               0., 0., 2., 2., 0.])
+    >>> grad = grid.calc_grad_at_link(2 * u)[grid.active_links]
+    >>> grad # doctest: +NORMALIZE_WHITESPACE
     array([ 2.,  2., -2.,
             1.,  1., -1.,  1.,
            -2., -2., -2.,

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -68,7 +68,7 @@ def calc_grad_at_link(grid, node_values, out=None):
     >>> grid.calc_grad_at_link('elevation')
     array([ 0.,  0.,  1.,  3.,  1.,  1., -1.,  1., -1.,  1.,  0.,  0.])
     """
-    grads = gradients.calculate_diff_at_links(grid, node_values, out=out)
+    grads = gradients.calc_diff_at_link(grid, node_values, out=out)
     grads /= grid.length_of_link
 
 #    n_vertical_links = (grid.shape[0] - 1) * grid.shape[1]
@@ -137,10 +137,19 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     >>> grid.calc_grad_at_active_link(node_values)
     array([ 3.,  1., -1., -1.])
     """
-    grads = gradients.calculate_diff_at_active_links(grid, node_values,
-                                                     out=out)
-    grads /= grid.length_of_link[grid.active_links]
-    return grads
+    if out is None:
+        out = grid.empty(at='active_link')
+
+    if len(out) != grid.number_of_active_links:
+        raise ValueError('output buffer does not match that of the grid.')
+
+    # grads = gradients.calculate_diff_at_active_links(grid, node_values,
+    #                                                  out=out)
+    grads = gradients.calc_diff_at_link(grid, node_values)
+    out[:] = grads[grid.active_links]
+    out /= grid.length_of_link[grid.active_links]
+
+    return out
 
 
 @use_field_name_or_array('node')

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -136,6 +136,15 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     ...                2., 2., 2.]
     >>> grid.calc_grad_at_active_link(node_values)
     array([ 3.,  1., -1., -1.])
+
+    This function is *deprecated*. Instead, use ``calc_grad_at_link``.
+
+    >>> grid = RasterModelGrid((3, 3), spacing=(1, 2))
+    >>> node_values = [0., 0., 0.,
+    ...                1., 3., 1.,
+    ...                2., 2., 2.]
+    >>> grid.calc_grad_at_link(node_values)[grid.active_links]
+    array([ 3.,  1., -1., -1.])
     """
     if out is None:
         out = grid.empty(at='active_link')

--- a/landlab/grid/tests/test_raster_funcs/test_gradients_at_active_links.py
+++ b/landlab/grid/tests/test_raster_funcs/test_gradients_at_active_links.py
@@ -25,7 +25,7 @@ def setup_grids():
 def test_unit_spacing():
     """Test with a grid with unit spacing."""
     rmg, values_at_nodes = _GRIDS['unit'], np.arange(20)
-    grads = rmg.calc_grad_at_active_link(values_at_nodes)
+    grads = rmg.calc_grad_at_link(values_at_nodes)[rmg.active_links]
 
     assert_array_equal(grads,
                        np.array([5.0, 5.0, 5.0,
@@ -43,7 +43,7 @@ def test_non_unit_spacing():
     """Test with a grid with non-unit spacing."""
     rmg, values_at_nodes = _GRIDS['non_square'], np.arange(20)
 
-    grads = rmg.calc_grad_at_active_link(values_at_nodes)
+    grads = rmg.calc_grad_at_link(values_at_nodes)[rmg.active_links]
     assert_array_equal(grads,
                        np.array([1.0, 1.0, 1.0,
                                  0.5, 0.5, 0.5, 0.5,
@@ -64,10 +64,9 @@ def test_out_array():
     """Test using the out keyword."""
     rmg, values_at_nodes = _GRIDS['non_square'], np.arange(20)
 
-    output_array = np.empty(17)
-    rtn_array = rmg.calc_grad_at_active_link(values_at_nodes,
-                                                        out=output_array)
-    assert_array_equal(rtn_array,
+    output_array = np.empty(rmg.number_of_links)
+    rtn_array = rmg.calc_grad_at_link(values_at_nodes, out=output_array)
+    assert_array_equal(rtn_array[rmg.active_links],
                        np.array([1.0, 1.0, 1.0,
                                  0.5, 0.5, 0.5, 0.5,
                                  1.0, 1.0, 1.0,

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -194,11 +194,11 @@ def test_diagonal_list_boundary():
 
 
 @with_setup(setup_grid)
-def test_is_interior():
+def test_node_is_core():
     for cell_id in [0, 1, 2, 3, 4, 5, 9, 10, 14, 15, 16, 17, 18, 19]:
-        assert_false(rmg.is_interior(cell_id))
+        assert_false(rmg.node_is_core(cell_id))
     for cell_id in [6, 7, 8, 11, 12, 13]:
-        assert_true(rmg.is_interior(cell_id))
+        assert_true(rmg.node_is_core(cell_id))
 
 
 @with_setup(setup_grid)

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -455,7 +455,7 @@ def imshow_grid(grid, values, **kwds):
         values = grid.field_values(values_at, values)
 
     if values_at == 'node':
-        imshow_node_grid(grid, values, **kwds)
+        imshow_grid_at_node(grid, values, **kwds)
     elif values_at == 'cell':
         imshow_cell_grid(grid, values, **kwds)
     else:

--- a/landlab/plot/video_out.py
+++ b/landlab/plot/video_out.py
@@ -116,7 +116,7 @@ class VideoPlotter(object):
         # initialize the plots for the vid
         if data_centering == 'node':
             self.centering = 'n'
-            self.plotfunc = imshow.imshow_node_grid
+            self.plotfunc = imshow.imshow_grid_at_node
         elif data_centering == 'cell':
             self.centering = 'c'
             self.plotfunc = imshow.imshow_cell_grid

--- a/landlab/tests/speed_test_model_grid.py
+++ b/landlab/tests/speed_test_model_grid.py
@@ -12,15 +12,15 @@ def main():
 
     nt = 1000
 
-    s = mg.zeros(centering='node')
-    g = mg.zeros(centering='active_link')
-    divg = mg.zeros(centering='node')
+    s = mg.zeros(at='node')
+    g = mg.zeros(at='link')
+    divg = mg.zeros(at='node')
 
     start_time = time.time()
 
     for i in range(nt):
 
-        g = mg.calc_grad_of_active_link(s, g)
+        g = mg.calc_grad_at_link(s, out=g)
 
     time1 = time.time()
 

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -258,9 +258,12 @@ def deprecated(use, version):
 
         @wraps(func)
         def _wrapped(*args, **kwargs):
-            warnings.warn(
-                message="Call to deprecated function {name}.".format(
-                    name=func.__name__), category=DeprecationWarning)
+            if func.__name__.startswith('_'):
+                pass
+            else:
+                warnings.warn(
+                    message="Call to deprecated function {name}.".format(
+                        name=func.__name__), category=DeprecationWarning)
             return func(*args, **kwargs)
         _wrapped.__dict__.update(func.__dict__)
 

--- a/landlab/utils/fault_facet_finder.py
+++ b/landlab/utils/fault_facet_finder.py
@@ -151,9 +151,9 @@ class find_facets(object):
         # solution - take a dip_dir input...
         angle_to_ft = (angle_to_ft + np.pi) % (2. * np.pi)
         self.angle_to_ft[subset] = angle_to_ft
-        #gridshow.imshow_node_grid(self.grid, self.distance_to_ft)
+        #gridshow.imshow_grid_at_node(self.grid, self.distance_to_ft)
         # show()
-        #gridshow.imshow_node_grid(self.grid, self.angle_to_ft)
+        #gridshow.imshow_grid_at_node(self.grid, self.angle_to_ft)
         # show()
         # the relevant condition is now that the local aspect and angle to fault
         # are the same...
@@ -172,20 +172,20 @@ class find_facets(object):
         self.diff_angles = np.empty(grid.core_nodes.size, dtype=float)
         self.diff_angles.fill(sys.float_info.max)
         self.diff_angles[subset] = diff_angles
-        #gridshow.imshow_node_grid(self.grid, self.angle_to_ft)
+        #gridshow.imshow_grid_at_node(self.grid, self.angle_to_ft)
         # show()
         figure(6)
-        gridshow.imshow_node_grid(self.grid, np.where(
+        gridshow.imshow_grid_at_node(self.grid, np.where(
             self.diff_angles < 100000., self.diff_angles, -1.))
         condition2 = np.less(diff_angles, angle_tolerance * np.pi / 180.)
         condition = np.logical_and(condition, condition2)
         core_nodes_size_condition = np.zeros(grid.core_nodes.size, dtype=bool)
         core_nodes_size_condition[subset] = condition
-        #gridshow.imshow_node_grid(self.grid, core_nodes_size_condition)
+        #gridshow.imshow_grid_at_node(self.grid, core_nodes_size_condition)
         # show()
         #core_nodes_size_condition = np.zeros(grid.core_nodes.size, dtype=bool)
         #core_nodes_size_condition[subset] = condition2
-        #gridshow.imshow_node_grid(self.grid, core_nodes_size_condition)
+        #gridshow.imshow_grid_at_node(self.grid, core_nodes_size_condition)
         # show()
         self.aspect_close_nodes = core_nodes_size_condition
         print('Calculated and stored nodes with aspects compatible with fault trace...')
@@ -205,7 +205,7 @@ class find_facets(object):
         threshold_in_rads = threshold_in_degrees * np.pi / 180.
         self.steep_nodes = np.greater(self.slopes, threshold_in_rads)
         print('Calculated and stored nodes with slopes exceeding slope threshold...')
-        #gridshow.imshow_node_grid(self.grid, self.steep_nodes)
+        #gridshow.imshow_grid_at_node(self.grid, self.steep_nodes)
         # show()
         return self.steep_nodes
 
@@ -218,13 +218,13 @@ class find_facets(object):
         possible_core_nodes = np.logical_and(
             self.steep_nodes, self.aspect_close_nodes)
         figure(1)
-        gridshow.imshow_node_grid(self.grid, self.elevs)
+        gridshow.imshow_grid_at_node(self.grid, self.elevs)
         figure(2)
-        gridshow.imshow_node_grid(self.grid, self.slopes)
+        gridshow.imshow_grid_at_node(self.grid, self.slopes)
         figure(3)
-        gridshow.imshow_node_grid(self.grid, self.aspect)
+        gridshow.imshow_grid_at_node(self.grid, self.aspect)
         figure(4)
-        gridshow.imshow_node_grid(self.grid, possible_core_nodes)
+        gridshow.imshow_grid_at_node(self.grid, possible_core_nodes)
         show()
 
     def find_coherent_facet_patches(self, tolerance=3., threshold_num_px=12):


### PR DESCRIPTION
This pull request removes usages of many (but not all) deprecated functions/methods. Most of the remaining usages are either private methods, in doctests for the deprecated functions themselves, or not straightforward to convert to an alternative.

Note that in this pull request I have disabled warnings for methods that start with an underscore. This can easily be turned back on.

@SiccarPoint: One problem I had was with active links. The `active_links` attribute doesn't seem to ever include active *diagonal* links. This is a problem when replacing `grid.calc_grad_at_active_link()` with `calc_grad_at_link()[grid.active_links]`.

@saisiddu: In the radiation component when I switched from,
```python
self._slope, self._aspect = grid.calculate_slope_aspect_at_nodes_burrough(vals='topographic__elevation')
```
to
```python
elevation = grid.at_node['topographic__elevation']
self._slope = grid.calc_slope_at_node(elevs=elevation)[grid.core_nodes]
self._aspect = np.radians(grid.calc_aspect_at_node(elevs=elevation)[grid.core_nodes])
```
I got slightly different results so I stuck with the original. I still would like to figure out what's going on there. Do you have any ideas?