### PR TITLE
Resolve issues around `length_of_link`

### DIFF
--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -354,7 +354,7 @@ class ChiFinder(Component):
         """
         receivers = self.grid.at_node['flow__receiver_node']
         links = self.grid.at_node['flow__link_to_receiver_node']
-        link_lengths = self.grid.length_of_link
+        link_lengths = self.grid._length_of_link_with_diagonals
         # because chi_array is all zeros, BC cases where node is receiver
         # resolve themselves
         half_integrand = 0.5 * chi_integrand_at_nodes
@@ -404,7 +404,8 @@ class ChiFinder(Component):
         """
         ch_links = self.grid.at_node['flow__link_to_receiver_node'][ch_nodes]
         ch_links_valid = ch_links[ch_links != BAD_INDEX_VALUE]
-        valid_link_lengths = self.grid.length_of_link[ch_links_valid]
+        valid_link_lengths = self.grid._length_of_link_with_diagonals[
+            ch_links_valid]
         return valid_link_lengths.mean()
 
     @property

--- a/landlab/components/flow_routing/flow_direction_DN.py
+++ b/landlab/components/flow_routing/flow_direction_DN.py
@@ -235,7 +235,7 @@ def flow_directions(elev, active_links, fromnode, tonode, link_slope,
                 links_list[:, 6] = grid._diagonal_links_at_node[non_boundary_nodes, 0]
                 links_list[:, 7] = grid._diagonal_links_at_node[non_boundary_nodes, 3]  # final order SW,NW,NE,SE
                 elevs_array = np.where(neighbor_nodes!=-1, elev[neighbor_nodes], np.finfo(float).max/1000.)
-            slope_array = (elev[non_boundary_nodes].reshape((non_boundary_nodes.size, 1)) - elevs_array)/grid.length_of_link[links_list]
+            slope_array = (elev[non_boundary_nodes].reshape((non_boundary_nodes.size, 1)) - elevs_array)/grid._length_of_link_with_diagonals[links_list]
             axis_indices = np.argmax(slope_array, axis=1)
             steepest_slope[non_boundary_nodes] = slope_array[np.indices(axis_indices.shape),axis_indices]
             downslope = np.greater(steepest_slope, 0.)

--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -267,7 +267,7 @@ class DepressionFinderAndRouter(Component):
             self._link_lengths[1] = dy
             self._link_lengths[3] = dy
         else:
-            self._link_lengths = self._grid.length_of_link
+            self._link_lengths = self._grid._length_of_link_with_diagonals
         self._lake_outlets = []  # a list of each unique lake outlet
         # ^note this is nlakes-long
 

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -294,7 +294,7 @@ class SteepnessFinder(Component):
         ch_dists = np.empty_like(ch_nodes, dtype=float)
         # dists from ch head, NOT drainage divide
         ch_dists[0] = 0.
-        np.cumsum(self.grid.length_of_link[ch_links[:-1]],
+        np.cumsum(self.grid._length_of_link_with_diagonals[ch_links[:-1]],
                   out=ch_dists[1:])
         return ch_dists
 

--- a/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
+++ b/landlab/components/stream_power/examples/test_script_for_fastscape_stream_power.py
@@ -54,7 +54,8 @@ for i in range(grid.number_of_nodes):
 
 # Calculate lengths of flow links
 flow_link_length = np.ones(np.size(z))
-flow_link_length[interior_nodes] = grid.length_of_link[rl[interior_nodes]] #DEJH suspects a node ordering bug here - rl is not in ID order, but interior_nodes is
+flow_link_length[interior_nodes] = grid._length_of_link_with_diagonals[
+    rl[interior_nodes]] #DEJH suspects a node ordering bug here - rl is not in ID order, but interior_nodes is
 print('fll:', flow_link_length)
 
 # Get a 2D array version of the elevations

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -298,8 +298,9 @@ class FastscapeEroder(Component):
         z = self._grid['node']['topographic__elevation']
         defined_flow_receivers = numpy.not_equal(self._grid['node'][
             'flow__link_to_receiver_node'], UNDEFINED_INDEX)
-        flow_link_lengths = self._grid.length_of_link[self._grid['node'][
-            'flow__link_to_receiver_node'][defined_flow_receivers]]
+        flow_link_lengths = self._grid._length_of_link_with_diagonals[
+            self._grid['node']['flow__link_to_receiver_node'][
+                defined_flow_receivers]]
 
         # make arrays from input the right size
         if type(self.K) is numpy.ndarray:

--- a/landlab/components/stream_power/sed_flux_dep_incision.py
+++ b/landlab/components/stream_power/sed_flux_dep_incision.py
@@ -620,8 +620,8 @@ class SedDepEroder(Component):
         core_draining_nodes = np.intersect1d(np.where(draining_nodes)[0],
                                              grid.core_nodes,
                                              assume_unique=True)
-        link_length[core_draining_nodes] = grid.length_of_link[grid.at_node[
-            steepest_link][core_draining_nodes]]
+        link_length[core_draining_nodes] = grid._length_of_link_with_diagonals[
+            grid.at_node[steepest_link][core_draining_nodes]]
 
         if self.Qc == 'MPM':
             if self.Dchar_in is not None:

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -426,8 +426,9 @@ class StreamPowerEroder(Component):
         upstream_order_IDs = self._grid['node']['flow__upstream_node_order']
         defined_flow_receivers = np.not_equal(self._grid['node'][
             'flow__link_to_receiver_node'], UNDEFINED_INDEX)
-        flow_link_lengths = self._grid.length_of_link[self._grid['node'][
-            'flow__link_to_receiver_node'][defined_flow_receivers]]
+        flow_link_lengths = self._grid._length_of_link_with_diagonals[
+            self._grid['node']['flow__link_to_receiver_node'][
+                defined_flow_receivers]]
         active_nodes = np.where(grid.status_at_node != CLOSED_BOUNDARY)[0]
         flow_receivers = self.grid['node']['flow__receiver_node']
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -2787,6 +2787,19 @@ class ModelGrid(ModelDataFieldsMixIn):
         else:
             return self._link_length
 
+    @property
+    def _length_of_link_with_diagonals(self):
+        """A dummy function, equivalent to `length_of_link` for the base class.
+
+        This method is required to maintain grid class generality in several
+        of the flow routing and stream power components. It is overridden in
+        RasterModelGrid only.
+
+        This method will be removed when LL's handling of diagonal links is
+        modernized.
+        """
+        return self.length_of_link
+
     def _create_length_of_link(self):
         """Get array of the lengths of all links.
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -2120,12 +2120,47 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     def length_of_link(self):
         """Get lengths of links.
 
-        Return the link lengths in the grid, as a nlinks-long array. This
-        method *does* test if diagonal links are present in the grid already;
-        if they are, return a longer array where the orthogonal links are
-        listed first, in ID order, then the diagonal links (i.e., diagonal
+        Return the link lengths in the grid, as a nlinks-long array.
+
+        Returns
+        -------
+        (4, N) ndarray
+            Link lengths.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> grid = RasterModelGrid((3, 3), spacing=(3, 4))
+        >>> grid.length_of_link
+        array([ 4.,  4.,  3.,  3.,  3.,  4.,  4.,  3.,  3.,  3.,  4.,  4.])
+
+        >>> grid = RasterModelGrid((3, 3), spacing=(4, 3))
+        >>> _ = grid._diagonal_links_at_node
+        >>> grid.length_of_link # doctest: +NORMALIZE_WHITESPACE
+        array([ 3.,  3.,  4.,  4.,  4.,
+                3.,  3.,  4.,  4.,  4.,
+                3.,  3.,  5.,  5.,  5.,
+                5.,  5.,  5.,  5.,  5.])
+        """
+        if self._link_length is None:
+            return self._create_length_of_link()
+        else:
+            return self._link_length[:self.number_of_links]
+
+    @property
+    def _length_of_link_with_diagonals(self):
+        """Get lengths of links, with diagonal IDs following orthogonal IDs.
+
+        Return the link lengths in the grid, as a nlinks-plus-ndiagonallinks-
+        long array, if diagonals are already present. This method *does* test
+        if diagonal links are present in the grid already; if they are,
+        returns a longer array where the orthogonal links are listed first,
+        in ID order, then the diagonal links (i.e., diagonal
         links have effective ID numbers which count up from the number of
         orthogonal links).
+
+        If diagonals have not been created, returns the same array as
+        :func:`length_of_link`.
 
         Returns
         -------

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -69,7 +69,7 @@ def calc_grad_at_link(grid, node_values, out=None):
     array([ 0.,  0.,  1.,  3.,  1.,  1., -1.,  1., -1.,  1.,  0.,  0.])
     """
     grads = gradients.calc_diff_at_link(grid, node_values, out=out)
-    grads /= grid.length_of_link[:grid.number_of_links]
+    grads /= grid.length_of_link
 
 #    n_vertical_links = (grid.shape[0] - 1) * grid.shape[1]
 #    diffs[:n_vertical_links] /= grid.dy

--- a/landlab/plot/channel_profile.py
+++ b/landlab/plot/channel_profile.py
@@ -53,18 +53,15 @@ def channel_nodes(grid, steepest_nodes, drainage_area, flow_receiver, number_of_
     return profile_IDs
 
 
-def get_distances_upstream(grid, len_node_arrays, profile_IDs, links_to_flow_receiver):
-    #defined_flow_receivers = numpy.greater_equal(links_to_flow_receiver,-1)
-    #flow_link_lengths = numpy.empty(len_node_arrays, dtype=float)
-    #flow_link_lengths[defined_flow_receivers] = grid.length_of_link[links_to_flow_receiver[defined_flow_receivers]]
-    # print numpy.sum(defined_flow_receivers)
+def get_distances_upstream(grid, len_node_arrays, profile_IDs,
+                           links_to_flow_receiver):
     distances_upstream = []
     for i in range(len(profile_IDs)):
         data_store = []
         total_distance = 0.
         data_store.append(total_distance)
         for j in range(len(profile_IDs[i]) - 1):
-            total_distance += grid.length_of_link[
+            total_distance += grid._length_of_link_with_diagonals[
                 links_to_flow_receiver[profile_IDs[i][j + 1]]]
             data_store.append(total_distance)
         distances_upstream.append(numpy.array(data_store))


### PR DESCRIPTION
As noted by user Laijingtao, there are potential issues around our
handling of `length_of_link` on rasters once diagonal links are created.

Formerly, `length_of_link` would be extended with diagonal links if
they had been created. This was documented, but was not obvious
behaviour. Now, this behaviour is only performed by the new internal
property, `_length_of_link_with_diagonals`. `length_of_link` itself
always now only returns the lengths of “true” Landlab links.

Code base updated so that the existing methods using `length_of_link`
now point to the right variant.

Note that the internal property will be removed along with all
RasterModelGrid class diagonal properties once a child class handling
diagonals explicitly exists.