### PR TITLE
Resolve bug

### DIFF
--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -160,7 +160,7 @@ class LinearDiffuser(Component):
                                          noclobber=True)
             # ^note this will object if this exists already
         except FieldError:
-            self.g = self.grid.at_link['topographic__gradient'] # keep a ref
+            self.g = self.grid.at_link['topographic__gradient']  # keep a ref
         try:
             self.qs = self.grid.add_field('link', 'unit_flux', qs,
                                           noclobber=True)

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -2604,13 +2604,13 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         >>> grid.length_of_link
         array([ 4.,  4.,  3.,  3.,  3.,  4.,  4.,  3.,  3.,  3.,  4.,  4.])
 
+        Since LL version 1, this method is unaffected by the existance or
+        otherwise of diagonal links on the grid:
+
         >>> grid = RasterModelGrid((3, 3), spacing=(4, 3))
         >>> _ = grid._diagonal_links_at_node
         >>> grid.length_of_link # doctest: +NORMALIZE_WHITESPACE
-        array([ 3.,  3.,  4.,  4.,  4.,
-                3.,  3.,  4.,  4.,  4.,
-                3.,  3.,  5.,  5.,  5.,
-                5.,  5.,  5.,  5.,  5.])
+        array([ 3.,  3.,  4.,  4.,  4.,  3.,  3.,  4.,  4.,  4.,  3.,  3.])
         """
         if self._link_length is None:
             self._create_length_of_link()
@@ -2642,15 +2642,14 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         --------
         >>> from landlab import RasterModelGrid
         >>> grid = RasterModelGrid((3, 3), spacing=(3, 4))
+
         >>> grid.length_of_link
         array([ 4.,  4.,  3.,  3.,  3.,  4.,  4.,  3.,  3.,  3.,  4.,  4.])
 
-        >>> grid = RasterModelGrid((3, 3), spacing=(4, 3))
-        >>> _ = grid._diagonal_links_at_node
-        >>> grid.length_of_link # doctest: +NORMALIZE_WHITESPACE
-        array([ 3.,  3.,  4.,  4.,  4.,
-                3.,  3.,  4.,  4.,  4.,
-                3.,  3.,  5.,  5.,  5.,
+        >>> grid._length_of_link_with_diagonals # doctest: +NORMALIZE_WHITESPACE
+        array([ 4.,  4.,  3.,  3.,  3.,
+                4.,  4.,  3.,  3.,  3.,
+                4.,  4.,  5.,  5.,  5.,
                 5.,  5.,  5.,  5.,  5.])
         """
         if self._link_length is None:
@@ -2665,7 +2664,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         --------
         >>> from landlab import RasterModelGrid
         >>> grid = RasterModelGrid((3, 4), spacing=(2, 3))
-        >>> grid._create_length_of_link() # doctest: +NORMALIZE_WHITESPACE
+        >>> grid._create_length_of_link()[
+        ...     :grid.number_of_links] # doctest: +NORMALIZE_WHITESPACE
         array([ 3., 3., 3.,
                 2., 2., 2., 2.,
                 3., 3., 3.,
@@ -2674,11 +2674,11 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
 
         >>> grid = RasterModelGrid((3, 3), spacing=(1, 2))
         >>> grid._create_length_of_link() # doctest: +NORMALIZE_WHITESPACE
-        array([ 2., 2.,
-                1., 1., 1.,
-                2., 2.,
-                1., 1., 1.,
-                2., 2.])
+        array([ 2.        ,  2.        ,  1.        ,  1.        ,
+                1.        ,  2.        ,  2.        ,  1.        ,
+                1.        ,  1.        ,  2.        ,  2.        ,
+                2.23606798,  2.23606798,  2.23606798,  2.23606798,
+                2.23606798,  2.23606798,  2.23606798,  2.23606798])
 
         Notes
         -----

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -2613,7 +2613,8 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                 5.,  5.,  5.,  5.,  5.])
         """
         if self._link_length is None:
-            return self._create_length_of_link()
+            self._create_length_of_link()
+            return self._link_length[:self.number_of_links]
         else:
             return self._link_length[:self.number_of_links]
 
@@ -2685,13 +2686,11 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         the horizontal links in that row to dx.
         """
         if self._link_length is None:
-            if self._diagonal_links_created:
-                self._link_length = np.empty(
-                    self.number_of_links + self._number_of_diagonal_links)
-                self._link_length[self.number_of_links:] = np.sqrt(
-                    self._dy ** 2. + self._dx ** 2.)
-            else:
-                self._link_length = self.empty(centering='link', dtype=float)
+            self._create_diag_links_at_node()
+            self._link_length = np.empty(
+                self.number_of_links + self._number_of_diagonal_links)
+            self._link_length[self.number_of_links:] = np.sqrt(
+                self._dy ** 2. + self._dx ** 2.)
 
             vertical_links = squad_links.vertical_link_ids(self.shape)
 

--- a/landlab/grid/tests/test_raster_grid/test_link_length.py
+++ b/landlab/grid/tests/test_raster_grid/test_link_length.py
@@ -1,5 +1,5 @@
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 from nose.tools import with_setup
 
 from landlab import RasterModelGrid
@@ -19,13 +19,17 @@ def setup_grid():
 
 @with_setup(setup_unit_grid)
 def test_unit_spacing():
-    lengths = _RMG._create_length_of_link()
+    lengths_incl_diags = _RMG._create_length_of_link()
+    lengths = _RMG.length_of_link
+    assert_array_equal(lengths_incl_diags[:_RMG.number_of_links], np.ones(31))
     assert_array_equal(lengths, np.ones(31))
+    assert_array_almost_equal(lengths_incl_diags[_RMG.number_of_links:],
+                              np.sqrt(2.)*np.ones(24))
 
 
 @with_setup(setup_grid)
 def test_non_unit_spacing():
-    assert_array_equal(_RMG._create_length_of_link(),
+    assert_array_equal(_RMG._create_length_of_link()[:_RMG.number_of_links],
                        [4., 4., 4., 4.,
                         3., 3., 3., 3., 3.,
                         4., 4., 4., 4.,
@@ -33,6 +37,9 @@ def test_non_unit_spacing():
                         4., 4., 4., 4.,
                         3., 3., 3., 3., 3.,
                         4., 4., 4., 4.])
+
+    assert_array_equal(_RMG._create_length_of_link()[_RMG.number_of_links:],
+                       5.*np.ones(24))
 
 
 @with_setup(setup_grid)


### PR DESCRIPTION
length_of_link now behaves internally consistently. It always returns
the number of true links, including on first call.

Also resolve associated issue where it was possible to begin using some
diagonal methods on the raster without having created all of the
diagonal link structures.