### PR TITLE
SiccarPoint/angle of link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,7 @@ Fluvial geomorphology
    :maxdepth: 4
 
    landlab.components.stream_power
+   landlab.components.detachment_ltd_erosion
 
 Flow routing
 ------------

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -290,9 +290,8 @@ class LinearDiffuser(Component):
             self._all_d8_active_links = np.union1d(
                 self.grid.active_links, self.grid._diag_active_links)
 
-        self._angle_of_link = self.grid.angle_of_link()
-        self._vertlinkcomp = np.sin(self._angle_of_link)
-        self._hozlinkcomp = np.cos(self._angle_of_link)
+        self._vertlinkcomp = np.sin(self.grid.angle_of_link)
+        self._hozlinkcomp = np.cos(self.grid.angle_of_link)
 
         if self._use_patches or self._kd_on_links:
             mg = self.grid

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -87,6 +87,7 @@ Information about links
 
     ~landlab.grid.base.ModelGrid.active_links
     ~landlab.grid.base.ModelGrid.angle_of_link
+    ~landlab.grid.base.ModelGrid.angle_of_link_about_head
     ~landlab.grid.base.ModelGrid.face_at_link
     ~landlab.grid.base.ModelGrid.fixed_links
     ~landlab.grid.base.ModelGrid.length_of_link
@@ -2035,16 +2036,53 @@ class ModelGrid(ModelDataFieldsMixIn):
         else:
             raise ValueError('only zero or one arguments accepted')
 
-    def angle_of_link(self, links='all', dirs=-1):
-        """Find and return the angle of link(s) in given direction.
+    @property
+    @make_return_array_immutable
+    def angle_of_link(self):
+        """Find and return the angle of a link about the node at the link tail.
 
-        Parameters
-        ----------
-        links : 1d numpy array or 'all'
-            one or more link IDs
-        dirs : 1d numpy array (must be same length as links)
-            direction of links relative to node: +1 means head is origin;
-            -1 means tail is origin.
+        Examples
+        --------
+        >>> from landlab import HexModelGrid
+        >>> mg = HexModelGrid(3, 2)
+        >>> mg.angle_of_link / np.pi * 3.  # 60 degree segments
+        array([ 0.,  2.,  1.,  2.,  1.,  0.,  0.,  1.,  2.,  1.,  2.,  0.])
+        """
+        try:
+            if not self._angle_of_link_created:
+                self._create_angle_of_link()
+        except AttributeError:
+            self._create_angle_of_link()
+        return self._angle_of_link_bothends[-1]
+
+    @property
+    @make_return_array_immutable
+    def angle_of_link_about_head(self):
+        """Find and return the angle of a link about the node at the link head.
+
+        Because links have direction, their angle can be specified as an angle
+        about either the node at the link head, or the node at the link tail.
+        The default behaviour of `angle_of_link` is to return the angle about
+        the link tail, but this method gives the angle about the link head.
+
+        Examples
+        --------
+        >>> from landlab import HexModelGrid
+        >>> mg = HexModelGrid(3, 2)
+        >>> mg.angle_of_link_about_head[:3] / np.pi * 3.  # 60 deg segments
+        array([ 3.,  5.,  4.])
+        """
+        try:
+            if not self._angle_of_link_created:
+                self._create_angle_of_link()
+        except AttributeError:
+            self._create_angle_of_link()
+        return self._angle_of_link_bothends[1]
+
+    def _create_angle_of_link(self):
+        """
+        Build a dict with keys (-1, 1) that contains the angles of the links
+        about both the link heads (1) and link tails (-1).
 
         Notes
         -----
@@ -2055,45 +2093,34 @@ class ModelGrid(ModelDataFieldsMixIn):
         negative and clockwise from the positive x axis. We want them
         counter-clockwise, which is what the last couple of lines before
         the return statement do.
-
-        Examples
-        --------
-        >>> from landlab import HexModelGrid
-        >>> mg = HexModelGrid(3, 2)
-        >>> mg.angle_of_link() / np.pi * 3.  # 60 degree segments
-        array([ 0.,  2.,  1.,  2.,  1.,  0.,  0.,  1.,  2.,  1.,  2.,  0.])
-
-         First 3 links only, angle from head this time:
-
-        >>> mg.angle_of_link(np.arange(3), 1.) / np.pi * 3.
-        array([ 3.,  5.,  4.])
         """
-        if links != 'all':
-            dx = -dirs * (self.node_x[self.node_at_link_head[links]] -
-                          self.node_x[self.node_at_link_tail[links]])
-            dy = -dirs * (self.node_y[self.node_at_link_head[links]] -
-                          self.node_y[self.node_at_link_tail[links]])
-        else:
+        self._angle_of_link_bothends = {}
+        for dirs in (-1, 1):
             dx = -dirs * (self.node_x[self.node_at_link_head] -
                           self.node_x[self.node_at_link_tail])
             dy = -dirs * (self.node_y[self.node_at_link_head] -
                           self.node_y[self.node_at_link_tail])
-        ang = np.arctan2(dy, dx)
-        (lower_two_quads, ) = np.where(ang < 0.0)
-        ang[lower_two_quads] = (2 * np.pi) + ang[lower_two_quads]
-        (no_link, ) = np.where(dirs == 0)
-        ang[no_link] = 2*np.pi
-        return ang
+            ang = np.arctan2(dy, dx)
+            (lower_two_quads, ) = np.where(ang < 0.0)
+            ang[lower_two_quads] = (2 * np.pi) + ang[lower_two_quads]
+            (no_link, ) = np.where(dirs == 0)
+            ang[no_link] = 2*np.pi
+            self._angle_of_link_bothends[dirs] = ang.copy()
+        self._angle_of_link_created = True
 
     def _sort_links_at_node_by_angle(self):
         """Sort the links_at_node and link_dirs_at_node arrays by angle.
         """
-        for n in range(self.number_of_nodes):
-            ang = self.angle_of_link(self.links_at_node[n, :],
-                                     self.link_dirs_at_node[n, :])
-            indices = np.argsort(ang)
-            self._links_at_node[n, :] = self._links_at_node[n, indices]
-            self._link_dirs_at_node[n, :] = self._link_dirs_at_node[n, indices]
+        ang = self.angle_of_link[self.links_at_node]
+        linkhead_at_node = self.link_dirs_at_node == 1
+        ang[linkhead_at_node] = self.angle_of_link_about_head[
+            self.links_at_node[linkhead_at_node]]
+        ang[self.link_dirs_at_node == 0] = 100.
+        argsorted = np.argsort(ang, axis=1)
+        indices = np.indices(ang.shape)[0] * ang.shape[1] + argsorted
+        self._links_at_node.flat = self._links_at_node.flat[indices.flatten()]
+        self._link_dirs_at_node.flat = self._link_dirs_at_node.flat[
+            indices.flatten()]
 
     def resolve_values_on_links(self, link_values, out=None):
         """Resolve the xy-components of links.

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -111,6 +111,7 @@ Information about links
     ~landlab.grid.hex.HexModelGrid.active_link_dirs_at_node
     ~landlab.grid.hex.HexModelGrid.active_links
     ~landlab.grid.hex.HexModelGrid.angle_of_link
+    ~landlab.grid.hex.HexModelGrid.angle_of_link_about_head
     ~landlab.grid.hex.HexModelGrid.downwind_links_at_node
     ~landlab.grid.hex.HexModelGrid.face_at_link
     ~landlab.grid.hex.HexModelGrid.fixed_links

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -1451,7 +1451,7 @@ def map_link_vector_sum_to_patch(grid, var_name, ignore_inactive_links=True,
 
     if type(var_name) is str:
         var_name = grid.at_link[var_name]
-    angles_at_links = grid.angle_of_link()  # CCW round tail
+    angles_at_links = grid.angle_of_link  # CCW round tail
     hoz_cpt = np.cos(angles_at_links)
     vert_cpt = np.sin(angles_at_links)
     hoz_vals = var_name * hoz_cpt

--- a/landlab/grid/radial.py
+++ b/landlab/grid/radial.py
@@ -113,6 +113,7 @@ Information about links
     ~landlab.grid.radial.RadialModelGrid.active_link_dirs_at_node
     ~landlab.grid.radial.RadialModelGrid.active_links
     ~landlab.grid.radial.RadialModelGrid.angle_of_link
+    ~landlab.grid.radial.RadialModelGrid.angle_of_link_about_head
     ~landlab.grid.radial.RadialModelGrid.downwind_links_at_node
     ~landlab.grid.radial.RadialModelGrid.face_at_link
     ~landlab.grid.radial.RadialModelGrid.fixed_links

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -132,6 +132,7 @@ Information about links
     ~landlab.grid.raster.RasterModelGrid.active_link_dirs_at_node
     ~landlab.grid.raster.RasterModelGrid.active_links
     ~landlab.grid.raster.RasterModelGrid.angle_of_link
+    ~landlab.grid.raster.RasterModelGrid.angle_of_link_about_head
     ~landlab.grid.raster.RasterModelGrid.downwind_links_at_node
     ~landlab.grid.raster.RasterModelGrid.face_at_link
     ~landlab.grid.raster.RasterModelGrid.fixed_links

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -105,6 +105,7 @@ Information about links
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.active_link_dirs_at_node
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.active_links
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.angle_of_link
+    ~landlab.grid.voronoi.VoronoiDelaunayGrid.angle_of_link_about_head
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.downwind_links_at_node
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.face_at_link
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.fixed_links


### PR DESCRIPTION
Modify code such that `angle_of_link` is a property not a function. The
ability to specify the end of the link about which to measure angle is
replaced by a new property, `angle_of_link_about_head` (`angle_of_link`
is about the tail end, by default).

Modifications were only necessary in one place to accommodate this new
style.