### PR TITLE
Gt debug cts

### DIFF
--- a/landlab/ca/celllab_cts.py
+++ b/landlab/ca/celllab_cts.py
@@ -129,7 +129,7 @@ import landlab
 import numpy as np
 import pylab as plt
 
-_USE_CYTHON = True
+_USE_CYTHON = False
 
 if _USE_CYTHON:
     from .cfuncs import do_transition
@@ -406,8 +406,6 @@ class CellLabCTSModel(object):
 
         # Keep a copy of the model grid; remember how many active links in it
         self.grid = model_grid
-        ###self._active_links_at_node = self.grid._active_links_at_node()
-        self._active_links_at_node = self.grid._active_links_at_node2()
 
         # Initialize random number generation
         np.random.seed(seed)
@@ -811,9 +809,13 @@ class CellLabCTSModel(object):
 
         if _DEBUG:
             print('get_next_event():')
+            print(('  current state:', current_state))
+            print(('  node pair:', self.node_pair[current_state]))
             print(('  next_time:', my_event.time))
             print(('  link:', my_event.link))
             print(('  xn_to:', my_event.xn_to))
+            print(('  nxn:', self.n_xn[current_state]))
+            print(('  rate:', self.xn_rate[current_state][:]))
             print(('  propswap:', my_event.propswap))
 
         return my_event
@@ -895,23 +897,16 @@ class CellLabCTSModel(object):
             Current time in simulation
         """
         if _DEBUG:
-            print('update_link_state() link ' + str(link) + ' to state ' + str(new_link_state))
+            print('update_link_state() link ' + str(link) + ' to state ' + str(new_link_state) + ' at time ' + str(current_time))
 
         # If the link connects to a boundary, we might have a different state
         # than the one we planned
-        # if self.grid.status_at_node[self.grid.link_fromnode[link]]!=_CORE or \
-        #   self.grid.status_at_node[self.grid.link_tonode[link]]!=_CORE:
         if self.bnd_lnk[link]:
             fns = self.node_state[self.grid.node_at_link_tail[link]]
             tns = self.node_state[self.grid.node_at_link_head[link]]
             orientation = self.link_orientation[link]
-            ##actual_pair = (fns,tns,orientation)
-            ##new_link_state = self.link_state_dict[actual_pair]
             new_link_state = orientation * self.num_node_states_sq + \
                 fns * self.num_node_states + tns
-            #assert new_link_state==new_link_state2, 'oops'
-#            if _DEBUG:
-#                print('**Boundary: overriding new link state to',new_link_state)
 
         self.link_state[link] = new_link_state
         if self.n_xn[new_link_state] > 0:
@@ -1043,12 +1038,6 @@ class CellLabCTSModel(object):
             # want to track), implement the swap.
             #   If the event requires a call to a user-defined callback
             # function, we handle that here too.
-#            print('trcts')
-#            print(tail_node)
-#            print(head_node)
-#            print(self.propid[tail_node])
-#            print(self.propid[head_node])
-#            print(self.prop_reset_value)
             if event.propswap:
                 tmp = self.propid[tail_node]
                 self.propid[tail_node] = self.propid[head_node]
@@ -1102,14 +1091,14 @@ class CellLabCTSModel(object):
         self.push_transitions_to_event_queue()
 
     #@profile
-    def run(self, run_duration, node_state_grid=None,
+    def run(self, run_to, node_state_grid=None,
             plot_each_transition=False, plotter=None):
         """Run the model forward for a specified period of time.
 
         Parameters
         ----------
-        run_duration : float
-            Length of time to run
+        run_to : float
+            Time to run to, starting from self.current_time
         node_state_grid : 1D array of ints (x number of nodes) (optional)
             Node states (if given, replaces model's current node state grid)
         plot_each_transition : bool (optional)
@@ -1121,40 +1110,49 @@ class CellLabCTSModel(object):
             self.set_node_state_grid(node_state_grid)
        
         # Continue until we've run out of either time or events
-        while self.current_time < run_duration and self.event_queue:
+        while self.current_time < run_to and self.event_queue:
 
             if _DEBUG:
                 print('Current Time = ', self.current_time)
 
-            # Pick the next transition event from the event queue
-            ev = heappop(self.event_queue)
+            # Is there an event scheduled to occur within this run?
+            if self.event_queue[0].time <= run_to:
 
-            if _DEBUG:
-                print('Event:', ev.time, ev.link, ev.xn_to)
+                # If so, pick the next transition event from the event queue
+                ev = heappop(self.event_queue)
 
-            if _USE_CYTHON:
-                do_transition(ev, self.next_update,
-                              self.grid.node_at_link_tail,
-                              self.grid.node_at_link_head,
-                              self.node_state, self.link_state,
-                              self.san, self.link_orientation,
-                              self.propid, self.prop_data,
-                              self.n_xn, self.xn_to, self.xn_rate,
-                              self.grid.links_at_node,
-                              self.grid.active_link_dirs_at_node,
-                              self.num_node_states, self.num_node_states_sq,
-                              self.prop_reset_value, self.xn_propswap,
-                              self.xn_prop_update_fn,
-                              self.bnd_lnk, self.event_queue,
-                              self,
-                              plot_each_transition,
-                              plotter)
+                if _DEBUG:
+                    print('Event:', ev.time, ev.link, ev.xn_to)
+    
+                # ... and execute the transition
+                if _USE_CYTHON:
+                    do_transition(ev, self.next_update,
+                                  self.grid.node_at_link_tail,
+                                  self.grid.node_at_link_head,
+                                  self.node_state, self.link_state,
+                                  self.san, self.link_orientation,
+                                  self.propid, self.prop_data,
+                                  self.n_xn, self.xn_to, self.xn_rate,
+                                  self.grid.links_at_node,
+                                  self.grid.active_link_dirs_at_node,
+                                  self.num_node_states, self.num_node_states_sq,
+                                  self.prop_reset_value, self.xn_propswap,
+                                  self.xn_prop_update_fn,
+                                  self.bnd_lnk, self.event_queue,
+                                  self,
+                                  plot_each_transition,
+                                  plotter)
+                else:
+                    self.do_transition(ev, self.current_time,
+                                       plot_each_transition, plotter)
+
+                # Update current time
+                self.current_time = ev.time
+                
+            # If there is no event scheduled for this span of time, simply
+            # advance current_time to the end of the current run period.
             else:
-                self.do_transition(ev, self.current_time,
-                                   plot_each_transition, plotter)
-
-            # Update current time
-            self.current_time = ev.time
+                self.current_time = run_to
 
 
 if __name__ == "__main__":

--- a/landlab/ca/tests/test_celllab_cts.py
+++ b/landlab/ca/tests/test_celllab_cts.py
@@ -91,7 +91,6 @@ def test_raster_cts():
     assert (ca.num_link_states==4), 'wrong number of link states'
     assert (ca.prop_data[5]==50), 'error in property data'
     assert (ca.xn_rate[2][0]==0.1), 'error in transition rate array'
-    assert (ca._active_links_at_node[1][6]==8), 'error in active link array'
     assert (ca.num_node_states==2), 'error in num_node_states'
     assert (ca.link_orientation[-1]==0), 'error in link orientation array'
     assert (ca.link_state_dict[(1, 0, 0)]==2), 'error in link state dict'


### PR DESCRIPTION
This PR fixes a bug in which the "run" method in CellLab CTS could run further than its "run_to" parameter, if an event occurred later. Also cythonizes another function. test-installed-landlab passes.