### PR TITLE
Gt fix lake bug

### DIFF
--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -406,7 +406,12 @@ class DepressionFinderAndRouter(Component):
             print('Unable to find drainage outlet for a lake.')
             print('In lake with these nodes:')
             for i in nodes_this_depression:
-                print((i, self._elev[i], self.flood_status[i], self._grid.status_at_node[i], self._node_nbrs[i], self._elev[self._node_nbrs[i]], self.flood_status[self._node_nbrs[i]], self._grid.status_at_node[self._node_nbrs[i]]))
+                print((i, self._elev[i], self.flood_status[i]), end="") 
+                print((self._grid.status_at_node[i]), end="")
+                print((self._node_nbrs[i]), end="")
+                print((self._elev[self._node_nbrs[i]]) , end="")
+                print((self.flood_status[self._node_nbrs[i]]), end="")
+                print((self._grid.status_at_node[self._node_nbrs[i]]))
         assert (lowest_elev < self._BIG_ELEV), \
             'failed to find lowest perim node'
         return lowest_node

--- a/landlab/components/flow_routing/lake_mapper.py
+++ b/landlab/components/flow_routing/lake_mapper.py
@@ -16,7 +16,6 @@ from landlab.grid.base import BAD_INDEX_VALUE as LOCAL_BAD_INDEX_VALUE
 # LOCAL_BAD_INDEX_VALUE = np.iinfo(np.int32).max
 import landlab
 
-
 # Codes for depression status
 _UNFLOODED = 0
 _PIT = 1
@@ -403,6 +402,11 @@ class DepressionFinderAndRouter(Component):
                             self.flood_status[nbr] == _FLOODED:
                         nodes_this_depression.append(nbr)
                         self.flood_status[nbr] = _CURRENT_LAKE
+        if lowest_elev == self._BIG_ELEV:
+            print('Unable to find drainage outlet for a lake.')
+            print('In lake with these nodes:')
+            for i in nodes_this_depression:
+                print((i, self._elev[i], self.flood_status[i], self._grid.status_at_node[i], self._node_nbrs[i], self._elev[self._node_nbrs[i]], self.flood_status[self._node_nbrs[i]], self._grid.status_at_node[self._node_nbrs[i]]))
         assert (lowest_elev < self._BIG_ELEV), \
             'failed to find lowest perim node'
         return lowest_node


### PR DESCRIPTION
This PR just adds some diagnostic output for the case when the lake-fill algorithm can't find an outlet. This can happen if, for example, the user accidentally passes it a watershed DEM with no outlet node(s) specified (i.e., surrounded by closed nodes), or if there is an isolated pocket of core node(s) surrounded by closed boundary nodes.