### PR TITLE
Implement cython for flow_accum_bw

### DIFF
--- a/landlab/components/flow_accum/cfuncs.pyx
+++ b/landlab/components/flow_accum/cfuncs.pyx
@@ -1,0 +1,31 @@
+import numpy as np
+cimport numpy as np
+cimport cython
+
+
+DTYPE = np.int
+ctypedef np.int_t DTYPE_INT_t
+
+
+@cython.boundscheck(False)
+cpdef _add_to_stack(DTYPE_INT_t l, DTYPE_INT_t j,
+                    np.ndarray[DTYPE_INT_t, ndim=1] s,
+                    np.ndarray[DTYPE_INT_t, ndim=1] delta,
+                    np.ndarray[DTYPE_INT_t, ndim=1] donors):
+
+    """
+    Adds node l to the stack and increments the current index (j).
+    """
+    cdef int m, n, delta_l, delta_lplus1
+
+    s[j] = l
+    j += 1
+    delta_l = delta[l]
+    delta_lplus1 = delta[l+1]
+
+    for n in range(delta_l, delta_lplus1):
+        m = donors[n]
+        if m != l:
+            j = _add_to_stack(m, j, s, delta, donors)
+    
+    return j

--- a/landlab/components/flow_accum/flow_accum_bw.py
+++ b/landlab/components/flow_accum/flow_accum_bw.py
@@ -25,6 +25,7 @@ If you simply want the ordered list by itself, use::
 Created: GT Nov 2013
 """
 from six.moves import range
+from .cfuncs import _add_to_stack
 
 import numpy
 
@@ -60,19 +61,8 @@ class _DrainageStack():
         >>> ds.s
         array([4, 1, 0, 2, 5, 6, 3, 8, 7, 9])
         """
-        self.s[self.j] = l
-        self.j += 1
-        #make some aliases to make the weave faster & better
-        delta = self.delta
-        D = self.D
-        add_it = self.add_to_stack
-        delta_l = int(numpy.take(delta,l))
-        delta_lplus1 = int(numpy.take(delta,l+1))
-
-        for n in range(delta_l, delta_lplus1):
-            m = self.D[n]
-            if m != l:
-                self.add_to_stack(m)
+        # we invoke cython here to attempt to suppress Python's RecursionLimit
+        self.j = _add_to_stack(l, self.j, self.s, self.delta, self.D)
 
 
 def _make_number_of_donors_array(r):

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ ext_modules = [
               ['landlab/ca/cfuncs.pyx']),
     Extension('landlab.components.flexure.cfuncs',
               ['landlab/components/flexure/cfuncs.pyx']),
+    Extension('landlab.components.flow_accum.cfuncs',
+              ['landlab/components/flow_accum/cfuncs.pyx']),
     Extension('landlab.components.flow_routing.cfuncs',
               ['landlab/components/flow_routing/cfuncs.pyx']),
     Extension('landlab.components.stream_power.cfuncs',


### PR DESCRIPTION
Implements cython for the recursive flow accumulation method
`add_to_stack`, aiming to fix Kelly’s issues with hitting Python’s
inbuilt recursion limit. Also seems to accelerate the component
significantly.

This changes duplicated in a pull about to go in to the master branch.