### PR TITLE
Add fields for patches and corners

### DIFF
--- a/landlab/field/field_mixin.py
+++ b/landlab/field/field_mixin.py
@@ -2,8 +2,8 @@
 from .grouped import ModelDataFields, GroupSizeError
 
 
-_GROUPS = ('node', 'cell', 'link', 'face', 'core_node', 'core_cell',
-           'active_link', 'active_face', )
+_GROUPS = ('node', 'link', 'patch', 'corner', 'face', 'cell', 'core_node',
+           'core_cell', 'active_link', 'active_face', )
 
 
 class ModelDataFieldsMixIn(ModelDataFields):

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -404,8 +404,8 @@ Use the groups attribute to see the group names.
 >>> groups = list(grid.groups)
 >>> groups.sort()
 >>> groups # doctest: +NORMALIZE_WHITESPACE
-['active_face', 'active_link', 'cell', 'core_cell', 'core_node', 'face',
- 'link', 'node']
+['active_face', 'active_link', 'cell', 'core_cell', 'core_node', 'corner',
+ 'face', 'link', 'node', 'patch']
 
 Create Field Arrays
 +++++++++++++++++++

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -172,6 +172,15 @@ Information about patches
     ~landlab.grid.base.ModelGrid.patches_present_at_link
     ~landlab.grid.base.ModelGrid.patches_present_at_node
 
+Information about corners
++++++++++++++++++++++++++
+
+.. autosummary::
+    :toctree: generated/
+
+    ~landlab.grid.base.ModelGrid.number_of_corners
+
+
 Data Fields in ModelGrid
 ------------------------
 :class:`~.ModelGrid` inherits from the :class:`~.ModelDataFields` class. This
@@ -194,6 +203,8 @@ itself that provide access to the values groups:
     ~landlab.grid.base.ModelGrid.at_cell
     ~landlab.grid.base.ModelGrid.at_link
     ~landlab.grid.base.ModelGrid.at_face
+    ~landlab.grid.base.ModelGrid.at_patch
+    ~landlab.grid.base.ModelGrid.at_corner
 
 Each of these attributes returns a ``dict``-like object whose keys are value
 names as strings and values are numpy arrays that gives quantities at
@@ -1595,7 +1606,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> grid.number_of_corners
         12
 
-        LLCATS: NINF
+        LLCATS: CNINF
         """
         return self.number_of_patches
 

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -485,6 +485,10 @@ BAD_INDEX_VALUE = -1
 # of that element in the grid.
 _ARRAY_LENGTH_ATTRIBUTES = {
     'node': 'number_of_nodes',
+    'patch': 'number_of_patches',
+    'link': 'number_of_links',
+    'corner': 'number_of_corners',
+    'face': 'number_of_faces',
     'cell': 'number_of_cells',
     'link': 'number_of_links',
     'face': 'number_of_faces',
@@ -787,9 +791,11 @@ class ModelGrid(ModelDataFieldsMixIn):
     _DEBUG_TRACK_METHODS = False
 
     at_node = {}  # : Values defined at nodes
-    at_cell = {}  # : Values defined at cells
     at_link = {}  # : Values defined at links
+    at_patch = {}  # : Values defined at patches
+    at_corner = {}  # : Values defined at corners
     at_face = {}  # : Values defined at faces
+    at_cell = {}  # : Values defined at cells
     at_core_node = {}  # : Values defined at core nodes
     at_core_cell = {}  # : Values defined at core cells
     at_active_link = {}  # : Values defined at active links

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1593,7 +1593,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         >>> from landlab import RasterModelGrid
         >>> grid = RasterModelGrid((4, 5))
         >>> grid.number_of_corners
-        20
+        12
 
         LLCATS: NINF
         """

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1585,6 +1585,21 @@ class ModelGrid(ModelDataFieldsMixIn):
         return len(self._cell_at_node)
 
     @property
+    def number_of_corners(self):
+        """Total number of nodes.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> grid = RasterModelGrid((4, 5))
+        >>> grid.number_of_corners
+        20
+
+        LLCATS: NINF
+        """
+        return self.number_of_patches
+
+    @property
     def number_of_cells(self):
         """Total number of cells.
 

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -192,6 +192,15 @@ Information about patches
     ~landlab.grid.hex.HexModelGrid.patches_present_at_link
     ~landlab.grid.hex.HexModelGrid.patches_present_at_node
 
+Information about corners
++++++++++++++++++++++++++
+
+.. autosummary::
+    :toctree: generated/
+
+    ~landlab.grid.hex.HexModelGrid.number_of_corners
+
+
 Data Fields in ModelGrid
 ------------------------
 :class:`~.ModelGrid` inherits from the :class:`~.ModelDataFields` class. This
@@ -214,6 +223,8 @@ itself that provide access to the values groups:
     ~landlab.grid.hex.HexModelGrid.at_cell
     ~landlab.grid.hex.HexModelGrid.at_link
     ~landlab.grid.hex.HexModelGrid.at_face
+    ~landlab.grid.hex.HexModelGrid.at_patch
+    ~landlab.grid.hex.HexModelGrid.at_corner
 
 Each of these attributes returns a ``dict``-like object whose keys are value
 names as strings and values are numpy arrays that gives quantities at

--- a/landlab/grid/radial.py
+++ b/landlab/grid/radial.py
@@ -190,6 +190,15 @@ Information about patches
     ~landlab.grid.radial.RadialModelGrid.patches_present_at_link
     ~landlab.grid.radial.RadialModelGrid.patches_present_at_node
 
+Information about corners
++++++++++++++++++++++++++
+
+.. autosummary::
+    :toctree: generated/
+
+    ~landlab.grid.radial.RadialModelGrid.number_of_corners
+
+
 Data Fields in ModelGrid
 ------------------------
 :class:`~.ModelGrid` inherits from the :class:`~.ModelDataFields` class. This
@@ -212,6 +221,8 @@ itself that provide access to the values groups:
     ~landlab.grid.radial.RadialModelGrid.at_cell
     ~landlab.grid.radial.RadialModelGrid.at_link
     ~landlab.grid.radial.RadialModelGrid.at_face
+    ~landlab.grid.radial.RadialModelGrid.at_patch
+    ~landlab.grid.radial.RadialModelGrid.at_corner
 
 Each of these attributes returns a ``dict``-like object whose keys are value
 names as strings and values are numpy arrays that gives quantities at

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -227,6 +227,15 @@ Information about patches
     ~landlab.grid.raster.RasterModelGrid.patches_present_at_link
     ~landlab.grid.raster.RasterModelGrid.patches_present_at_node
 
+Information about corners
++++++++++++++++++++++++++
+
+.. autosummary::
+    :toctree: generated/
+
+    ~landlab.grid.raster.RasterModelGrid.number_of_corners
+
+
 Data Fields in ModelGrid
 ------------------------
 :class:`~.ModelGrid` inherits from the :class:`~.ModelDataFields` class. This
@@ -249,6 +258,8 @@ itself that provide access to the values groups:
     ~landlab.grid.raster.RasterModelGrid.at_cell
     ~landlab.grid.raster.RasterModelGrid.at_link
     ~landlab.grid.raster.RasterModelGrid.at_face
+    ~landlab.grid.raster.RasterModelGrid.at_patch
+    ~landlab.grid.raster.RasterModelGrid.at_corner
 
 Each of these attributes returns a ``dict``-like object whose keys are value
 names as strings and values are numpy arrays that gives quantities at

--- a/landlab/grid/tests/test_raster_grid/test_corners.py
+++ b/landlab/grid/tests/test_raster_grid/test_corners.py
@@ -1,0 +1,29 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_equal
+
+from landlab import RasterModelGrid
+
+
+def test_number_of_corners():
+    """Test number of corners on a raster."""
+    grid = RasterModelGrid((4, 5))
+    assert_equal(grid.number_of_corners, 12)
+
+
+def test_add_ones_at_corners():
+    """Test add a field to corners."""
+    grid = RasterModelGrid((4, 5))
+    grid.add_ones('z', at='corner')
+
+    assert_array_equal(grid.at_corner['z'],
+                       [1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])
+
+
+def test_add_field_at_corners():
+    """Test add a field to corners."""
+    grid = RasterModelGrid((4, 5))
+    x = np.arange(grid.number_of_corners)
+    grid.add_field('z', x, at='corner')
+
+    assert_array_equal(grid.at_corner['z'], x)

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -182,6 +182,15 @@ Information about patches
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.patches_present_at_link
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.patches_present_at_node
 
+Information about corners
++++++++++++++++++++++++++
+
+.. autosummary::
+    :toctree: generated/
+
+    ~landlab.grid.voronoi.VoronoiDelaunayGrid.number_of_corners
+
+
 Data Fields in ModelGrid
 ------------------------
 :class:`~.ModelGrid` inherits from the :class:`~.ModelDataFields` class. This
@@ -204,6 +213,8 @@ itself that provide access to the values groups:
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.at_cell
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.at_link
     ~landlab.grid.voronoi.VoronoiDelaunayGrid.at_face
+    ~landlab.grid.voronoi.VoronoiDelaunayGrid.at_patch
+    ~landlab.grid.voronoi.VoronoiDelaunayGrid.at_corner
 
 Each of these attributes returns a ``dict``-like object whose keys are value
 names as strings and values are numpy arrays that gives quantities at


### PR DESCRIPTION
This pull request add fields for both *patches* and *corners*. The following should now work,

```python
>>> from landlab import RasterModelGrid
>>> grid = RasterModelGrid((4, 5))
>>> grid.add_ones('z', at='corner')
>>> grid.at_corner['z']
array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.])
```
and likewise for *patches*. We can now create fields for:

* *nodes*, *links*, *patches*, and
* *corners*, *faces*, *cells*
