### PR TITLE
Make PrecipitationDistribution a component

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -19,6 +19,7 @@ from .uniform_precip import PrecipitationDistribution
 from .soil_moisture import SoilInfiltrationGreenAmpt
 from .plant_competition_ca import VegCA
 from .gflex import gFlex
+from .fire_generator import FireGenerator
 
 
 COMPONENTS = [ChiFinder, LinearDiffuser,
@@ -28,7 +29,7 @@ COMPONENTS = [ChiFinder, LinearDiffuser,
               Radiation, SinkFiller, StreamPowerEroder,
               FastscapeEroder, SedDepEroder, KinematicWaveRengers,
               SteepnessFinder, DetachmentLtdErosion, gFlex,
-              SoilInfiltrationGreenAmpt,
+              SoilInfiltrationGreenAmpt, FireGenerator,
               SoilMoisture, Vegetation, VegCA]
 
 

--- a/landlab/components/fire_generator/generate_fire.py
+++ b/landlab/components/fire_generator/generate_fire.py
@@ -47,9 +47,10 @@ To get a time to next fire:
 
 from random import weibullvariate
 from scipy import special
+from landlab import Component
 
 
-class FireGenerator(object):
+class FireGenerator(Component):
 
     """Generate a random fire event or time series.
 
@@ -69,6 +70,18 @@ class FireGenerator(object):
         it can be found using mean fire recurrence value and the
         get_scale_parameter() method described later.
     """
+
+    _name = 'FireGenerator'
+
+    _input_var_names = tuple()
+
+    _output_var_names = tuple()
+
+    _var_units = dict()
+
+    _var_mapping = dict()
+
+    _var_doc = dict()
 
     def __init__(self, mean_fire_recurrence=0.0, shape_parameter=0.0,
                  scale_parameter=None):

--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -16,7 +16,7 @@ import numpy as np
 from landlab import Component
 
 
-class PrecipitationDistribution(object):
+class PrecipitationDistribution(Component):
 
     """Generate precipitation events.
 
@@ -61,6 +61,18 @@ class PrecipitationDistribution(object):
     >>> for (dt, rate) in precip.yield_storm_interstorm_duration_intensity():
     ...     pass  # and so on
     """
+
+    _name = 'PrecipitationDistribution'
+
+    _input_var_names = tuple()
+
+    _output_var_names = tuple()
+
+    _var_units = dict()
+
+    _var_mapping = dict()
+
+    _var_doc = dict()
 
     def __init__(self, mean_storm_duration=0.0, mean_interstorm_duration=0.0,
                  mean_storm_depth=0.0, total_t=0.0, delta_t=None, **kwds):


### PR DESCRIPTION
A quick addition of a standard interface on PrecipitationDistribution.

Just because it’s not spatially resolved and doesn’t use fields,
doesn’t mean it shouldn’t have a LL interface indicating as much…