### PR TITLE
Remove unsized fields

### DIFF
--- a/landlab/field/field_mixin.py
+++ b/landlab/field/field_mixin.py
@@ -2,10 +2,6 @@
 from .grouped import ModelDataFields, GroupSizeError
 
 
-_GROUPS = ('node', 'link', 'patch', 'corner', 'face', 'cell', 'core_node',
-           'core_cell', 'active_link', 'active_face', )
-
-
 class ModelDataFieldsMixIn(ModelDataFields):
 
     """Mix-in that provides un-sized fields.
@@ -70,17 +66,6 @@ class ModelDataFieldsMixIn(ModelDataFields):
 
     def __init__(self, **kwds):
         super(ModelDataFieldsMixIn, self).__init__(**kwds)
-        for group in _GROUPS:
-            ModelDataFields.new_field_location(self, group)
-
-    def new_field_location(self, group, size=None):
-        """Add a new quantity to a field, but not available from here.
-
-        LLCATS: DEPR, FIELDCR
-        """
-        raise AttributeError(
-            "'ModelDataFieldsMixIn' object has no attribute "
-            "'new_field_location'")
 
     def empty(self, *args, **kwds):
         """Array, filled with unititialized values, for a given element.

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -501,13 +501,17 @@ _ARRAY_LENGTH_ATTRIBUTES = {
     'corner': 'number_of_corners',
     'face': 'number_of_faces',
     'cell': 'number_of_cells',
-    'link': 'number_of_links',
-    'face': 'number_of_faces',
-    'core_node': 'number_of_core_nodes',
-    'core_cell': 'number_of_core_cells',
     'active_link': 'number_of_active_links',
     'active_face': 'number_of_active_faces',
+    'core_node': 'number_of_core_nodes',
+    'core_cell': 'number_of_core_cells',
 }
+
+# Fields whose sizes can not change.
+_SIZED_FIELDS = {'node', 'link', 'patch', 'corner', 'face', 'cell', }
+
+# Fields whose sizes can change after creation.
+_UNSIZED_FIELDS = {'core_node', 'core_cell', 'active_link', 'active_face', }
 
 # Define the boundary-type codes
 
@@ -837,6 +841,12 @@ class ModelGrid(ModelDataFieldsMixIn):
         # Assumes 1) node_at_link_tail and node_at_link_head have been
         # created, and 2) so have node_x and node_y.
         # self._sort_links_by_midpoint()
+
+        for loc in _SIZED_FIELDS:
+            size = self.number_of_elements(loc)
+            ModelDataFields.new_field_location(self, loc, size=size)
+        for loc in _UNSIZED_FIELDS:
+            ModelDataFields.new_field_location(self, loc, size=None)
 
     def _create_link_face_coords(self):
         """Create x, y coordinates for link-face intersections.
@@ -1772,15 +1782,15 @@ class ModelGrid(ModelDataFieldsMixIn):
             self._reset_link_status_list()
             return self._fixed_links.size
 
-    def number_of_elements(self, element_name):
+    def number_of_elements(self, name):
         """Number of instances of an element.
 
         Get the number of instances of a grid element in a grid.
 
         Parameters
         ----------
-        element_name : {'node', 'cell', 'link', 'face', 'core_node',
-            'core_cell', 'active_link', 'active_face'}
+        name : {'node', 'cell', 'link', 'face', 'core_node', 'core_cell',
+                'active_link', 'active_face'}
             Name of the grid element.
 
         Returns
@@ -1809,9 +1819,10 @@ class ModelGrid(ModelDataFieldsMixIn):
         LLCATS: GINF
         """
         try:
-            return getattr(self, _ARRAY_LENGTH_ATTRIBUTES[element_name])
+            return getattr(self, _ARRAY_LENGTH_ATTRIBUTES[name])
         except KeyError:
-            raise TypeError('element name not understood')
+            raise TypeError(
+                '{name}: element name not understood'.format(name=name))
 
     @property
     @make_return_array_immutable

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -847,6 +847,7 @@ class ModelGrid(ModelDataFieldsMixIn):
             ModelDataFields.new_field_location(self, loc, size=size)
         for loc in _UNSIZED_FIELDS:
             ModelDataFields.new_field_location(self, loc, size=None)
+        ModelDataFields.set_default_group(self, 'node')
 
     def _create_link_face_coords(self):
         """Create x, y coordinates for link-face intersections.

--- a/landlab/grid/tests/test_raster_grid/test_fields.py
+++ b/landlab/grid/tests/test_raster_grid/test_fields.py
@@ -1,0 +1,27 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+from nose.tools import assert_raises
+
+from landlab import RasterModelGrid
+
+
+def test_add_field_at_node():
+    """Add field at nodes."""
+    grid = RasterModelGrid((4, 5))
+    grid.add_field('z', np.arange(20), at='node')
+
+    assert_array_equal(grid.at_node['z'], np.arange(20))
+
+
+def test_add_field_without_at_keyword():
+    """Test default is at nodes."""
+    grid = RasterModelGrid((4, 5))
+    grid.add_field('z', np.arange(20))
+
+    assert_array_equal(grid.at_node['z'], np.arange(20))
+
+
+def test_add_field_without_at():
+    """Test raises error with wrong size array."""
+    grid = RasterModelGrid((4, 5))
+    assert_raises(ValueError, grid.add_field, 'z', np.arange(21))

--- a/landlab/grid/voronoi.py
+++ b/landlab/grid/voronoi.py
@@ -538,18 +538,18 @@ class VoronoiDelaunayGrid(ModelGrid):
     25
 
     >>> import numpy as np
-    >>> x = [0, 0, 0, 0,
-    ...      1, 1, 1, 1,
-    ...      2, 2, 2, 2,]
+    >>> x = [0, 0.1, 0.2, 0.3,
+    ...      1, 1.1, 1.2, 1.3,
+    ...      2, 2.1, 2.2, 2.3,]
     >>> y = [0, 1, 2, 3,
     ...      0, 1, 2, 3,
     ...      0, 1, 2, 3]
     >>> vmg = VoronoiDelaunayGrid(x, y)
     >>> vmg.node_x # doctest: +NORMALIZE_WHITESPACE
-    array([ 0.,  1.,  2.,
-            0.,  1.,  2.,
-            0.,  1.,  2.,
-            0.,  1.,  2.])
+    array([ 0. ,  1. ,  2. ,
+            0.1,  1.1,  2.1,
+            0.2,  1.2,  2.2,
+            0.3,  1.3,  2.3])
     >>> vmg.node_y # doctest: +NORMALIZE_WHITESPACE
     array([ 0.,  0.,  0.,
             1.,  1.,  1.,


### PR DESCRIPTION
This pull request removed unsized fields for the core `ModelGrid` elements. That is, `node`, `link`, `patch`, `corner`, `face`, and `cell`. There are still fields for elements like `active_link`, `core_node`, etc. Since the size of these fields can change after the grid has been created, they need to be flexible in their size.