### PR TITLE
Remove active link fields

### DIFF
--- a/landlab/components/overland_flow/tests/test_dealmeida_overland_flow.py
+++ b/landlab/components/overland_flow/tests/test_dealmeida_overland_flow.py
@@ -24,7 +24,7 @@ def setup_grid():
     grid = RasterModelGrid((32, 240), spacing=25)
     grid.add_zeros('node', 'surface_water__depth')
     grid.add_zeros('node', 'topographic__elevation')
-    grid.add_zeros('surface_water__discharge', at='active_link')
+    grid.add_zeros('surface_water__discharge', at='link')
     deAlm = OverlandFlow(grid, mannings_n=0.01, h_init=0.001)
     globals().update({
         'deAlm': OverlandFlow(grid)})
@@ -44,7 +44,8 @@ def test_deAlm_input_var_names():
 
 @with_setup(setup_grid)
 def test_deAlm_output_var_names():
-    assert_equal(deAlm.output_var_names, ('surface_water__depth', 'surface_water__discharge',
+    assert_equal(deAlm.output_var_names, ('surface_water__depth',
+                                          'surface_water__discharge',
                                           'water_surface__gradient', ))
 
 @with_setup(setup_grid)
@@ -76,8 +77,8 @@ def test_deAlm_analytical():
     time = 0.0
 
     while time < 500.:
-        grid['link']['surface_water__discharge'][left_inactive_ids] = (
-            grid['link']['surface_water__discharge'][left_inactive_ids + 1])
+        grid.at_link['surface_water__discharge'][left_inactive_ids] = (
+            grid.at_link['surface_water__discharge'][left_inactive_ids + 1])
         dt = deAlm.calc_time_step()
         deAlm.overland_flow(dt)
         h_boundary = (((7./3.) * (0.01**2) * (0.4**3) *
@@ -109,8 +110,8 @@ def test_deAlm_analytical_imposed_dt_short():
     time = 0.0
 
     while time < 500.:
-        grid['link']['surface_water__discharge'][left_inactive_ids] = (
-            grid['link']['surface_water__discharge'][left_inactive_ids + 1])
+        grid.at_link['surface_water__discharge'][left_inactive_ids] = (
+            grid.at_link['surface_water__discharge'][left_inactive_ids + 1])
         dt = 10.
         deAlm.overland_flow(dt)
         h_boundary = (((7./3.) * (0.01**2) * (0.4**3) *
@@ -142,8 +143,8 @@ def test_deAlm_analytical_imposed_dt_long():
     time = 0.0
 
     while time < 500.:
-        grid['link']['surface_water__discharge'][left_inactive_ids] = (
-            grid['link']['surface_water__discharge'][left_inactive_ids + 1])
+        grid.at_link['surface_water__discharge'][left_inactive_ids] = (
+            grid.at_link['surface_water__discharge'][left_inactive_ids + 1])
         dt = 100.
         deAlm.run_one_step(dt)
         h_boundary = (((7./3.) * (0.01**2) * (0.4**3) *

--- a/landlab/field/field_mixin.py
+++ b/landlab/field/field_mixin.py
@@ -20,48 +20,6 @@ class ModelDataFieldsMixIn(ModelDataFields):
     >>> grid = RasterModelGrid((4, 5))
     >>> grid.number_of_elements('node')
     20
-
-    Examples
-    --------
-
-    A `RasterModelGrid` is an example of a class that inherits from
-    `ModelDataFieldsMixIn`.
-
-    >>> from landlab import RasterModelGrid, CLOSED_BOUNDARY
-    >>> grid = RasterModelGrid((4, 5))
-
-    After we initially create the grid, it has a number of active links.
-    However, since we haven't assigned or created a field based on the number,
-    the field is un-sized.
-
-    >>> grid.number_of_elements('active_link')
-    17
-    >>> grid.at_active_link.size is None
-    True
-
-    If we change the status of some of the nodes, the number of active links
-    changes. If we now create an array based on the current number of active
-    links, that number *is now fixed*.
-
-    >>> grid.status_at_node[:5] = CLOSED_BOUNDARY
-    >>> grid.number_of_elements('active_link')
-    14
-    >>> grid.ones(at='active_link', dtype=int)
-    array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
-    >>> grid.at_active_link.size
-    14
-
-    Because the number of active links is fixed in our collection of fields,
-    if we change the number of active links in our grid, an exception is
-    raised if we try to create a new active link array.
-
-    >>> grid.status_at_node[-5:] = CLOSED_BOUNDARY
-    >>> grid.number_of_elements('active_link')
-    11
-    >>> grid.ones(at='active_link', dtype=int)
-    ...     # doctest: +IGNORE_EXCEPTION_DETAIL
-    Traceback (most recent call last):
-    GroupSizeError: number of active_link elements has changed. (was = 14, now=11)
     """
 
     def __init__(self, **kwds):

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -415,15 +415,14 @@ Use the groups attribute to see the group names.
 >>> groups = list(grid.groups)
 >>> groups.sort()
 >>> groups # doctest: +NORMALIZE_WHITESPACE
-['active_face', 'active_link', 'cell', 'core_cell', 'core_node', 'corner',
- 'face', 'link', 'node', 'patch']
+['cell', 'corner', 'face', 'link', 'node', 'patch']
 
 Create Field Arrays
 +++++++++++++++++++
 If you just want to create an array but not add it to the grid, you can use
 the :meth:`~.ModelGrid.ones` method.
 
->>> grid.ones(centering='node')
+>>> grid.ones(at='node')
 array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.])
 >>> list(grid.at_node.keys()) # Nothing has been added to the grid
 []
@@ -509,9 +508,6 @@ _ARRAY_LENGTH_ATTRIBUTES = {
 
 # Fields whose sizes can not change.
 _SIZED_FIELDS = {'node', 'link', 'patch', 'corner', 'face', 'cell', }
-
-# Fields whose sizes can change after creation.
-_UNSIZED_FIELDS = {'core_node', 'core_cell', 'active_link', 'active_face', }
 
 # Define the boundary-type codes
 
@@ -785,14 +781,6 @@ class ModelGrid(ModelDataFieldsMixIn):
         Values at links.
     at_face : dict-like
         Values at faces.
-    at_core_node : dict-like
-        Values at core nodes.
-    at_core_cell : dict-like
-        Values at core cells.
-    at_active_link : dict-like
-        Values at active links.
-    at_active_face : dict-like
-        Values at active faces.
 
     Other Parameters
     ----------------
@@ -811,10 +799,6 @@ class ModelGrid(ModelDataFieldsMixIn):
     at_corner = {}  # : Values defined at corners
     at_face = {}  # : Values defined at faces
     at_cell = {}  # : Values defined at cells
-    at_core_node = {}  # : Values defined at core nodes
-    at_core_cell = {}  # : Values defined at core cells
-    at_active_link = {}  # : Values defined at active links
-    at_active_face = {}  # : Values defined at active faces
 
     # : Nodes on the other end of links pointing into a node.
     _node_inlink_matrix = numpy.array([], dtype=numpy.int32)
@@ -845,8 +829,8 @@ class ModelGrid(ModelDataFieldsMixIn):
         for loc in _SIZED_FIELDS:
             size = self.number_of_elements(loc)
             ModelDataFields.new_field_location(self, loc, size=size)
-        for loc in _UNSIZED_FIELDS:
-            ModelDataFields.new_field_location(self, loc, size=None)
+        # for loc in _UNSIZED_FIELDS:
+        #     ModelDataFields.new_field_location(self, loc, size=None)
         ModelDataFields.set_default_group(self, 'node')
 
     def _create_link_face_coords(self):
@@ -3267,7 +3251,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         improve speed slightly by creating an array outside the loop. For
         example, do this once, before the loop:
 
-        >>> divflux = rmg.zeros(centering='core_cell') # outside loop
+        >>> divflux = np.zeros(rmg.number_of_core_cells) # outside loop
 
         Then do this inside the loop:
 
@@ -3550,7 +3534,7 @@ class ModelGrid(ModelDataFieldsMixIn):
         of all the links in the grid.
         """
         if self._link_length is None:
-            self._link_length = self.empty(centering='link', dtype=float)
+            self._link_length = self.empty(at='link', dtype=float)
 
         diff_x = (self.node_x[self.node_at_link_tail] -
                   self.node_x[self.node_at_link_head])

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -130,7 +130,7 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     LLCATS: DEPR LINF GRAD
     """
     if out is None:
-        out = grid.empty(centering='active_link')
+        out = np.empty(grid.number_of_active_links, dtype=float)
     return np.divide(node_values[grid._activelink_tonode] -
                      node_values[grid._activelink_fromnode],
                      grid.length_of_link[grid.active_links], out=out)
@@ -289,7 +289,7 @@ def calculate_diff_at_active_links(grid, node_values, out=None):
     LLCATS: DEPR LINF GRAD
     """
     if out is None:
-        out = grid.empty(at='active_link')
+        out = np.empty(grid.number_of_active_links, dtype=float)
     node_values = np.asarray(node_values)
     return np.subtract(node_values[grid._activelink_tonode],
                        node_values[grid._activelink_fromnode], out=out)

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -805,9 +805,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     (4, 5)
     >>> rmg.number_of_active_links
     17
-    >>> vals = rmg.add_zeros('vals', at='active_link')
-    >>> vals.size
-    17
 
     Set the nodes along the top edge of the grid to be *closed* boundaries.
     This means that any links touching these nodes will be *inactive*.
@@ -816,9 +813,6 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
     >>> rmg.number_of_node_rows, rmg.number_of_node_columns
     (4, 5)
     >>> rmg.number_of_active_links
-    14
-    >>> vals = rmg.add_zeros('vals', at='active_link')
-    >>> vals.size
     14
 
     A `RasterModelGrid` can have different node spacings in the *x* and *y*

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -152,7 +152,7 @@ def calc_grad_at_active_link(grid, node_values, out=None):
     LLCATS: LINF GRAD
     """
     if out is None:
-        out = grid.empty(at='active_link')
+        out = np.empty(grid.number_of_active_links, dtype=float)
 
     if len(out) != grid.number_of_active_links:
         raise ValueError('output buffer does not match that of the grid.')

--- a/landlab/grid/tests/test_raster_grid/test_allocators.py
+++ b/landlab/grid/tests/test_raster_grid/test_allocators.py
@@ -10,8 +10,7 @@ from landlab import RasterModelGrid
 
 
 ELEMENTS = ['node', 'cell', 'link', 'face']
-ELEMENTS += ['core_node', 'core_cell', 'active_link', 'active_face']
-#ELEMENTS += ['active_' + name for name in ELEMENTS]
+# ELEMENTS += ['core_node', 'core_cell', 'active_link', 'active_face']
 TYPES = ['float', 'int', 'bool']
 
 
@@ -73,8 +72,7 @@ def generate_add_ones_tests():
 
 def generate_empty_tests():
     elements = ['node', 'cell', 'link', 'face']
-    elements += ['core_node', 'core_cell', 'active_link', 'active_face']
-    #elements += ['active_' + name for name in elements]
+    # elements += ['core_node', 'core_cell', 'active_link', 'active_face']
 
     types = ['float', 'int', 'bool']
 
@@ -92,8 +90,7 @@ def generate_empty_tests():
 
 def generate_add_empty_tests():
     elements = ['node', 'cell', 'link', 'face']
-    elements += ['core_node', 'core_cell', 'active_link', 'active_face']
-    #elements += ['active_' + name for name in elements]
+    # elements += ['core_node', 'core_cell', 'active_link', 'active_face']
 
     types = ['float', 'int', 'bool']
 


### PR DESCRIPTION
This pull request completely removes field locations for `active_links`, `active_faces`, `core_nodes`, and `core_cells`.

@jadams15: The biggest change, which actually isn't all the big, is in the unit tests for your overland flow component. Maybe you could have a look at see if it's fine?