### PR TITLE
modify node_can_drain method

### DIFF
--- a/landlab/components/flow_routing/tests/test_lake_mapper.py
+++ b/landlab/components/flow_routing/tests/test_lake_mapper.py
@@ -224,8 +224,6 @@ def check_array_values1(rmg, lm):
     """
     Check values of the various fields against known values.
     """
-#    for i in range(rmg.number_of_nodes):
-#        print i, rmg.at_node['topographic__elevation'][i], lm.is_pit[i]
 
     assert_array_equal(lm.is_pit,
     [False, False, False, False, False, False, False, False,


### PR DESCRIPTION
This PR fixes a bug in the lake mapper. Basically, the issue was as follows: sometimes the potential outlet node of a lake lies above a neighboring node that itself is flooded in a different lake. Until now, this was handled by saying "if the neighbor node is flooded, you (the potential outlet) can't drain to it" -- even if the water level lies below the potential outlet. This had the odd side effect of producing (in certain cases) negative depression depths. A solution is to consider a flooded neighbor to be a valid potential outlet IF its own outlet lies below the new outlet being considered. The logic adds a potentially expensive loop, but it is only invoked if there is at least one flooded node neighboring the potential outlet.