### PR TITLE
precip gen: don't round; allow generated to sequence to end in a storm

### DIFF
--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -29,7 +29,7 @@ class PrecipitationDistribution(Component):
         PrecipitationDistribution(mean_storm_duration=0.0,
                                   mean_interstorm_duration=0.0,
                                   mean_storm_depth=0.0, total_t=0.0,
-                                  delta_t=0.0)
+                                  delta_t=0.0, random_seed=0)
 
     Parameters
     ----------
@@ -44,6 +44,8 @@ class PrecipitationDistribution(Component):
     delta_t : float, optional
         If you want to break up storms into determined subsections using
         yield_storm_interstorm_duration_intensity, a delta_t is needed.
+    random_seed : int or float, optional
+        Seed value for random-number generator.
 
     Examples
     --------
@@ -75,7 +77,8 @@ class PrecipitationDistribution(Component):
     _var_doc = dict()
 
     def __init__(self, mean_storm_duration=0.0, mean_interstorm_duration=0.0,
-                 mean_storm_depth=0.0, total_t=0.0, delta_t=None, **kwds):
+                 mean_storm_depth=0.0, total_t=0.0, delta_t=None, 
+                 random_seed=0, **kwds):
         """Create the storm generator.
 
         Parameters
@@ -91,6 +94,8 @@ class PrecipitationDistribution(Component):
         delta_t : float or None, optional
             If you want to break up storms into determined subsections using
             yield_storm_interstorm_duration_intensity, a delta_t is needed.
+        random_seed : int or float, optional
+            Seed value for random-number generator.
         """
 
         self.mean_storm_duration = mean_storm_duration
@@ -112,6 +117,9 @@ class PrecipitationDistribution(Component):
 
         # If a time series is created later, this blank list will be used.
         self.storm_time_series = []
+        
+        # Seed the random-number generator
+        self.seed_generator(random_seed)
 
         # Given the mean values assigned above using either the model
         # parameter dictionary or the init function, we can call the
@@ -352,6 +360,52 @@ class PrecipitationDistribution(Component):
                 else:
                     yield (interstorm_duration, 0.)
                 self._elapsed_time += interstorm_duration
+                
+    def seed_generator(self, seedval=0):
+        """Seed the random-number generator.
+        
+        The examples illustrate:
+        (1) that we can get the same sequence again by re-seeding with the
+            same value (the default is zero)
+        (2) when we use a value other than the default, we get a different
+            sequence
+        
+        Example
+        -------
+        >>> precip = PrecipitationDistribution(mean_storm_duration = 1.5,
+        ...     mean_interstorm_duration = 15.0, mean_storm_depth = 0.5,
+        ...     total_t = 100.0, delta_t = 1.)
+        >>> round(precip.storm_duration, 2)
+        2.79
+        >>> round(precip.interstorm_duration, 2)
+        21.28
+        >>> round(precip.storm_depth, 2)
+        2.45
+        >>> round(precip.intensity, 2)
+        0.88
+        >>> precip.seed_generator() # re-seed and get same sequence again
+        >>> round(precip.get_precipitation_event_duration(), 2)
+        2.79
+        >>> round(precip.get_interstorm_event_duration(), 2)
+        21.28
+        >>> round(precip.get_storm_depth(), 2)
+        2.45
+        >>> round(precip.get_storm_intensity(), 2)
+        0.88
+        >>> precip = PrecipitationDistribution(mean_storm_duration = 1.5,
+        ...     mean_interstorm_duration = 15.0, mean_storm_depth = 0.5,
+        ...     total_t = 100.0, delta_t = 1., random_seed=1)
+        >>> round(precip.storm_duration, 2) # diff't vals with diff't seed
+        0.22
+        >>> round(precip.interstorm_duration, 2)
+        28.2
+        >>> round(precip.storm_depth, 4)
+        0.0012
+        >>> round(precip.intensity, 4)
+        0.0054
+        """
+        random.seed(seedval)
+        np.random.seed(seedval)
 
     @property
     def elapsed_time(self):


### PR DESCRIPTION
Two minor changes to the PrecipitationDistribution component:
1) storm and interstorm duration are no longer rounded to 2 decimals (which I think removes the need to test for zero durations)
2) the generator function now allows the possibility for the sequence to end in the middle of a storm (previously, if time ran out during a storm, it would still return a zero-duration interstorm period, which had the odd side effect of forcing a model to always have zero precipitation just before an output to file)