### PR TITLE
Adding a field group "at_everywhere" to store single element arrays meant to represent values global to the grid. 

### DIFF
--- a/landlab/field/field_mixin.py
+++ b/landlab/field/field_mixin.py
@@ -58,7 +58,13 @@ class ModelDataFieldsMixIn(ModelDataFields):
             group = kwds.pop('at', kwds.pop('centering', 'node'))
         else:
             group = args[0]
-
+        
+        if group=='grid':
+            raise ValueError("empty is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.")        
+        
         n_elements = self.number_of_elements(group)
 
         if self[group].size is None:
@@ -107,7 +113,14 @@ class ModelDataFieldsMixIn(ModelDataFields):
             group = kwds.pop('at', kwds.pop('centering', 'node'))
         else:
             group = args[0]
-
+        
+        if group=='grid':
+            raise ValueError("ones is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.\nAlternatively, if you want ones"
+                             "of the shape stored at_grid, use np.array(1).")
+                             
         n_elements = self.number_of_elements(group)
 
         if self[group].size is None:
@@ -151,7 +164,14 @@ class ModelDataFieldsMixIn(ModelDataFields):
             group = kwds.pop('at', kwds.pop('centering', 'node'))
         else:
             group = args[0]
-
+            
+        if group=='grid':
+            raise ValueError("zeros is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.\nAlternatively, if you want zeros"
+                             "of the shape stored at_grid, use np.array(0).")
+                             
         n_elements = self.number_of_elements(group)
 
         if self[group].size is None:

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -492,6 +492,8 @@ class ModelDataFields(object):
         Return a new array of the data field size, filled with zeros. Keyword
         arguments are the same as that for the equivalent numpy function.
 
+        This method is not valid for the group *grid*.        
+        
         See Also
         --------
         numpy.zeros : See for a description of optional keywords.
@@ -525,7 +527,9 @@ class ModelDataFields(object):
         entries, and add it to the field as *name*. The *units* keyword gives
         the units of the new fields as a string. Remaining keyword arguments
         are the same as that for the equivalent numpy function.
-
+        
+        This method is not valid for the group *grid*.
+        
         Construction::
 
             add_empty(group, name, units='-', noclobber=True)
@@ -564,8 +568,8 @@ class ModelDataFields(object):
             raise ValueError('number of arguments must be 1 or 2')
             
         if group=='grid':
-            raise ValueError("add_empty is not supported for at_grid values"
-                             "use \n grid.at_grid['value_name']=value \n"
+            raise ValueError("add_empty is not supported for at_grid values "
+                             "use\ngrid.at_grid['value_name']=value\n"
                              "instead")        
                              
         numpy_kwds = kwds.copy()
@@ -582,6 +586,8 @@ class ModelDataFields(object):
         add it to the field as *name*. The *units* keyword gives the units of
         the new fields as a string. Remaining keyword arguments are the same
         as that for the equivalent numpy function.
+        
+        This method is not valid for the group *grid*.
 
         Construction::
 
@@ -638,7 +644,7 @@ class ModelDataFields(object):
 
         if group=='grid':
             raise ValueError("add_ones is not supported for at_grid values"
-                             "use \n grid.at_grid['value_name']=value \n"
+                             " use\ngrid.at_grid['value_name']=value\n"
                              "instead")                
         
         numpy_kwds = kwds.copy()
@@ -694,8 +700,8 @@ class ModelDataFields(object):
             raise ValueError('number of arguments must be 1 or 2')
         
         if group=='grid':
-            raise ValueError("add_zeros is not supported for at_grid values"
-                             "use \n grid.at_grid['value_name']=value \n"
+            raise ValueError("add_zeros is not supported for at_grid values "
+                             "use\ngrid.at_grid['value_name']=value\n"
                              "instead")                
         
         numpy_kwds = kwds.copy()
@@ -710,6 +716,9 @@ class ModelDataFields(object):
         Add an array of data values to a collection of fields and associate it
         with the key, *name*. Use the *copy* keyword to, optionally, add a
         copy of the provided array.
+        
+        In the case of adding to the collection *grid*, the added field is a
+        numpy scalar rather than a numpy array. 
 
         Construction::
 

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -788,11 +788,6 @@ class ModelDataFields(object):
         if not group:
             raise ValueError('missing group name')
         
-        if group=='grid':
-            raise ValueError("add_field is not supported for at_grid values"
-                             "use \n grid.at_grid['value_name']=value \n"
-                             "instead")        
-        
         return self[group].add_field(name, value_array, **kwds)
 
     def set_units(self, group, name, units):

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -441,6 +441,11 @@ class ModelDataFields(object):
 
         LLCATS: FIELDCR
         """
+        if group=='grid':
+            raise ValueError("empty is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.")
         return self[group].empty(**kwds)
 
     def ones(self, group, **kwds):
@@ -479,6 +484,12 @@ class ModelDataFields(object):
 
         LLCATS: FIELDCR
         """
+        if group=='grid':
+            raise ValueError("ones is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.\nAlternatively, if you want ones "
+                             "of the shape stored at_grid, use np.array(1).")
         return self[group].ones(**kwds)
 
     def zeros(self, group, **kwds):
@@ -517,6 +528,13 @@ class ModelDataFields(object):
 
         LLCATS: FIELDCR
         """
+        if group=='grid':
+            raise ValueError("zeros is not supported for at='grid', if you "
+                             "want to create a field at the grid, use\n"
+                             "grid.at_grid['value_name']=value\n"
+                             "instead.\nAlternatively, if you want zeros"
+                             "of the shape stored at_grid, use np.array(0).")
+                             
         return self[group].zeros(**kwds)
 
     def add_empty(self, *args, **kwds):

--- a/landlab/field/scalar_data_fields.py
+++ b/landlab/field/scalar_data_fields.py
@@ -403,7 +403,8 @@ class ScalarDataFields(dict):
             raise FieldError('{name}: already exists'. format(name=name))
 
         value_array = np.asarray(value_array)
-        value_array.shape = (-1, )
+        if value_array.ndim > 0:
+            value_array.shape = (-1, )
 
         if copy:
             value_array = value_array.copy()

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -183,6 +183,9 @@ def test_scalar_field():
 
     fields.at_all_over_the_place['const'] = 1.
     assert_array_equal(np.array(1.), fields.at_all_over_the_place['const'])
+    
+    assert_raises(ValueError, fields.add_field, 'new_value', [0,1], at='all_over_the_place')
+
 
 def test_grid_field():
     fields = ModelDataFields()

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -183,3 +183,15 @@ def test_scalar_field():
 
     fields.at_all_over_the_place['const'] = 1.
     assert_array_equal(np.array(1.), fields.at_all_over_the_place['const'])
+
+def test_grid_field():
+    fields = ModelDataFields()
+    fields.new_field_location('grid', 1)
+    
+    assert_raises(ValueError, fields.add_zeros, 'value', at='grid')
+    assert_raises(ValueError, fields.add_empty, 'value', at='grid')
+    assert_raises(ValueError, fields.add_ones, 'value', at='grid')
+    
+    assert_raises(ValueError, fields.zeros, at='grid')
+    assert_raises(ValueError, fields.empty, at='grid')
+    assert_raises(ValueError, fields.ones, at='grid')

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -172,3 +172,14 @@ def test_delete_field():
     fields.delete_field('link', 'vals')
     assert_raises(KeyError, lambda: fields.field_units('link', 'vals'))
     assert_raises(KeyError, lambda: fields.at_link['vals'])
+
+
+def test_scalar_field():
+    fields = ModelDataFields()
+    fields.new_field_location('all_over_the_place', 1)
+
+    assert_dict_equal(dict(), fields.at_all_over_the_place)
+    assert_raises(AttributeError, lambda: fields.at_cell)
+
+    fields.at_all_over_the_place['const'] = 1.
+    assert_array_equal(np.array(1.), fields.at_all_over_the_place['const'])

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -195,6 +195,6 @@ def test_grid_field():
     assert_raises(ValueError, fields.add_empty, 'value', at='grid')
     assert_raises(ValueError, fields.add_ones, 'value', at='grid')
     
-    assert_raises(ValueError, fields.zeros, at='grid')
-    assert_raises(ValueError, fields.empty, at='grid')
-    assert_raises(ValueError, fields.ones, at='grid')
+    assert_raises(ValueError, fields.zeros, 'grid')
+    assert_raises(ValueError, fields.empty, 'grid')
+    assert_raises(ValueError, fields.ones, 'grid')

--- a/landlab/field/tests/test_grouped_fields.py
+++ b/landlab/field/tests/test_grouped_fields.py
@@ -175,6 +175,7 @@ def test_delete_field():
 
 
 def test_scalar_field():
+    """Test adding a generic scalar field."""
     fields = ModelDataFields()
     fields.new_field_location('all_over_the_place', 1)
 
@@ -187,14 +188,19 @@ def test_scalar_field():
     assert_raises(ValueError, fields.add_field, 'new_value', [0,1], at='all_over_the_place')
 
 
-def test_grid_field():
+def test_grid_field_add_zeros_ones_empty():
+    """Test creating scalar fields with add_zeros, add_empty, and add_ones."""
     fields = ModelDataFields()
     fields.new_field_location('grid', 1)
     
     assert_raises(ValueError, fields.add_zeros, 'value', at='grid')
     assert_raises(ValueError, fields.add_empty, 'value', at='grid')
     assert_raises(ValueError, fields.add_ones, 'value', at='grid')
-    
+
+def test_grid_field_zeros_ones_empty():
+    """Test creating scalar fields with zeros, empty, and ones."""
+    fields = ModelDataFields()
+    fields.new_field_location('grid', 1)    
     assert_raises(ValueError, fields.zeros, 'grid')
     assert_raises(ValueError, fields.empty, 'grid')
     assert_raises(ValueError, fields.ones, 'grid')

--- a/landlab/grid/tests/test_raster_grid/test_fields.py
+++ b/landlab/grid/tests/test_raster_grid/test_fields.py
@@ -30,6 +30,9 @@ def test_add_field_at_grid_value_error():
     """Test raises error with wrong size array for adding a at_grid field."""
     grid = RasterModelGrid((4, 5))
     assert_raises(ValueError, grid.add_field, 'value', [0,1], at='grid')
+    
+    with assert_raises(ValueError):
+        grid.at_grid['new_value']=[2,4]
 
 def test_add_field_at_grid():
     """Test add field at grid."""
@@ -45,6 +48,7 @@ def test_adding_field_at_grid_two_ways():
     assert_array_equal(grid.at_grid['value_1'], grid.at_grid['value_2'])
     
 def test_add_ones_zeros_empty_to_at_grid():
+    """Test different add methods for keyword at='grid'"""
     grid = RasterModelGrid((4, 5))
     assert_raises(ValueError, grid.add_zeros, 'value', at='grid')
     assert_raises(ValueError, grid.add_empty, 'value', at='grid')

--- a/landlab/grid/tests/test_raster_grid/test_fields.py
+++ b/landlab/grid/tests/test_raster_grid/test_fields.py
@@ -27,7 +27,7 @@ def test_add_field_without_at():
     assert_raises(ValueError, grid.add_field, 'z', np.arange(21))
 
 def test_add_field_at_grid_value_error():
-    """Test raises error with wrong size array for adding a at_grid field."""
+    """Test raises error with wrong size array for adding a at_grid field both possible ways."""
     grid = RasterModelGrid((4, 5))
     assert_raises(ValueError, grid.add_field, 'value', [0,1], at='grid')
     
@@ -54,6 +54,9 @@ def test_add_ones_zeros_empty_to_at_grid():
     assert_raises(ValueError, grid.add_empty, 'value', at='grid')
     assert_raises(ValueError, grid.add_ones, 'value', at='grid')
     
+def test_ones_zeros_empty_to_at_grid():
+    """Test get array with field size methods for keyword at='grid'"""
+    grid = RasterModelGrid((4, 5))
     assert_raises(ValueError, grid.zeros, at='grid')
     assert_raises(ValueError, grid.empty, at='grid')
     assert_raises(ValueError, grid.ones, at='grid')

--- a/landlab/grid/tests/test_raster_grid/test_fields.py
+++ b/landlab/grid/tests/test_raster_grid/test_fields.py
@@ -36,3 +36,16 @@ def test_add_field_at_grid():
     grid = RasterModelGrid((4, 5))
     grid.at_grid['value']=1
     assert_array_equal(1, grid.at_grid['value'].size)
+
+def test_adding_field_at_grid_two_ways():
+    """Test add field at grid two ways."""
+    grid = RasterModelGrid((4, 5))
+    grid.at_grid['value_1']=1
+    grid.add_field('value_2', 1, at='grid')
+    assert_array_equal(grid.at_grid['value_1'], grid.at_grid['value_2'])
+    
+def test_add_ones_zeros_empty_to_at_grid():
+    grid = RasterModelGrid((4, 5))
+    assert_raises(ValueError, grid.add_zeros, 'value', at='grid')
+    assert_raises(ValueError, grid.add_empty, 'value', at='grid')
+    assert_raises(ValueError, grid.add_ones, 'value', at='grid')

--- a/landlab/grid/tests/test_raster_grid/test_fields.py
+++ b/landlab/grid/tests/test_raster_grid/test_fields.py
@@ -49,3 +49,7 @@ def test_add_ones_zeros_empty_to_at_grid():
     assert_raises(ValueError, grid.add_zeros, 'value', at='grid')
     assert_raises(ValueError, grid.add_empty, 'value', at='grid')
     assert_raises(ValueError, grid.add_ones, 'value', at='grid')
+    
+    assert_raises(ValueError, grid.zeros, at='grid')
+    assert_raises(ValueError, grid.empty, at='grid')
+    assert_raises(ValueError, grid.ones, at='grid')


### PR DESCRIPTION
To discuss and potentially change from this pull request:

1) Name. I’ve used “at_everywhere” because to keep in line with the current code used to set/test the size of controlled field groups I needed to create a property that mirrored the existing properties grid.number_of …  grid.number_of_value_at_everywhere is imperfect, but it is the best thing that I could come up with. If anyone has a better idea for how to name this, please let me know. 

2) Value or array. At the moment,  I’ve mirrored the other controlled field groups (at_node, at_cell, etc) in that this field group must be made of arrays of length 1. One could argue that this field group should be required to be str, int, float, or bool, rather than an array of length one. I wasn’t sure which was best, so I’ve implemented the version that was closest to the current field groups, and listed this here for discussion. 