### PR TITLE
edit depth-dep prod and wxing

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -21,7 +21,7 @@ from .plant_competition_ca import VegCA
 from .gflex import gFlex
 from .drainage_density import DrainageDensity
 from .fire_generator import FireGenerator
-from .weathering import ExponentialWeathering
+from .weathering import ExponentialWeatherer
 from .depth_dependent_diffusion import DepthDependentDiffuser
 
 
@@ -34,7 +34,7 @@ COMPONENTS = [ChiFinder, LinearDiffuser,
               SteepnessFinder, DetachmentLtdErosion, gFlex,
               SoilInfiltrationGreenAmpt, FireGenerator,
               SoilMoisture, Vegetation, VegCA, DrainageDensity,
-	      ExponentialWeathering, DepthDependentDiffuser]
+	      ExponentialWeatherer, DepthDependentDiffuser]
 
 
 __all__ = [cls.__name__ for cls in COMPONENTS]

--- a/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
+++ b/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
@@ -15,31 +15,28 @@ class DepthDependentDiffuser(Component):
     This component implements a depth and slope dependent linear diffusion rule
     in the style of Johnstone and Hilley (2014). 
 
-        
     Parameters
     ----------
     grid: ModelGrid
         Landlab ModelGrid object
-    k: float
+    soil_creep_efficiency: float
         Hillslope efficiency, m/yr
-    hstar: float
+    soil_transport_decay_depth: float
         characteristic transport soil depth, m
-    
-
 
     Examples
     --------
     >>> import numpy as np
     >>> from landlab import RasterModelGrid
-    >>> from landlab.components import ExponentialWeathering, DepthDependentDiffuser
+    >>> from landlab.components import ExponentialWeatherer, DepthDependentDiffuser
     >>> mg = RasterModelGrid((5, 5))
     >>> soilTh = mg.add_zeros('node', 'soil__depth')
     >>> z = mg.add_zeros('node', 'topographic__elevation')
     >>> BRz = mg.add_zeros('node', 'bedrock__elevation')
-    >>> expweath = ExponentialWeathering(mg)
+    >>> expweath = ExponentialWeatherer(mg)
     >>> DDdiff = DepthDependentDiffuser(mg)
-    >>> expweath.exponentialweather()
-    >>> np.allclose(mg.at_node['weathering__rate'], 1.)
+    >>> expweath.calc_soil_prod_rate()
+    >>> np.allclose(mg.at_node['soil_production__rate'], 1.)
     True
     >>> DDdiff.soilflux(2.)
     >>> np.allclose(mg.at_node['topographic__elevation'], 0.)
@@ -57,12 +54,12 @@ class DepthDependentDiffuser(Component):
     >>> z += mg.node_x.copy()
     >>> BRz += mg.node_x/2.
     >>> soilTh[:] = z - BRz
-    >>> expweath = ExponentialWeathering(mg)
+    >>> expweath = ExponentialWeatherer(mg)
     >>> DDdiff = DepthDependentDiffuser(mg)
-    >>> expweath.exponentialweather()
+    >>> expweath.calc_soil_prod_rate()
     >>> mynodes = mg.nodes[2, :]
     >>> np.allclose(
-    ...     mg.at_node['weathering__rate'][mynodes],
+    ...     mg.at_node['soil_production__rate'][mynodes],
     ...     np.array([ 1., 0.60653066, 0.36787944, 0.22313016, 0.13533528]))
     True
     >>> DDdiff.soilflux(2.)
@@ -75,7 +72,6 @@ class DepthDependentDiffuser(Component):
     True
     >>> np.allclose(mg.at_node['soil__depth'], z - BRz)
     True
-
     """
 
     _name = 'DepthDependentDiffuser'
@@ -83,7 +79,7 @@ class DepthDependentDiffuser(Component):
     _input_var_names = (
         'topographic__elevation',
         'soil__depth',
-        'weathering__rate',
+        'soil_production__rate',
     )
     
     _output_var_names = (
@@ -99,7 +95,7 @@ class DepthDependentDiffuser(Component):
         'topographic__slope' : 'm/m',
         'soil__depth' : 'm',
         'soil__flux' : 'm^2/yr',
-        'weathering__rate' : 'm/yr',
+        'soil_production__rate' : 'm/yr',
         'bedrock__elevation' : 'm',
     }
     
@@ -108,7 +104,7 @@ class DepthDependentDiffuser(Component):
         'topographic__slope' : 'link',
         'soil__depth' : 'node',
         'soil__flux' : 'link',
-        'weathering__rate' : 'node',
+        'soil_production__rate' : 'node',
         'bedrock__elevation' :'node',
     }
         
@@ -121,64 +117,61 @@ class DepthDependentDiffuser(Component):
                 'depth of soil/weather bedrock',
         'soil__flux':
                 'flux of soil in direction of link', 
-        'weathering__rate':
+        'soil_production__rate':
                 'rate of soil production at nodes',
         'bedrock__elevation':
                 'elevation of the bedrock surface',
     }
 
-    def __init__(self,grid,k=1,hstar=1,**kwds):
-        
+    def __init__(self,grid, soil_creep_efficiency=1.0,
+                 soil_transport_decay_depth=1.0, **kwds):
+        """Initialize the DepthDependentDiffuser."""
        
-        
-        #Store grid and parameters
+        # Store grid and parameters
         self._grid = grid
-        self.k = k
-        self.hstar = hstar
-        
-        
-        
-        #create fields
-        #elevation
+        self._kd = soil_creep_efficiency * soil_transport_decay_depth
+        self.soil_transport_decay_depth = soil_transport_decay_depth
+
+        # create fields
+        # elevation
         if 'topographic__elevation' in self.grid.at_node:
             self.elev = self.grid.at_node['topographic__elevation']
         else:
             self.elev = self.grid.add_zeros('node','topographic__elevation')
         
-        #slope
+        # slope
         if 'topographic__slope' in self.grid.at_link:
             self.slope = self.grid.at_link['topographic__slope']
         else:
             self.slope = self.grid.add_zeros('link','topographic__slope')
         
-        #soil depth
+        # soil depth
         if 'soil__depth' in self.grid.at_node:
             self.depth = self.grid.at_node['soil__depth']
         else:
             self.depth = self.grid.add_zeros('node','soil__depth')
         
-        #soil flux
+        # soil flux
         if 'soil__flux' in self.grid.at_link:
             self.flux = self.grid.at_link['soil__flux']
         else:
             self.flux=self.grid.add_zeros('link','soil__flux')
             
-        #weathering rate
-        if 'weathering__rate' in self.grid.at_node:
-            self.weather = self.grid.at_node['weathering__rate']
+        # weathering rate
+        if 'soil_production__rate' in self.grid.at_node:
+            self.soil_prod_rate = self.grid.at_node['soil_production__rate']
         else:
-            self.weather=self.grid.add_zeros('node','weathering__rate')
+            self.soil_prod_rate = self.grid.add_zeros('node','soil_production__rate')
             
-        #bedrock elevation
+        # bedrock elevation
         if 'bedrock__elevation' in self.grid.at_node:
             self.bedrock = self.grid.at_node['bedrock__elevation']
         else:
             self.bedrock = self.grid.add_zeros('node','bedrock__elevation')
- 
+
         self._active_nodes = self.grid.status_at_node != CLOSED_BOUNDARY
-        
-        
-    
+
+
     def soilflux(self, dt):
         """Calculate soil flux for a time period 'dt'.
 
@@ -187,41 +180,45 @@ class DepthDependentDiffuser(Component):
 
         dt: float (time)
             The imposed timestep.
-
         """
 
+        #update soil thickness
+        self.grid.at_node['soil__depth'][:] = (self.grid.at_node['topographic__elevation'] - 
+                                               self.grid.at_node['bedrock__elevation'])
 
-        #update soil depth
-        self.grid.at_node['soil__depth'][:] = self.grid.at_node['topographic__elevation'] - self.grid.at_node['bedrock__elevation']
-        
         #Calculate soil depth at links.
         H_link = self.grid.map_value_at_max_node_to_link('topographic__elevation','soil__depth')
-        
+
         #Calculate gradients
         slope = self.grid.calc_grad_at_link(self.elev)
         slope[self.grid.status_at_link == INACTIVE_LINK] = 0.
-        
+
         #Calculate flux
-        self.flux[:] = -self.k*slope*self.hstar*(1.-np.exp(-H_link/self.hstar))
-        
+        self.flux[:] = (-self._kd
+                        * slope 
+                        * (1.0 - np.exp(-H_link
+                                        / self.soil_transport_decay_depth)))
+
         #Calculate flux divergence
         dqdx = self.grid.calc_flux_div_at_node(self.flux)
         dqdx[self.grid.status_at_node == CLOSED_BOUNDARY] = 0.
-        
+
         #Calculate change in soil depth
-        dhdt = self.weather-dqdx
-        
+        dhdt = self.soil_prod_rate - dqdx
+
         #Calculate soil depth at nodes
-        self.depth[self._active_nodes] += dhdt[self._active_nodes]*dt
+        self.depth[self._active_nodes] += dhdt[self._active_nodes] * dt
         
         #prevent negative soil thickness
         self.depth[self.depth < 0.0] = 0.0
 
         #Calculate bedrock elevation
-        self.bedrock[self._active_nodes] -= self.weather[self._active_nodes]*dt
+        self.bedrock[self._active_nodes] -= (self.soil_prod_rate[self._active_nodes] 
+                                             * dt)
 
         #Update topography
-        self.elev[self._active_nodes] = self.depth[self._active_nodes]+self.bedrock[self._active_nodes]
+        self.elev[self._active_nodes] = (self.depth[self._active_nodes]
+                                         + self.bedrock[self._active_nodes])
 
 
     def run_one_step(self, dt, **kwds):
@@ -232,7 +229,5 @@ class DepthDependentDiffuser(Component):
         dt: float (time)
             The imposed timestep.
         """
-       
-        
 
         self.soilflux(dt, **kwds)

--- a/landlab/components/weathering/__init__.py
+++ b/landlab/components/weathering/__init__.py
@@ -1,4 +1,4 @@
-from .exponential_weathering import ExponentialWeathering
+from .exponential_weathering import ExponentialWeatherer
 
-__all__ = ['ExponentialWeathering', ]
+__all__ = ['ExponentialWeatherer', ]
 


### PR DESCRIPTION
Some syntactical and PEP8 edits to RCG's Depth-Dependent Diffusion and Expo Weathering components.

@kbarnhart when you review this could you get Rachel to look over your shoulder? Want to make sure she's on board. Edits are mostly to do with var naming. Parameter names should mirror those used in input files, and longer descriptive names are generally better than names like "k". I changed "weathering" to "soil production" because geochem folks have other meanings for "weathering" (of course soil scientists might not like "soil production" either, but "mobile regolith production" seems too long)