### PR TITLE
fastscape assert now passes float64; also tiny doc tweak

### DIFF
--- a/docs/landlab.components.stream_power.rst
+++ b/docs/landlab.components.stream_power.rst
@@ -6,7 +6,7 @@ FastscapeEroder: Compute fluvial erosion using stream power theory ("fastscape" 
     :undoc-members:
     :show-inheritance:
 
-StreamPower: Compute fluvial erosion using stream power theory (explicit forward-difference solution)
+StreamPower: Compute fluvial erosion using stream power theory (also uses "fastscape" algorithm but provides slightly different formulation and options)
 -----------------------------------------------------------------------------------------------------
 
 .. automodule:: landlab.components.stream_power.stream_power

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -337,7 +337,8 @@ class FastscapeEroder(Component):
         else:
             K_here = self.K
         if rainfall_intensity_if_used is not None:
-            assert type(rainfall_intensity_if_used) in (float, int)
+            assert type(rainfall_intensity_if_used) in (float, numpy.float64, 
+                                                        int)
             r_i_here = float(rainfall_intensity_if_used)
         else:
             r_i_here = self._r_i


### PR DESCRIPTION
FastscapeEroder has an assert to test assumption that if rainfall_intensity is not a field (name, array, etc.), then it is either float or int. But it's possible for a driver to have it be a numpy.float64. That's now added.
Also changed an outdated doc comment saying (incorrectly) that StreamPowerEroder doesn't use fastscape algo.
By the way, why do we have 2 stream power components that use the same algo?