### PR TITLE
Fix issue 432

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    - hdf4 >= 4.2.12 # [not win and np == '111']
+    - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml
@@ -30,7 +30,7 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    - hdf4 >= 4.2.12 # [not win and np == '111']
+    - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -15,6 +15,7 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
+    - hdf4 >= 4.2.12 # [not win and np == '111']
     - cython
     - six
     - pyyaml
@@ -29,6 +30,7 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
+    - hdf4 >= 4.2.12 # [not win and np == '111']
     - cython
     - six
     - pyyaml


### PR DESCRIPTION
This PR kind of fixes issue #432. The problem is that installing from the default Anaconda channel (installing from the conda-forge channel works) creates a version conflict (between numpy-1.11, jpeg-9b, and hdf4-4.2.12) when using netcdf4-1.2.4. This seems to only be a problem on Mac and Linux and numpy-1.11.

I've added a requirement in `meta.yaml` for `hdf4 >= 4.2.12` for the problem build cases. I hope this will resolve itself and, in the future, we can remove this requirement. Anyway, this should get our builds on `master` passing again.