### PR TITLE
Fix issue #428

### DIFF
--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -3276,14 +3276,12 @@ class ModelGrid(ModelDataFieldsMixIn):
         self._reset_lists_of_nodes_cells()
         self._create_active_faces()
 
-        try:
-            self._active_link_dirs_at_node[:] = self._link_dirs_at_node[:]
-            inactive_links = (self.status_at_link[self.links_at_node] ==
-                              INACTIVE_LINK)
-            inactive_links[self.link_dirs_at_node == 0] = False
-            self._active_link_dirs_at_node[inactive_links] = 0
-        except AttributeError:  # doesn't exist yet
-            pass
+        self._active_link_dirs_at_node[:] = self._link_dirs_at_node[:]
+        inactive_links = (self.status_at_link[self.links_at_node] ==
+                          INACTIVE_LINK)
+        inactive_links[self.link_dirs_at_node == 0] = False
+        self._active_link_dirs_at_node[inactive_links] = 0
+
         try:
             if self.diagonal_list_created:
                 self.diagonal_list_created = False

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -3275,7 +3275,9 @@ class ModelGrid(ModelDataFieldsMixIn):
         self._reset_link_status_list()
         self._reset_lists_of_nodes_cells()
         self._create_active_faces()
+
         try:
+            self._active_link_dirs_at_node[:] = self._link_dirs_at_node[:]
             inactive_links = (self.status_at_link[self.links_at_node] ==
                               INACTIVE_LINK)
             inactive_links[self.link_dirs_at_node == 0] = False

--- a/landlab/grid/tests/test_raster_grid/test_BC_updates.py
+++ b/landlab/grid/tests/test_raster_grid/test_BC_updates.py
@@ -13,6 +13,37 @@ def setup_grid():
     })
 
 
+def test_issue_428_a():
+    """Issue #428"""
+    grid = RasterModelGrid((4, 4))
+    grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
+
+    assert_equal(grid.status_at_node[1], 4)
+    assert_equal(grid.status_at_link[4], 4)
+    assert_array_equal(grid.active_link_dirs_at_node[1],[0, 0, 0, 0])
+
+    grid.status_at_node[1] = 1
+    assert_equal(grid.status_at_link[4], 0)
+    assert_array_equal(grid.active_link_dirs_at_node[1], [0, -1, 0, 0])
+
+
+def test_issue_428_b():
+    """Issue #428"""
+    grid = RasterModelGrid((4, 4))
+
+    z = np.ones(grid.number_of_nodes)
+    z[grid.nodes_at_bottom_edge] = -9999.
+    z[grid.nodes_at_left_edge] = -9999.
+    z[grid.nodes_at_top_edge] = -9999.
+    z[grid.nodes_at_right_edge] = -9999.
+    z[1] = .5
+
+    assert_array_equal(grid.active_link_dirs_at_node[1], [0, -1, 0, 0])
+
+    grid.set_watershed_boundary_condition(z)
+    assert_array_equal(grid.active_link_dirs_at_node[1], [0, -1, 0, 0])
+
+
 @with_setup(setup_grid)
 def test_link_update_with_nodes_closed():
     rmg.status_at_node[rmg.nodes_at_bottom_edge] = CLOSED_BOUNDARY


### PR DESCRIPTION
This pull request is intended to fix issue #428.

I've made only a small change in `_update_links_nodes_cells_to_new_BCs`. Now the active link directions are rest to the link directions and then the active link directions are reset based on the current boundary conditions.

I also added a couple tests that reproduce the two issues described in #428.