### PR TITLE
Kbarnhart/stream power error

### DIFF
--- a/landlab/components/stream_power/cfuncs.pyx
+++ b/landlab/components/stream_power/cfuncs.pyx
@@ -92,7 +92,7 @@ def erode_with_link_alpha_varthresh(np.ndarray[DTYPE_INT_t, ndim=1] src_nodes,
         dst_id = dst_nodes[src_id]
         threshxdt = threshsxdt[i]
 
-        if src_id != dst_id:
+        if src_id != dst_id and z[src_id] > z[dst_id]:
             next_z = z[src_id]
             prev_z = 0.
             niter = 0

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -490,9 +490,6 @@ class StreamPowerEroder(Component):
 
         # Disable incision in flooded nodes, as appropriate
         if flooded_nodes is not None:
-            if flooded_nodes.dtype != bool:
-                flooded_nodes = flooded_nodes.astype(bool)
-            flooded_nodes = flooded_nodes
             _K_unit_time[flooded_nodes] = 0.
 
         # Operate the main function:


### PR DESCRIPTION
A few errors in stream power discovered through use. 

1. accidental conversion of flooded_nodes to boolean if it is provided as at_node array

2. making the critera uniform between the two functions in the cfuncs.pyx in stream_power. 