### PR TITLE
Gt fix fastscape variable k

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.ipynb_checkpoints
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -248,8 +248,9 @@ class FastscapeEroder(Component):
                 self.K = self._grid.at_node[K_sp]
         elif type(K_sp) in (float, int):  # a float
             self.K = float(K_sp)
-        elif len(K_sp) == self.grid.number_of_nodes:
-            self.K = numpy.array(K_sp)
+        elif (type(K_sp) is numpy.ndarray
+              and len(K_sp) == self.grid.number_of_nodes):
+            self.K = K_sp
         else:
             raise TypeError('Supplied type of K_sp ' +
                             'was not recognised, or array was ' +

--- a/landlab/components/stream_power/stream_power_smooth_threshold.py
+++ b/landlab/components/stream_power/stream_power_smooth_threshold.py
@@ -228,6 +228,18 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
         else:
             thresh = self.thresholds
 
+        # Handle possibility of spatially varying K
+        if type(self.K) is np.ndarray:
+            K = self.K[defined_flow_receivers]
+        else:
+            K = self.K
+
+        # Handle possibility of spatially varying threshold
+        if type(self.thresholds) is np.ndarray:
+            thresh = self.thresholds[defined_flow_receivers]
+        else:
+            thresh = self.thresholds            
+
         # Set up alpha, beta, delta arrays
         #
         #   First, compute drainage area or discharge raised to the power m.
@@ -236,7 +248,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
 
         #   Alpha
         self.alpha[defined_flow_receivers==False] = 0.0
-        self.alpha[defined_flow_receivers] = (self.K * dt
+        self.alpha[defined_flow_receivers] = (K * dt
             * self.A_to_the_m[defined_flow_receivers] / flow_link_lengths)
 
         #   Gamma
@@ -244,7 +256,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
         self.gamma[defined_flow_receivers] = dt * thresh
 
         #   Delta
-        self.delta[defined_flow_receivers] = ((self.K
+        self.delta[defined_flow_receivers] = ((K
             * self.A_to_the_m[defined_flow_receivers] ) 
             / (thresh * flow_link_lengths))
 
@@ -264,6 +276,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
                                  #fprime2=new_elev_prime2)
 
         # TODO: handle case self.thresholds = 0
+        # THIS WOULD REQUIRE SETTING DELTA = 0 WHEN/WHERE THRESHOLD = 0
 
 
 


### PR DESCRIPTION
Minor change to FastscapeEroder: previously, when user passes an array as K_sp, the component makes a copy. Better if the user can change the K_sp field dynamically, however. Now changed to use a reference to the passed K_sp array, so if user changes the array, FastscapeEroder will "see" the changes.

@kbarnhart or @SiccarPoint could you take a quick look and merge please?