### PR TITLE
Kbarnhart/consistent parameter names

### DIFF
--- a/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
+++ b/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
@@ -123,7 +123,7 @@ class CubicNonLinearDiffuser(Component):
 
         # Calculate flux
         self.flux[:] = -(self.K * self.slope
-                         + (self.K
+                         + ((self.K/(self.slope_crit**2))
                             * np.power(self.slope, 3)))
 
         # Calculate flux divergence

--- a/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
+++ b/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
@@ -21,8 +21,8 @@ class CubicNonLinearDiffuser(Component):
     ----------
     grid: ModelGrid
             Landlab ModelGrid object
-    soil_transport_coefficient: float
-            Hillslope efficiency, m/yr
+    k_over_slope_crit_sq: float
+            Hillslope diffusivity, m**2/yr
     slope_crit: float
             Critical slope 
         
@@ -81,7 +81,7 @@ class CubicNonLinearDiffuser(Component):
                 'flux of soil in direction of link', 
     }
 
-    def __init__(self, grid, soil_transport_coefficient=1., slope_crit=1.,
+    def __init__(self, grid, diffusivity=1., slope_crit=1.,
                  **kwds):
         
         """Initialize CubicNonLinearDiffuser.
@@ -89,12 +89,8 @@ class CubicNonLinearDiffuser(Component):
 
         # Store grid and parameters
         self._grid = grid
-        self.k = soil_transport_coefficient
+        self.K = diffusivity
         self.slope_crit = slope_crit
-
-        # For efficiency, store the quantity Kd / Sc^2
-        self.k_over_slope_crit_sq = (soil_transport_coefficient
-                                     / (slope_crit * slope_crit))
 
         # Create fields:
         #
@@ -126,8 +122,8 @@ class CubicNonLinearDiffuser(Component):
         self.slope[self.grid.status_at_link == INACTIVE_LINK] = 0.
 
         # Calculate flux
-        self.flux[:] = -(self.k * self.slope
-                         + (self.k_over_slope_crit_sq 
+        self.flux[:] = -(self.K * self.slope
+                         + (self.K
                             * np.power(self.slope, 3)))
 
         # Calculate flux divergence

--- a/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
+++ b/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
@@ -21,7 +21,7 @@ class CubicNonLinearDiffuser(Component):
     ----------
     grid: ModelGrid
             Landlab ModelGrid object
-    k_over_slope_crit_sq: float
+    diffusivity: float
             Hillslope diffusivity, m**2/yr
     slope_crit: float
             Critical slope 

--- a/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
+++ b/landlab/components/cubic_nonlinear_hillslope_flux/cubic_nonlinear_hillslope_flux.py
@@ -21,7 +21,7 @@ class CubicNonLinearDiffuser(Component):
     ----------
     grid: ModelGrid
             Landlab ModelGrid object
-    diffusivity: float
+    linear_diffusivity: float
             Hillslope diffusivity, m**2/yr
     slope_crit: float
             Critical slope 
@@ -81,7 +81,7 @@ class CubicNonLinearDiffuser(Component):
                 'flux of soil in direction of link', 
     }
 
-    def __init__(self, grid, diffusivity=1., slope_crit=1.,
+    def __init__(self, grid, linear_diffusivity=1., slope_crit=1.,
                  **kwds):
         
         """Initialize CubicNonLinearDiffuser.
@@ -89,7 +89,7 @@ class CubicNonLinearDiffuser(Component):
 
         # Store grid and parameters
         self._grid = grid
-        self.K = diffusivity
+        self.K = linear_diffusivity
         self.slope_crit = slope_crit
 
         # Create fields:

--- a/landlab/components/depth_dependent_cubic_soil_creep/hillslope_depth_dependent_cubic_flux.py
+++ b/landlab/components/depth_dependent_cubic_soil_creep/hillslope_depth_dependent_cubic_flux.py
@@ -20,7 +20,7 @@ class DepthDependentCubicDiffuser(Component):
     ----------
     grid: ModelGrid
         Landlab ModelGrid object
-    diffusivity: float
+    linear_diffusivity: float
         Hillslope diffusivity, m**2/yr
     slope_crit: float
         Critical gradient parameter, m/m
@@ -128,7 +128,7 @@ class DepthDependentCubicDiffuser(Component):
     }
 
     def __init__(self,grid,
-                 diffusivity=1.0,
+                 linear_diffusivity=1.0,
                  slope_crit=1.0,
                  soil_transport_decay_depth=1.0,
                  **kwds):
@@ -136,7 +136,7 @@ class DepthDependentCubicDiffuser(Component):
 
         # Store grid and parameters
         self._grid = grid
-        self.K = diffusivity
+        self.K = linear_diffusivity
         self.soil_transport_decay_depth = soil_transport_decay_depth
         self.slope_crit = slope_crit
 

--- a/landlab/components/depth_dependent_cubic_soil_creep/hillslope_depth_dependent_cubic_flux.py
+++ b/landlab/components/depth_dependent_cubic_soil_creep/hillslope_depth_dependent_cubic_flux.py
@@ -20,8 +20,8 @@ class DepthDependentCubicDiffuser(Component):
     ----------
     grid: ModelGrid
         Landlab ModelGrid object
-    soil_creep_efficiency: float
-        Hillslope efficiency, m/yr
+    diffusivity: float
+        Hillslope diffusivity, m**2/yr
     slope_crit: float
         Critical gradient parameter, m/m
     soil_transport_decay_depth: float
@@ -127,18 +127,18 @@ class DepthDependentCubicDiffuser(Component):
                 'elevation of the bedrock surface',
     }
 
-    def __init__(self,grid, soil_creep_efficiency=1.0, slope_crit=1.0,
-                 soil_transport_decay_depth=1.0, **kwds):
+    def __init__(self,grid,
+                 diffusivity=1.0,
+                 slope_crit=1.0,
+                 soil_transport_decay_depth=1.0,
+                 **kwds):
         """Initialize the DepthDependentCubicDiffuser."""
 
         # Store grid and parameters
         self._grid = grid
-        self._kd = soil_creep_efficiency * soil_transport_decay_depth
+        self.K = diffusivity
         self.soil_transport_decay_depth = soil_transport_decay_depth
         self.slope_crit = slope_crit
-
-        # For efficiency, store the quantity Kd / Sc^2
-        self.k_over_slope_crit_sq = self._kd / (slope_crit * slope_crit)
 
         # create fields
         # elevation
@@ -204,10 +204,10 @@ class DepthDependentCubicDiffuser(Component):
         #print(self.elev[nn])
 
         #Calculate flux
-        self.flux[:] = -((self._kd * slope
-                          + self.k_over_slope_crit_sq * np.power(slope, 3))
-                         * (1.0 - np.exp(-H_link
-                                         / self.soil_transport_decay_depth)))
+        self.flux[:] = -((self.K*slope
+                       + (self.K/(self.slope_crit**2)) * np.power(slope, 3))
+                        * (1.0 - np.exp(-H_link
+                                        / self.soil_transport_decay_depth)))
 
         #Calculate flux divergence
         dqdx = self.grid.calc_flux_div_at_node(self.flux)

--- a/landlab/components/depth_dependent_cubic_soil_creep/tests/test_depth_dependent_cubic_diffuser.py
+++ b/landlab/components/depth_dependent_cubic_soil_creep/tests/test_depth_dependent_cubic_diffuser.py
@@ -28,7 +28,7 @@ def test_4x7_grid_vs_analytical_solution():
     # Instantiate components, and set their parameters. Note that traditional
     # diffusivity, D, is D = SCE x H*, where SCE is soil-creep efficiency.
     # Here we want D = 0.01 m2/yr and H* = 0,.5 m, so cwe set SCE = 0.02.
-    diffuser = DepthDependentCubicDiffuser(mg, diffusivity=0.01,
+    diffuser = DepthDependentCubicDiffuser(mg, linear_diffusivity=0.01,
                                            slope_crit=0.8,
                                            soil_transport_decay_depth=0.5)
     weatherer = ExponentialWeatherer(mg, max_soil_production_rate=0.0002,

--- a/landlab/components/depth_dependent_cubic_soil_creep/tests/test_depth_dependent_cubic_diffuser.py
+++ b/landlab/components/depth_dependent_cubic_soil_creep/tests/test_depth_dependent_cubic_diffuser.py
@@ -28,7 +28,7 @@ def test_4x7_grid_vs_analytical_solution():
     # Instantiate components, and set their parameters. Note that traditional
     # diffusivity, D, is D = SCE x H*, where SCE is soil-creep efficiency.
     # Here we want D = 0.01 m2/yr and H* = 0,.5 m, so cwe set SCE = 0.02.
-    diffuser = DepthDependentCubicDiffuser(mg, soil_creep_efficiency=0.02,
+    diffuser = DepthDependentCubicDiffuser(mg, diffusivity=0.01,
                                            slope_crit=0.8,
                                            soil_transport_decay_depth=0.5)
     weatherer = ExponentialWeatherer(mg, max_soil_production_rate=0.0002,

--- a/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
+++ b/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
@@ -19,8 +19,10 @@ class DepthDependentDiffuser(Component):
     ----------
     grid: ModelGrid
         Landlab ModelGrid object
-    soil_creep_efficiency: float
-        Hillslope efficiency, m/yr
+    linear_diffusivity: float
+        Hillslope diffusivity, m**2/yr
+        Equivalent to the soil creep efficiency 
+        times the soil transport decay depth.
     soil_transport_decay_depth: float
         characteristic transport soil depth, m
 
@@ -124,13 +126,13 @@ class DepthDependentDiffuser(Component):
                 'elevation of the bedrock surface',
     }
 
-    def __init__(self,grid, soil_creep_efficiency=1.0,
+    def __init__(self,grid, linear_diffusivity=1.0,
                  soil_transport_decay_depth=1.0, **kwds):
         """Initialize the DepthDependentDiffuser."""
 
         # Store grid and parameters
         self._grid = grid
-        self._kd = soil_creep_efficiency * soil_transport_decay_depth
+        self.K = linear_diffusivity
         self.soil_transport_decay_depth = soil_transport_decay_depth
 
         # create fields
@@ -198,7 +200,7 @@ class DepthDependentDiffuser(Component):
         slope[self.grid.status_at_link == INACTIVE_LINK] = 0.
 
         #Calculate flux
-        self.flux[:] = (-self._kd
+        self.flux[:] = (-self.K
                         * slope
                         * (1.0 - np.exp(-H_link
                                         / self.soil_transport_decay_depth)))


### PR DESCRIPTION
Changes parameter names and input parameters for three hillslope components

CubicNonLinearDiffuser
DepthDependentCubicDiffuser
DepthDependentDiffuser

that took as input parameters a variety of "efficiencies" that were derivatives of the hillslope diffusivity and other given input parameters. 

In order to move towards standardization, all have been replaced with linear_diffusivity and small bits of the component code has changed to account for conversion.