### PR TITLE
no deposit option for linear diffusion

### DIFF
--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -74,7 +74,7 @@ class LinearDiffuser(Component):
         performed on a raster. 'on_diagonals' pretends that the "faces" of a
         cell with 8 links are represented by a stretched regular octagon set
         within the true cell.
-    deposit : {'yes', 'no'}
+    deposit : {'True', 'False'}
         Whether diffusive material can be deposited. 'yes' means that diffusive 
         material will be deposited if the divergence of sediment flux is 
         negative. 'no' means that even when the divergence of sediment flux is 
@@ -168,7 +168,7 @@ class LinearDiffuser(Component):
 
     @use_file_name_or_kwds
     def __init__(self, grid, linear_diffusivity=None, method='simple',
-                 deposit='yes', **kwds):
+                 deposit='True', **kwds):
         self._grid = grid
         self._bc_set_code = self.grid.bc_set_code
         assert method in ('simple', 'resolve_on_patches', 'on_diagonals')
@@ -213,12 +213,9 @@ class LinearDiffuser(Component):
         if self._use_patches:
             assert self._kd_on_links
         # set _deposit flag to tell code whether or not diffusion can deposit.    
-        if deposit == 'yes':
-            self._deposit = True
-        else:
-            self._deposit = False
         
-
+        self._deposit = deposit
+    
         # for component back compatibility (undocumented):
         # note component can NO LONGER do internal uplift, at all.
         # ###

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -75,15 +75,15 @@ class LinearDiffuser(Component):
         cell with 8 links are represented by a stretched regular octagon set
         within the true cell.
     deposit : {'True', 'False'}
-        Whether diffusive material can be deposited. 'yes' means that diffusive 
+        Whether diffusive material can be deposited. 'True' means that diffusive 
         material will be deposited if the divergence of sediment flux is 
-        negative. 'no' means that even when the divergence of sediment flux is 
-        negative, no material is deposited. (No deposition ever.) The 'no'
+        negative. 'False' means that even when the divergence of sediment flux is 
+        negative, no material is deposited. (No deposition ever.) The 'False'
         case is a bit of a band-aid to account for cases when fluvial incision
         likely removes any material that would be deposited. If one couples
         fluvial detachment-limited incision with linear diffusion, the channels
         will not reach the predicted analytical solution unless deposit is set
-        to 'no'.
+        to 'False'.
 
     Examples
     --------

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -74,16 +74,16 @@ class LinearDiffuser(Component):
         performed on a raster. 'on_diagonals' pretends that the "faces" of a
         cell with 8 links are represented by a stretched regular octagon set
         within the true cell.
-    deposit : {'True', 'False'}
-        Whether diffusive material can be deposited. 'True' means that diffusive 
+    deposit : {True, False}
+        Whether diffusive material can be deposited. True means that diffusive 
         material will be deposited if the divergence of sediment flux is 
-        negative. 'False' means that even when the divergence of sediment flux is 
-        negative, no material is deposited. (No deposition ever.) The 'False'
+        negative. False means that even when the divergence of sediment flux is 
+        negative, no material is deposited. (No deposition ever.) The False
         case is a bit of a band-aid to account for cases when fluvial incision
         likely removes any material that would be deposited. If one couples
         fluvial detachment-limited incision with linear diffusion, the channels
         will not reach the predicted analytical solution unless deposit is set
-        to 'False'.
+        to False.
 
     Examples
     --------
@@ -168,7 +168,7 @@ class LinearDiffuser(Component):
 
     @use_file_name_or_kwds
     def __init__(self, grid, linear_diffusivity=None, method='simple',
-                 deposit='True', **kwds):
+                 deposit=True, **kwds):
         self._grid = grid
         self._bc_set_code = self.grid.bc_set_code
         assert method in ('simple', 'resolve_on_patches', 'on_diagonals')

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -74,6 +74,16 @@ class LinearDiffuser(Component):
         performed on a raster. 'on_diagonals' pretends that the "faces" of a
         cell with 8 links are represented by a stretched regular octagon set
         within the true cell.
+    deposit : {'yes', 'no'}
+        Whether diffusive material can be deposited. 'yes' means that diffusive 
+        material will be deposited if the divergence of sediment flux is 
+        negative. 'no' means that even when the divergence of sediment flux is 
+        negative, no material is deposited. (No deposition ever.) The 'no'
+        case is a bit of a band-aid to account for cases when fluvial incision
+        likely removes any material that would be deposited. If one couples
+        fluvial detachment-limited incision with linear diffusion, the channels
+        will not reach the predicted analytical solution unless deposit is set
+        to 'no'.
 
     Examples
     --------
@@ -158,7 +168,7 @@ class LinearDiffuser(Component):
 
     @use_file_name_or_kwds
     def __init__(self, grid, linear_diffusivity=None, method='simple',
-                 **kwds):
+                 deposit='yes', **kwds):
         self._grid = grid
         self._bc_set_code = self.grid.bc_set_code
         assert method in ('simple', 'resolve_on_patches', 'on_diagonals')
@@ -202,6 +212,12 @@ class LinearDiffuser(Component):
         # *directionality* in the diffusivities.
         if self._use_patches:
             assert self._kd_on_links
+        # set _deposit flag to tell code whether or not diffusion can deposit.    
+        if deposit == 'yes':
+            self._deposit = True
+        else:
+            self._deposit = False
+        
 
         # for component back compatibility (undocumented):
         # note component can NO LONGER do internal uplift, at all.
@@ -533,6 +549,8 @@ class LinearDiffuser(Component):
 
             # Calculate the total rate of elevation change
             dzdt = - self.dqsds
+            if not self._deposit :
+                dzdt[np.where(dzdt>0)] = 0.
             # Update the elevations
             timestep = self.dt
             if i == (repeats):

--- a/landlab/components/diffusion/tests/test_sniff_diffusion.py
+++ b/landlab/components/diffusion/tests/test_sniff_diffusion.py
@@ -126,7 +126,7 @@ def test_diffusion():
 def test_diffusion_no_deposit():
     # Make an array with three core nodes, in one column.
     # Because there is zero slope between two of the nodes, there 
-    # would be deposition. However, with the deposit flag as 'no',
+    # would be deposition. However, with the deposit flag as 'False',
     # the elevation of the node with zero downslope gradient will not change.
     # Use closed boundaries all around because this is a simpler scenario.
     mg = RasterModelGrid((5, 3), (10, 10))
@@ -138,7 +138,7 @@ def test_diffusion_no_deposit():
     
     # The gradient at node 7 should be zero, so the elevation here would
     # go up if deposition was allowed. Maker sure it doesn't change with 
-    # deposit set to 'no'
+    # deposit set to 'False'
     z_7_before = z[7]
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, True)

--- a/landlab/components/diffusion/tests/test_sniff_diffusion.py
+++ b/landlab/components/diffusion/tests/test_sniff_diffusion.py
@@ -145,7 +145,7 @@ def test_diffusion_no_deposit():
 
     # instantiate:
     dfn = LinearDiffuser(mg, linear_diffusivity=1., method='simple',
-                 deposit='no')
+                 deposit='False')
     
     dfn.run_one_step(100)
     

--- a/landlab/components/diffusion/tests/test_sniff_diffusion.py
+++ b/landlab/components/diffusion/tests/test_sniff_diffusion.py
@@ -6,7 +6,8 @@ functionality is working.
 import os
 
 import numpy as np
-from numpy.testing import assert_array_equal, assert_array_almost_equal
+from numpy.testing import assert_array_equal, assert_array_almost_equal, \
+     assert_equal
 try:
     from nose.tools import assert_is
 except ImportError:
@@ -121,3 +122,36 @@ def test_diffusion():
                             5.80291603e-05,   4.34416626e-04])
 
     assert_array_almost_equal(mg.at_node['topographic__elevation'], z_target)
+    
+def test_diffusion_no_deposit():
+    # Make an array with three core nodes, in one column.
+    # Because there is zero slope between two of the nodes, there 
+    # would be deposition. However, with the deposit flag as 'no',
+    # the elevation of the node with zero downslope gradient will not change.
+    # Use closed boundaries all around because this is a simpler scenario.
+    mg = RasterModelGrid((5, 3), (10, 10))
+    z = mg.zeros(at='node')
+    z[4]=3.
+    z[7]=3.
+    z[10]=4.
+    mg['node']['topographic__elevation'] = z
+    
+    # The gradient at node 7 should be zero, so the elevation here would
+    # go up if deposition was allowed. Maker sure it doesn't change with 
+    # deposit set to 'no'
+    z_7_before = z[7]
+
+    mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
+
+    # instantiate:
+    dfn = LinearDiffuser(mg, linear_diffusivity=1., method='simple',
+                 deposit='no')
+    
+    dfn.run_one_step(100)
+    
+    z_7_after = z[7]
+    
+    assert_equal(z_7_before, z_7_after)
+    
+    
+

--- a/landlab/components/diffusion/tests/test_sniff_diffusion.py
+++ b/landlab/components/diffusion/tests/test_sniff_diffusion.py
@@ -145,7 +145,7 @@ def test_diffusion_no_deposit():
 
     # instantiate:
     dfn = LinearDiffuser(mg, linear_diffusivity=1., method='simple',
-                 deposit='False')
+                 deposit=False)
     
     dfn.run_one_step(100)
     


### PR DESCRIPTION
deposit flag added to linear diffusion for new option to make diffusion only erode. Material that would be deposited 'disappears' - presumably because it is taken up by fluvial channels.