### PR TITLE
add basic version of implicit kinwave model

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -5,8 +5,13 @@ from .detachment_ltd_erosion import DetachmentLtdErosion, DepthSlopeProductErosi
 from .flexure import Flexure
 from .flow_routing import FlowRouter, DepressionFinderAndRouter
 from .nonlinear_diffusion import PerronNLDiffuse
+from .flow_director import FlowDirectorD8
+from .flow_director import FlowDirectorSteepest
+from .flow_director import FlowDirectorMFD
+from .flow_director import FlowDirectorDINF
+from .flow_accum import FlowAccumulator
 from .overland_flow import OverlandFlowBates, OverlandFlow
-from .overland_flow import KinematicWaveRengers
+from .overland_flow import KinematicWaveRengers, KinwaveImplicitOverlandFlow
 from .potentiality_flowrouting import PotentialityFlowRouter
 from .pet import PotentialEvapotranspiration
 from .radiation import Radiation
@@ -22,17 +27,13 @@ from .gflex import gFlex
 from .drainage_density import DrainageDensity
 from .weathering import ExponentialWeatherer
 from .depth_dependent_diffusion import DepthDependentDiffuser
-from .flow_director import FlowDirectorD8
-from .flow_director import FlowDirectorSteepest
-from .flow_director import FlowDirectorMFD
-from .flow_director import FlowDirectorDINF
-from .flow_accum import FlowAccumulator
 from .cubic_nonlinear_hillslope_flux import CubicNonLinearDiffuser
 from .depth_dependent_cubic_soil_creep import DepthDependentCubicDiffuser
 
 COMPONENTS = [ChiFinder, LinearDiffuser,
               Flexure, FlowRouter, DepressionFinderAndRouter,
               PerronNLDiffuse, OverlandFlowBates, OverlandFlow,
+	      KinwaveImplicitOverlandFlow,
               PotentialEvapotranspiration, PotentialityFlowRouter,
               Radiation, SinkFiller, 
               StreamPowerEroder, StreamPowerSmoothThresholdEroder,

--- a/landlab/components/overland_flow/__init__.py
+++ b/landlab/components/overland_flow/__init__.py
@@ -1,8 +1,10 @@
 from .generate_overland_flow_Bates import OverlandFlowBates
 from .generate_overland_flow_deAlmeida import OverlandFlow
 from .kinematic_wave_rengers import KinematicWaveRengers
+from .generate_overland_flow_implicit_kinwave import KinwaveImplicitOverlandFlow
 
 
 __all__ = ['OverlandFlowBates',
            'OverlandFlow',
+	   'KinwaveImplicitOverlandFlow',
            'KinematicWaveRengers']

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -17,7 +17,9 @@ import numpy as np
 
 def water_fn(x, a, b, c, d, e):
     """Evaluates the solution to the water-depth equation.
-    
+
+    Called by scipy.newton() to find solution for $x$ using Newton's method.
+
     Parameters
     ----------
     x : float

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -228,7 +228,8 @@ class KinwaveImplicitOverlandFlow(Component):
 
         # Instantiate flow router
         self.flow_accum = FlowAccumulator(grid, 'topographic__elevation',
-                                          flow_director='MFD')
+                                    flow_director='MFD',
+                                    partition_method='square_root_of_slope')
 
         # Flag to let us know whether this is our first iteration
         self.first_iteration = True

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -16,6 +16,41 @@ import numpy as np
 
 
 def water_fn(x, a, b, c, d, e):
+    """Evaluates the solution to the water-depth equation.
+    
+    Parameters
+    ----------
+    x : float
+        Water depth at new time step.
+    a : float
+        "alpha" parameter (see below)
+    b : float
+        Weighting factor on new versus old time step. $b=1$ means purely
+        implicit solution with all weight on $H$ at new time step. $b=0$ (not
+        recommended) would mean purely explicit.
+    c : float
+        Water depth at old time step (time step $t$ instead of $t+1$)
+    d : float
+        Depth-discharge exponent; normally either 5/3 (Manning) or 3/2 (Chezy)
+    e : float
+        Water inflow volume per unit cell area in one time step.
+
+    This equation represents the implicit solution for water depth $H$ at the
+    next time step. In the code below, it is formulated in a generic way. 
+    Written using more familiar terminology, the equation is:
+
+    $H - H_0 + \alpha ( w H + (w-1) H_0)^d - \Delta t (R + Q_{in} / A)$
+    
+    $\alpha = \frac{\Delta t \sum S^{1/2}}{C_f A}$
+    
+    where $H$ is water depth at the given node at the new time step, $H_0$ is
+    water depth at the prior time step, $w$ is a weighting factor, $d$ is the
+    depth-discharge exponent (2/3 or 1/2), $\Delta t$ is time-step duration,
+    $R$ is local runoff rate, $Q_{in}$ is inflow discharge, $A$ is cell area,
+    $C_f$ is a dimensional roughness coefficient, and $\sum S^{1/2}$ represents
+    the sum of square-root-of-downhill-gradient over all outgoing (downhill)
+    links.
+    """
     return x - c + a * (b * x + (b - 1.0) * c) ** d - e
 
 

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -1,0 +1,319 @@
+# -*- coding: utf-8 -*-
+"""
+Landlab component for overland flow using a local implicit solution to the
+kinematic-wave approximation.
+
+Created on Fri May 27 14:26:13 2016
+
+@author: gtucker
+"""
+
+
+from landlab import Component
+from landlab.components import FlowAccumulator
+from scipy.optimize import newton
+import numpy as np
+
+
+def water_fn(x, a, b, c, d, e):
+    return x - c + a * (b * x + (b - 1.0) * c) ** d - e
+
+
+class KinwaveImplicitOverlandFlow(Component):
+    """
+    Calculate shallow water flow over topography.
+
+    Landlab component that implements a two-dimensional kinematic wave model.
+    This is a form of the 2D shallow-water equations in which energy slope is
+    assumed to equal bed slope. The solution method is locally implicit, and
+    works as follows. At each time step, we iterate from upstream to downstream
+    over the topography. Because we are working downstream, we can assume that
+    we know the total water inflow to a given cell. We solve the following mass 
+    conservation equation at each cell:
+        
+        $(H^{t+1} - H^t)/\Delta t = Q_{in}/A - Q_{out}/A + R$
+        
+    where $H$ is water depth, $t$ indicates time step number, $\Delta t$ is
+    time step duration, $Q_{in}$ is total inflow discharge, $Q_{out}$ is total
+    outflow discharge, $A$ is cell area, and $R$ is local runoff rate 
+    (precipitation minus infiltration; could be negative if runon infiltration
+    is occurring).
+    
+    The specific outflow discharge leaving a cell along one of its faces is:
+        
+        $q = (1/C_r) H^\alpha S^{1/2}$
+    
+    where $C_r$ is a roughness coefficient (such as Manning's n), $\alpha$ is
+    an exponent equal to 5/3 for the Manning equation and 3/2 for the Chezy
+    family, and $S$ is the downhill-positive gradient of the link that crosses
+    this particular face. Outflow discharge is zero for links that are flat or
+    "uphill" from the given node. Total discharge out of a cell is then the
+    sum of (specific discharge x face width) over all outflow faces
+        
+        $Q_{out} = \sum_{i=1}^N (1/C_r) H^\alpha S_i^{1/2} W_i$
+        
+    where $N$ is the number of outflow faces (i.e., faces where the ground
+    slopes downhill away from the cell's node), and $W_i$ is the width of face
+    $i$.
+    
+    We use the depth at the cell's node, so this simplifies to:
+
+        $Q_{out} = (1/C_r) H'^\alpha \sum_{i=1}^N S_i^{1/2} W_i$
+        
+    We define $H$ in the above as a weighted sum of the "old" (time step $t$)
+    and "new" (time step $t+1$) depth values:
+        
+        $H' = w H^{t+1} + (1-w) H^t$
+    
+    If $w=1$, the method is fully implicit. If $w=0$, it is a simple forward
+    explicit method.
+    
+    When we combine these equations, we have an equation that includes the
+    unknown $H^{t+1}$ and a bunch of terms that are known. If $w\ne 0$, it is
+    a nonlinear equation in $H^{t+1}$, and must be solved iteratively. We do
+    this using a root-finding method in the scipy.optimize library.
+
+    Construction:
+
+        KinwaveImplicitOverlandFlow(grid, precip_rate=1.0,
+                                    precip_duration=1.0,
+                                    infilt_rate=0.0,
+                                    roughness=0.01, **kwds)
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        A Landlab grid object.
+    precip_rate : float, optional (defaults to 1 mm/hr)
+        Precipitation rate, mm/hr
+    precip_duration : float, optional (defaults to 1 hour)
+        Duration of precipitation, hours
+    infilt_rate : float, optional (defaults to 0)
+        Maximum rate of infiltration, mm/hr
+    roughnes : float, defaults to 0.01
+        Manning roughness coefficient, s/m^1/3
+
+    Examples
+    --------
+    >>> from landlab import RasterModelGrid
+    >>> rg = RasterModelGrid((4, 5), 10.0)
+    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> kw = KinwaveImplicitOverlandFlow(rg)
+    >>> round(kw.runoff_rate * 1.0e7, 2)
+    2.78
+    >>> kw.vel_coef  # default value
+    100.0
+    >>> rg.at_node['surface_water__depth'][6:9]
+    array([ 0.,  0.,  0.])
+    """
+
+    _name = 'KinwaveImplicitOverlandFlow'
+
+    _input_var_names = (
+        'topographic__elevation',
+    )
+
+    _output_var_names = (
+        'topographic__gradient',
+        'surface_water__depth',
+        #'water__velocity',
+        #'water__specific_discharge',
+        'surface_water_inflow__discharge',
+    )
+
+    _var_units = {
+        'topographic__elevation': 'm',
+        'topographic__slope': 'm/m',
+        'surface_water__depth': 'm',
+        'water__velocity': 'm/s',
+        'water__specific_discharge': 'm2/s',
+    }
+
+    _var_mapping = {
+        'topographic__elevation': 'node',
+        'topographic__gradient': 'link',
+        'surface_water__depth': 'node',
+        #'water__velocity': 'link',
+        #'water__specific_discharge': 'link',
+        'surface_water_inflow__discharge' : 'node',
+    }
+
+    _var_doc = {
+        'topographic__elevation':
+            'elevation of the ground surface relative to some datum',
+        'topographic__gradient':
+            'gradient of the ground surface',
+        'surface_water__depth':
+            'depth of water',
+#        'water__velocity':
+#            'flow velocity component in the direction of the link',
+#        'water__specific_discharge':
+#            'flow discharge component in the direction of the link',
+        'surface_water_inflow__discharge':
+            'water volume inflow rate to the cell around each node'
+    }
+
+    def __init__(self, grid, runoff_rate=1.0, roughness=0.01,
+                 changing_topo=False, depth_exp=1.5, weight=1.0, **kwds):
+        """Initialize the KinwaveOverlandFlowModel.
+
+        Parameters
+        ----------
+        grid : ModelGrid
+            Landlab ModelGrid object
+        runoff_rate : float, optional (defaults to 1 mm/hr)
+            Precipitation rate, mm/hr
+        roughnes : float, defaults to 0.01
+            Manning roughness coefficient, s/m^1/3
+        changing_topo : boolean, optional (defaults to False)
+            Flag indicating whether topography changes between time steps
+        depth_exp : float (defaults to 1.5)
+            Exponent on water depth in velocity equation (3/2 for Darcy/Chezy,
+            5/3 for Manning)
+        weight : float (defaults to 1.0)
+            Weighting on depth at new time step versus old time step (1 = all
+            implicit; 0 = explicit)
+        """
+
+        # Store grid and parameters and do unit conversion
+        self._grid = grid
+        self.runoff_rate = runoff_rate / 3600000.0  # convert to m/s
+        self.vel_coef = 1.0 / roughness  # do division now to save time
+        self.changing_topo = changing_topo
+        self.depth_exp = depth_exp
+        self.weight = weight
+
+        # Get elevation field
+        try:
+            self.elev = grid.at_node['topographic__elevation']
+        except:
+            raise
+
+        # Create fields...
+        #  Water depth
+        if 'surface_water__depth' in grid.at_node:
+            self.depth = grid.at_node['surface_water__depth']
+        else:
+            self.depth = grid.add_zeros('node', 'surface_water__depth')
+        #   Slope
+        if 'topographic__gradient' in grid.at_link:
+            self.slope = grid.at_link['topographic__gradient']
+        else:
+            self.slope = grid.add_zeros('link', 'topographic__gradient')
+        #  Velocity
+#        if 'water__velocity' in grid.at_link:
+#            self.vel = grid.at_link['water__velocity']
+#        else:
+#            self.vel = grid.add_zeros('link', 'water__velocity')
+        #  Discharge
+#        if 'surface_water__specific_discharge' in grid.at_link:
+#            self.disch = grid.at_link['surface_water__specific_discharge']
+#        else:
+#            self.disch = grid.add_zeros('link',
+#                                        'surface_water__specific_discharge')
+        #  Inflow discharge at nodes
+        if 'surface_water_inflow__discharge' in grid.at_node:
+            self.disch_in = grid.at_node['surface_water_inflow__discharge']
+        else:
+            self.disch_in = grid.add_zeros('node',
+                                           'surface_water_inflow__discharge')
+
+        # This array holds, for each node, the sum of sqrt(slope) x face width
+        # for each link/face.
+        self.grad_width_sum = grid.zeros('node')
+
+        # This array holds the prefactor in the algebraic equation that we
+        # will find a solution for.
+        self.alpha = grid.zeros('node')
+
+        # Instantiate flow router
+        self.flow_accum = FlowAccumulator(grid, 'topographic__elevation',
+                                          flow_director='MFD')
+
+        # Flag to let us know whether this is our first iteration
+        self.first_iteration = True
+
+    def run_one_step(self, dt, current_time=0.0, runoff_rate=None, **kwds):
+        """Calculate water flow for a time period `dt`.
+        """
+        # Handle runoff rate
+        if runoff_rate is None:
+            runoff_rate = self.runoff_rate
+
+        # If it's our first iteration, or if the topography may be changing,
+        # do flow routing and calculate square root of slopes at links     
+        if self.changing_topo or self.first_iteration:
+
+            # Calculate the ground-surface slope
+            self.slope[self.grid.active_links] = \
+                self._grid.calc_grad_at_link(self.elev)[self._grid.active_links]
+                
+            # Take square root of slope magnitude for use in velocity eqn
+            self.sqrt_slope = np.sqrt(np.abs(self.slope))
+
+            # Re-route flow, which gives us the downstream-to-upstream
+            # ordering
+            self.flow_accum.run_one_step()
+            self.nodes_ordered = self.grid.at_node['flow__upstream_node_order']
+            self.flow_lnks = self.grid.at_node['flow__links_to_receiver_nodes']
+
+            # (Re)calculate, for each node, sum of sqrt(gradient) x width
+            self.grad_width_sum[:] = 0.0
+            for i in range(self.flow_lnks.shape[1]):
+                self.grad_width_sum[:] += (self.sqrt_slope[self.flow_lnks[:,i]]
+                    * self._grid.width_of_face[
+                            self.grid.face_at_link[self.flow_lnks[:,i]]])
+
+            # Calculate values of alpha, which is defined as
+            #
+            #   $\alpha = \frac{\Sigma W S^{1/2} \Delta t}{A C_r}$
+            cores = self.grid.core_nodes
+            self.alpha[cores] = (
+                self.vel_coef * self.grad_width_sum[cores] * dt 
+                / (self.grid.area_of_cell[self.grid.cell_at_node[cores]]))
+
+        # Zero out inflow discharge
+        self.disch_in[:] = 0.0
+
+        # Upstream-to-downstream loop
+        for i in range(len(self.nodes_ordered) - 1, -1, -1):
+            n = self.nodes_ordered[i]
+            if self.grid.status_at_node[n] == 0:
+
+                # Solve for new water depth
+                aa = self.alpha[n]
+                cc = self.depth[n]
+                ee = ((dt * runoff_rate) 
+                       + (dt * self.disch_in[n] 
+                          / self.grid.area_of_cell[self.grid.cell_at_node[n]]))
+                self.depth[n] = newton(water_fn, self.depth[n], 
+                                       args=(aa, self.weight, cc, 
+                                             self.depth_exp, ee))
+
+                # Calc outflow
+                Heff = (self.weight * self.depth[n]
+                        + (1.0 - self.weight) * cc)
+                outflow = (self.vel_coef * (Heff ** self.depth_exp)
+                           * self.grad_width_sum[n])  # this is manning/chezy/darcy
+
+                # Send flow downstream. Here we take total inflow discharge
+                # and partition it among the node's neighbors. For this, we use
+                # the flow director's "proportions" array, which contains, for
+                # each node, the proportion of flow that heads out toward each
+                # of its N neighbors. The proportion is zero if the neighbor is
+                # uphill; otherwise, it is S^1/2 / sum(S^1/2). If for example
+                # we have a raster grid, there will be four neighbors and four
+                # proportions, some of which may be zero and some between 0 and
+                # 1.
+                self.disch_in[self.grid.neighbors_at_node[n]] += (outflow
+                    * self.flow_accum.flow_director.proportions[n])
+
+                # TODO: the above is enough to implement the solution for flow
+                # depth, but it does not provide any information about flow
+                # velocity or discharge on links. This could be added as an
+                # optional method, perhaps done just before output.
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/landlab/components/overland_flow/tests/test_kinwave_implicit.py
+++ b/landlab/components/overland_flow/tests/test_kinwave_implicit.py
@@ -84,9 +84,8 @@ def test_steady_basic_ramp():
     for i in range(22):
         kw.run_one_step(1.0)
 
-    # Look at a column of nodes down the middle. The inflow from uphill should
-    # be, from top to bottom: 0, 0.004, 0.008, 0.012, 0.016, 0.02, 0.024, 0.028
-    assert_equal(kw.disch_in[85], 0.0)
+    # Again, look at a column of nodes down the middle. The inflow from uphill 
+    # should now be 1/10 of the prior example.
     assert_equal(round(kw.disch_in[75], 4), 0.0004)
     assert_equal(round(kw.disch_in[65], 4), 0.0008)
     assert_equal(round(kw.disch_in[55], 4), 0.0012)

--- a/landlab/components/overland_flow/tests/test_kinwave_implicit.py
+++ b/landlab/components/overland_flow/tests/test_kinwave_implicit.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Unit tests for KinwaveImplicitOverlandFlowModel.
+
+Created on Sat Apr  1 10:49:33 2017
+
+@author: gtucker
+"""
+
+from landlab import RasterModelGrid
+from landlab.components import KinwaveImplicitOverlandFlow
+from nose.tools import assert_equal
+from numpy.testing import assert_array_equal
+import numpy as np
+
+
+def test_initialization():
+    """Test initialization with various parameters.
+    """
+    rg = RasterModelGrid((3, 4), 2.0)
+    rg.add_zeros('node', 'topographic__elevation')
+    kw = KinwaveImplicitOverlandFlow(rg)
+
+    # Make sure fields have been created
+    for field_name in kw._var_mapping:
+        if kw._var_mapping[field_name] == 'node':
+            assert field_name in kw.grid.at_node
+        elif kw._var_mapping[field_name] == 'link':
+            assert field_name in kw.grid.at_link
+
+    # Re-initialize, this time with fields already existing in the grid
+    # (this triggers the "if" instead of "else" in the field setup in init)
+    kw = KinwaveImplicitOverlandFlow(rg)
+
+
+def test_first_iteration():
+    """Test stuff that happens only on first iteration"""
+    
+    # Create a basic ramp
+    rg = RasterModelGrid((10,10), spacing=(2, 2))
+    rg.add_field('topographic__elevation', 0.1 * rg.node_y, at='node')
+
+    # Create component and run it
+    kw = KinwaveImplicitOverlandFlow(rg)
+    kw.run_one_step(1.0)
+
+    # Max gradient should be 0.1, and min should be zero
+    assert_equal(round(np.amax(kw.grid.at_link['topographic__gradient']), 2),
+                 0.1)
+    assert_equal(round(np.amin(kw.grid.at_link['topographic__gradient']), 2),
+                 0.0)
+    assert_equal(round(np.amax(kw.sqrt_slope), 3), 0.316)
+    assert_equal(round(np.amax(kw.grad_width_sum), 3), 0.632)
+    assert_equal(round(np.amax(kw.alpha), 3), 15.811)
+
+
+def test_steady_basic_ramp():
+    """Run to steady state with basic ramp"""
+
+    # Create a basic ramp
+    rg = RasterModelGrid((10,10), spacing=(2, 2))
+    rg.add_field('topographic__elevation', 0.1 * rg.node_y, at='node')
+
+    # Create component and run it
+    kw = KinwaveImplicitOverlandFlow(rg)
+    for i in range(12):
+        kw.run_one_step(1.0, runoff_rate=0.001)
+
+    # Look at a column of nodes down the middle. The inflow from uphill should
+    # be, from top to bottom: 0, 0.004, 0.008, 0.012, 0.016, 0.02, 0.024, 0.028
+    assert_equal(kw.disch_in[85], 0.0)
+    assert_equal(round(kw.disch_in[75], 3), 0.004)
+    assert_equal(round(kw.disch_in[65], 3), 0.008)
+    assert_equal(round(kw.disch_in[55], 3), 0.012)
+    assert_equal(round(kw.disch_in[45], 3), 0.016)
+    assert_equal(round(kw.disch_in[35], 3), 0.020)
+    assert_equal(round(kw.disch_in[25], 3), 0.024)
+    assert_equal(round(kw.disch_in[15], 3), 0.028)
+
+    # Try with passing in runoff
+    kw = KinwaveImplicitOverlandFlow(rg, runoff_rate=360.0)
+    kw.depth[:] = 0.0
+    for i in range(22):
+        kw.run_one_step(1.0)
+
+    # Look at a column of nodes down the middle. The inflow from uphill should
+    # be, from top to bottom: 0, 0.004, 0.008, 0.012, 0.016, 0.02, 0.024, 0.028
+    assert_equal(kw.disch_in[85], 0.0)
+    assert_equal(round(kw.disch_in[75], 4), 0.0004)
+    assert_equal(round(kw.disch_in[65], 4), 0.0008)
+    assert_equal(round(kw.disch_in[55], 4), 0.0012)
+    assert_equal(round(kw.disch_in[45], 4), 0.0016)
+    assert_equal(round(kw.disch_in[35], 4), 0.0020)
+    assert_equal(round(kw.disch_in[25], 4), 0.0024)
+    assert_equal(round(kw.disch_in[15], 4), 0.0028)
+
+    # Try with default runoff rate of 1 mm/hr = 2.78e-7 m/s
+    kw = KinwaveImplicitOverlandFlow(rg)
+    assert_equal(round(kw.runoff_rate * 1.0e7, 2), 2.78)
+    kw.depth[:] = 0.0
+    for i in range(18):
+        kw.run_one_step(10.0)
+
+    # Look at a column of nodes down the middle. The inflow from uphill should
+    # be, from top to bottom: 0, 0.004, 0.008, 0.012, 0.016, 0.02, 0.024, 0.028
+    assert_equal(kw.disch_in[85], 0.0)
+    assert_equal(round(kw.disch_in[75], 7), 0.0000011)
+    assert_equal(round(kw.disch_in[65], 7), 0.0000022)
+    assert_equal(round(kw.disch_in[55], 7), 0.0000033)
+    assert_equal(round(kw.disch_in[45], 7), 0.0000044)
+    assert_equal(round(kw.disch_in[35], 7), 0.0000055)
+    assert_equal(round(kw.disch_in[25], 7), 0.0000066)
+    assert_equal(round(kw.disch_in[15], 7), 0.0000077)
+
+
+def test_curved_surface():
+    """Test flow across a curved surface."""
+
+    # Create a grid
+    rg = RasterModelGrid((10,10), spacing=(2, 2))
+    rg.add_field('topographic__elevation', 3.*rg.node_x**2 + rg.node_y**2,
+                 at='node')
+
+    # Create component and run it
+    kw = KinwaveImplicitOverlandFlow(rg)
+    for i in range(8):
+        kw.run_one_step(1.0, runoff_rate=0.001)
+
+    # The inflow discharge to each cell at steady state should equal the
+    # runoff rate times the "inflow" drainage area, which is the total drainage
+    # area minus the area of the cell itself. Here we'll test a column of core
+    # nodes across the middle of the domain.
+    area = rg.at_node['drainage_area']
+    runoff_rate = 0.001
+    unit_area = 4.0
+    for i in range(15, 95, 10):
+        assert_equal(round(kw.disch_in[i], 6),
+                     round(runoff_rate * (area[i] - unit_area), 6))
+
+
+if __name__ == '__main__':
+    test_initialization()
+    test_first_iteration()
+    test_steady_basic_ramp()
+    test_curved_surface()


### PR DESCRIPTION
This is a new component that implements an order-N "node by node" implicit solution to the kinematic wave approximation of the shallow-water equations. The basic idea is that if you can process the nodes in upstream-to-downstream order, you can always know the inflow discharge at a particular node. With that, and assuming that the depth of water at the node sets the outflow to the adjacent downhill nodes, it's possible to do an implicit solution for water depth at the new time step. Here, more generally, it's weighted between H at the new and old time steps, with a user-specified weight factor. The algorithm uses the MFD FlowAccumulator, which is order-N. Moreover, the algorithm itself should be order-N, since it sweeps through nodes once.