### PR TITLE
Changes to flow_accumulation stack construction

### DIFF
--- a/landlab/components/flow_accum/flow_accum_to_n.py
+++ b/landlab/components/flow_accum/flow_accum_to_n.py
@@ -160,18 +160,21 @@ class _DrainageStack_to_n():
             self.s.extend(add_to_stack)
             base = base-add_to_stack
             base.update(upstream)
+        
+        # verify that every element has been added once. If not, add it. 
+        bincount = numpy.bincount(self.s, minlength=len(self.delta)-1)
+        self.s.extend(numpy.where(bincount<1)[0])
 
         # in some strange topologies, with nodes contributing to multiple base levels,
         # nodes may occur more than once, check and if this happens, choose the later
         # occurance
-
         bincount = numpy.bincount(self.s, minlength=len(self.delta)-1)
         if any(bincount > 1):
             needs_fixing = numpy.where(bincount>1)[0]
             for nf in needs_fixing:
-                nfi = numpy.where(self.s==nf)[0]
-                for nfii in nfi[:-1]:
-                    self.s.pop(nfii)
+                num_remove = bincount[nf]-1
+                for rep in range(num_remove):
+                    self.s.remove(nf)
 
 def _make_number_of_donors_array_to_n(r, p):
 


### PR DESCRIPTION
An stack issue was found while working on a side project. When using
route-to-multiple, sometimes node ids can be added twice. Pre-existing
code to fix this was not working in an application. This code fixes the
issue in the application.