### PR TITLE
Fix netcdf4 import error

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -16,11 +16,12 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    - hdf4 >=4.2.12 # [not win and np == 111]
+    # - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml
     - setuptools
+    - jpeg <=8 # [osx and np==111]
 
   run:
     - python
@@ -32,12 +33,13 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    - hdf4 >=4.2.12 # [not win and np == 111]
+    # - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml
     - setuptools
     - xarray
+    - jpeg <=8 # [osx and np==111]
 
 build:
   string: {{ environ.get('BUILD_STR', '') }}

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -16,7 +16,6 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    # - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml
@@ -33,7 +32,6 @@ requirements:
     - matplotlib
     - numpydoc
     - netcdf4
-    # - hdf4 >=4.2.12 # [not win and np == 111]
     - cython
     - six
     - pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ nose>=1.3
 matplotlib
 numpydoc
 netCDF4
-hdf4 >=4.2.12
 sympy
 pandas
 cython>=0.22


### PR DESCRIPTION
This pull request fixes an issue on OSX where `netCDF4` (from the default conda channel - netcdf4 from PyPI and conda-forge are fine) fails to import with `numpy==1.11` installed. The reported error is:
```
Library not loaded: @rpath/libjpeg.8.dylib
```
It seems that the netcdf4 package on Anaconda was build with `jpeg==8` but the default version is now 9. This pull request simply specifies jpeg version 8 as a requirement in the conda build recipe for OSX with numpy 1.11.