### PR TITLE
imshow grid query on mouse button press

### DIFF
--- a/landlab/plot/event_handler.py
+++ b/landlab/plot/event_handler.py
@@ -8,12 +8,12 @@ from pprint import pprint
 
 
 def query_grid_on_button_press(event, grid):
-    """Print node information using an imshow plot.
+    """Print and returns node information using an imshow plot.
 
     This function is triggered when a mouse button is pressed on the matplotlib
     figure connected by event. Coordinates of grid and its node attributes are
-    printed only when the event location is within the axes of the figure.
-    The node whose attributes are printed is the node at the center of the
+    queried only when the event location is within the axes of the figure.
+    The node whose attributes are queried is the node at the center of the
     cell that contains the event coordinates.
 
     This function only works with raster model grids.
@@ -24,6 +24,11 @@ def query_grid_on_button_press(event, grid):
         Event associated with a figure canvas using mpl_connect().
     grid : RasterModelGrid
         Grid containing the attributes to print.
+        
+    Returns
+    -------
+    query_results :
+        Dictionary containing grid query results.
     """
     if type(grid) is not RasterModelGrid:
         raise TypeError('Only raster grids can be queried.')
@@ -32,7 +37,7 @@ def query_grid_on_button_press(event, grid):
         x_pressed = int(round(event.xdata / grid.dx))
         y_pressed = int(round(event.ydata / grid.dy))
         
-        attributes = {
+        query_results = {
                 'grid location': {
                         'x_coord': event.xdata,
                         'y_coord': event.ydata
@@ -46,4 +51,6 @@ def query_grid_on_button_press(event, grid):
                 }
         
         print('\nGrid query results:\n')
-        pprint(attributes, width=1)
+        pprint(query_results, width=1)
+        
+    return query_results 

--- a/landlab/plot/event_handler.py
+++ b/landlab/plot/event_handler.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python
+"""
+Functions to interact with figures that plot Landlab grid data.
+"""
+
+from landlab import RasterModelGrid
+from pprint import pprint
+
+
+def query_grid_on_button_press(event, grid):
+    """Print node information using an imshow plot.
+
+    This function is triggered when a mouse button is pressed on the matplotlib
+    figure connected by event. Coordinates of grid and its node attributes are
+    printed only when the event location is within the axes of the figure.
+    The node whose attributes are printed is the node at the center of the
+    cell that contains the event coordinates.
+
+    This function only works with raster model grids.
+
+    Parameters
+    ----------
+    event : matplotlib event
+        Event associated with a figure canvas using mpl_connect().
+    grid : RasterModelGrid
+        Grid containing the attributes to print.
+    """
+    if type(grid) is not RasterModelGrid:
+        raise TypeError('Only raster grids can be queried.')
+   
+    if all([event.xdata, event.ydata]):        
+        x_pressed = int(round(event.xdata / grid.dx))
+        y_pressed = int(round(event.ydata / grid.dy))
+        
+        attributes = {
+                'grid location': {
+                        'x_coord': event.xdata,
+                        'y_coord': event.ydata
+                        },
+                'node': {
+                        'ID': grid.grid_coords_to_node_id(y_pressed,
+                                                          x_pressed),
+                        'column': x_pressed,
+                        'row': y_pressed
+                        }
+                }
+        
+        print('\nGrid query results:\n')
+        pprint(attributes, width=1)

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -25,6 +25,7 @@ except ImportError:
 from landlab.grid import CLOSED_BOUNDARY
 from landlab.grid.raster import RasterModelGrid
 from landlab.grid.voronoi import VoronoiDelaunayGrid
+from landlab.plot.event_handler import query_grid_on_button_press
 from landlab.utils.decorators import deprecated
 
 
@@ -45,6 +46,9 @@ def imshow_grid_at_node(grid, values, **kwds):
 
     Use matplotlib functions like xlim, ylim to modify your plot after calling
     :func:`imshow_grid`, as desired.
+
+    Node coordinates are printed when a mouse button is pressed on a cell in
+    the plot.
 
     This function happily works with both regular and irregular grids.
 
@@ -133,6 +137,9 @@ def imshow_grid_at_node(grid, values, **kwds):
 
     if isinstance(values, str):
         plt.title(values)
+        
+    plt.gcf().canvas.mpl_connect('button_press_event', 
+       lambda event: query_grid_on_button_press(event, grid))
 
 
 @deprecated(use='imshow_grid_at_node', version='0.5')

--- a/landlab/plot/tests/test_event_handler.py
+++ b/landlab/plot/tests/test_event_handler.py
@@ -1,0 +1,35 @@
+#! /usr/bin/env python
+"""
+Created on Thu Jun 29 11:02:28 2017
+
+@author: njlyons
+"""
+
+from landlab import imshow_grid, RasterModelGrid
+from landlab.plot.event_handler import query_grid_on_button_press
+from matplotlib.pyplot import gcf
+from matplotlib.backend_bases import Event
+from numpy.testing import assert_equal
+
+
+def test_query_grid_on_button_press():
+    
+    rmg = RasterModelGrid((5, 5))
+    imshow_grid(rmg, rmg.nodes, cmap='RdYlBu')
+    
+    # Programmatically create an event near the grid center.
+    event = Event('simulated_event', gcf().canvas)
+    event.xdata = int(rmg.number_of_node_columns * 0.5)
+    event.ydata = int(rmg.number_of_node_rows * 0.5)
+    
+    results = query_grid_on_button_press(event, rmg)
+    x_coord = results['grid location']['x_coord']
+    y_coord = results['grid location']['x_coord']
+    
+    msg = 'Items: Simulated matplotlib event and query results.'
+    assert_equal(x_coord, event.xdata, msg)
+    assert_equal(y_coord, event.ydata, msg)
+    
+    msg = 'Items: Node ID and grid coordinates of simulated matplotlib event.'
+    node = rmg.grid_coords_to_node_id(event.xdata, event.ydata)
+    assert_equal(results['node']['ID'], node, msg)


### PR DESCRIPTION
This pull request includes a new file, `landlab.plot.event_handler` for matplotlib events. The sole function (so far) prints node coordinates when users mouse press imshow figures. This function is attached to a figure in `landlab.plot.imshow.imshow_grid_at_node`. 