### PR TITLE
Changing the default behavior of FlowDirectors to many (DINF and MFD)

### DIFF
--- a/landlab/components/flow_director/flow_direction_dinf.py
+++ b/landlab/components/flow_director/flow_direction_dinf.py
@@ -393,7 +393,7 @@ def flow_directions_dinf(grid,
     steepest_link[drains_to_self] = UNDEFINED_INDEX
 
     steepest_receiver = receivers[slope_sort]
-    steepest_receiver[drains_to_self] = UNDEFINED_INDEX
+    steepest_receiver[drains_to_self] = node_id[drains_to_self]
 
 
     # Optionally, handle baselevel nodes: they are their own receivers

--- a/landlab/components/flow_director/flow_direction_mfd.py
+++ b/landlab/components/flow_director/flow_direction_mfd.py
@@ -291,6 +291,7 @@ def flow_directions_mfd(elev,
     ## identify the steepest link and steepest receiever.
     steepest_link = receiver_links[slope_sort]
     steepest_receiver = receivers[slope_sort]
+    steepest_receiver[drains_to_self] = node_id[drains_to_self]
 
     # Optionally, handle baselevel nodes: they are their own receivers
     if baselevel_nodes is not None:

--- a/landlab/components/flow_director/flow_director_dinf.py
+++ b/landlab/components/flow_director/flow_director_dinf.py
@@ -160,7 +160,7 @@ class FlowDirectorDINF(_FlowDirectorToMany):
     >>> mg.at_node['flow__link_to_receiver_node']
     array([-1,  0,  1,  2,  3, 24,  8,  9, -1, 11, 32, 34, -1, 18, 38, 40])
     >>> mg.at_node['flow__receiver_node']
-    array([-1,  0,  1,  2,  0,  0,  5,  6, -1,  5,  5,  6, -1,  9,  9, 10])
+    array([ 0,  0,  1,  2,  0,  0,  5,  6,  8,  5,  5,  6, 12,  9,  9, 10])
 
     Finally, FlowDirectorDINF identifies sinks, or local lows.
 

--- a/landlab/components/flow_director/flow_director_mfd.py
+++ b/landlab/components/flow_director/flow_director_mfd.py
@@ -147,7 +147,7 @@ class FlowDirectorMFD(_FlowDirectorToMany):
     >>> mg.at_node['flow__link_to_receiver_node']
     array([-1, -1, -1, -1, 12, -1, -1, -1, -1])
     >>> mg.at_node['flow__receiver_node']
-    array([-1, -1, -1, -1,  0, -1, -1, -1, -1])
+    array([0, 1, 2, 3, 0, 5, 6, 7, 8])
 
     Finally, FlowDirectorMFD identifies sinks, or local lows.
 


### PR DESCRIPTION
Previously FlowDirectorDINF and FlowDirectorMFD created
“flow__link_to_receiver_node” and if the node flowed to itself, set the
value to -1. This is different than how the flow-director to one
methods work (value was set to node-id value).

This discrepancy was discovered by @amanaster2 while trying to use the
implicit kinematic wave component (which relies on flow director MFD)
along with the fastscape stream power component (which expects
flow-to-self nodes to have node id as the receiver not -1) (PR #507)

This commit should fix this issue. @amanaster2 - want to check out this branch and test that it addresses your problem. 