### PR TITLE
SiccarPoint/uniform precip

### DIFF
--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -34,7 +34,7 @@ class PrecipitationDistribution(Component):
 
     Parameters
     ----------
-    grid : ModelGrid
+    grid : ModelGrid or None
         A Landlab grid (optional). If provided, storm intensities will be
         stored as a grid scalar field as the component simulates storms.
     mean_storm_duration : float
@@ -61,9 +61,9 @@ class PrecipitationDistribution(Component):
     model run time and delta t...  Say we use 1.5 for mean storm, 15 for mean
     interstorm, 0.5 for mean depth, 100 for model run time and 1 for delta t...
 
-    >>> precip = PrecipitationDistribution(mean_storm_duration = 1.5,
-    ...     mean_interstorm_duration = 15.0, mean_storm_depth = 0.5,
-    ...     total_t = 100.0, delta_t = 1.)
+    >>> precip = PrecipitationDistribution(mean_storm_duration=1.5,
+    ...     mean_interstorm_duration=15.0, mean_storm_depth=0.5,
+    ...     total_t=100.0, delta_t=1.)
     >>> for (dt, rate) in precip.yield_storm_interstorm_duration_intensity():
     ...     pass  # and so on
     """
@@ -493,9 +493,9 @@ class PrecipitationDistribution(Component):
 
         Examples
         --------
-        >>> precip = PrecipitationDistribution(mean_storm_duration = 1.5,
-        ...     mean_interstorm_duration = 15.0, mean_storm_depth = 0.5,
-        ...     total_t = 100.0, delta_t = 1.)
+        >>> precip = PrecipitationDistribution(mean_storm_duration=1.5,
+        ...     mean_interstorm_duration=15.0, mean_storm_depth=0.5,
+        ...     total_t=100.0, delta_t=1.)
         >>> round(precip.storm_duration, 2)
         2.79
         >>> round(precip.interstorm_duration, 2)
@@ -513,9 +513,9 @@ class PrecipitationDistribution(Component):
         2.45
         >>> round(precip.get_storm_intensity(), 2)
         0.88
-        >>> precip = PrecipitationDistribution(mean_storm_duration = 1.5,
-        ...     mean_interstorm_duration = 15.0, mean_storm_depth = 0.5,
-        ...     total_t = 100.0, delta_t = 1., random_seed=1)
+        >>> precip = PrecipitationDistribution(mean_storm_duration=1.5,
+        ...     mean_interstorm_duration=15.0, mean_storm_depth=0.5,
+        ...     total_t=100.0, delta_t=1., random_seed=1)
         >>> round(precip.storm_duration, 2) # diff't vals with diff't seed
         0.22
         >>> round(precip.interstorm_duration, 2)

--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -144,7 +144,7 @@ class PrecipitationDistribution(Component):
 
         # Test if we got a grid. If we did, then assign it to _grid, and we
         # are able to use the at_grid field. If not, that's cool too.
-        if grid is not none:
+        if grid is not None:
             assert isinstance(grid, ModelGrid)  # must be a grid
             self._grid = grid
 

--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -189,7 +189,7 @@ class PrecipitationDistribution(Component):
         self.storm_duration = self.get_precipitation_event_duration()
         self.interstorm_duration = self.get_interstorm_event_duration()
         self.storm_depth = self.get_storm_depth()
-        self._intensity = self.get_storm_intensity()
+        self._intensity[0] = self.get_storm_intensity()
 
     def get_precipitation_event_duration(self):
         """This method is the storm generator.
@@ -275,8 +275,8 @@ class PrecipitationDistribution(Component):
         float
             The storm intensity.
         """
-        self._intensity = self.storm_depth / self.storm_duration
-        return self._intensity
+        self._intensity[0] = self.storm_depth / self.storm_duration
+        return self._intensity[0]
 
     def get_storm_time_series(self):
         """Get a time series of storms.
@@ -291,6 +291,9 @@ class PrecipitationDistribution(Component):
         ending times of the precipitation event and z and c represent the
         average intensity (mm/hr) of the storm lasting from x to y and a to be,
         respectively.
+
+        Even if a grid was passed to the component at instantiation, calling
+        this method does not update the grid fields.
 
         Returns
         -------
@@ -470,3 +473,9 @@ class PrecipitationDistribution(Component):
         This will be particularly useful in the midst of a yield loop.
         """
         return self._elapsed_time
+
+    @property
+    def intensity(self):
+        """Get the intensity of the most recent storm simulated.
+        """
+        return self.get_storm_intensity()

--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -66,6 +66,32 @@ class PrecipitationDistribution(Component):
     ...     total_t=100.0, delta_t=1.)
     >>> for (dt, rate) in precip.yield_storm_interstorm_duration_intensity():
     ...     pass  # and so on
+
+    Alternatively, we can pass a grid to the component, and call yield_storms()
+    to generate storm-interstorm float pairs while the intensity data is stored
+    in the grid scalar field 'rainfall__flux':
+
+    >>> from landlab import RasterModelGrid
+    >>> mg = RasterModelGrid((4, 5), (1., 1.))
+    >>> precip = PrecipitationDistribution(mg, mean_storm_duration=1.5,
+    ...     mean_interstorm_duration=15.0, mean_storm_depth=0.5,
+    ...     total_t=46.)
+    >>> storm_dts = []
+    >>> interstorm_dts = []
+    >>> intensities = []
+    >>> precip.seed_generator(seedval=1)
+    >>> for (storm_dt, interstorm_dt) in precip.yield_storms():
+    ...     storm_dts.append(storm_dt)
+    ...     interstorm_dts.append(interstorm_dt)
+    ...     intensities.append(mg.at_grid['rainfall__flux'])
+    >>> len(storm_dts) == 4  # 4 storms in the simulation
+    True
+    >>> len(interstorm_dts) == len(storm_dts)
+    True
+    >>> np.isclose(sum(storm_dts) + sum(interstorm_dts), 46.)  # test total_t
+    True
+    >>> np.isclose(interstorm_dts[-1], 0.)  # sequence truncated as necessary
+    True
     """
 
     _name = 'PrecipitationDistribution'
@@ -432,6 +458,30 @@ class PrecipitationDistribution(Component):
         -----
         One recommended procedure is to instantiate the generator, then call
         instance.next() repeatedly to get the sequence.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> mg = RasterModelGrid((4, 5), (1., 1.))
+        >>> precip = PrecipitationDistribution(mg, mean_storm_duration=1.5,
+        ...     mean_interstorm_duration=15.0, mean_storm_depth=0.5,
+        ...     total_t=46.)
+        >>> storm_dts = []
+        >>> interstorm_dts = []
+        >>> intensities = []
+        >>> precip.seed_generator(seedval=1)
+        >>> for (storm_dt, interstorm_dt) in precip.yield_storms():
+        ...     storm_dts.append(storm_dt)
+        ...     interstorm_dts.append(interstorm_dt)
+        ...     intensities.append(mg.at_grid['rainfall__flux'])
+        >>> len(storm_dts) == 4  # 4 storms in the simulation
+        True
+        >>> len(interstorm_dts) == len(storm_dts)
+        True
+        >>> np.isclose(sum(storm_dts) + sum(interstorm_dts), 46.)  # total_t
+        True
+        >>> np.isclose(interstorm_dts[-1], 0.)  # sequence gets truncated
+        True
         """
         # we must have instantiated with a grid, so check:
         assert hasattr(self, '_grid')

--- a/landlab/components/uniform_precip/generate_uniform_precip.py
+++ b/landlab/components/uniform_precip/generate_uniform_precip.py
@@ -26,13 +26,17 @@ class PrecipitationDistribution(Component):
 
     Construction::
 
-        PrecipitationDistribution(mean_storm_duration=0.0,
+        PrecipitationDistribution(grid=None,
+                                  mean_storm_duration=0.0,
                                   mean_interstorm_duration=0.0,
                                   mean_storm_depth=0.0, total_t=0.0,
                                   delta_t=0.0, random_seed=0)
 
     Parameters
     ----------
+    grid : ModelGrid
+        A Landlab grid (optional). If provided, storm intensities will be
+        stored as a grid scalar field as the component simulates storms.
     mean_storm_duration : float
         Average duration of a precipitation event.
     mean_interstorm_duration : float
@@ -88,6 +92,9 @@ class PrecipitationDistribution(Component):
 
         Parameters
         ----------
+        grid : ModelGrid
+            A Landlab grid (optional). If provided, storm intensities will be
+            stored as a grid scalar field as the component simulates storms.
         mean_storm_duration : float
             Average duration of a precipitation event.
         mean_interstorm_duration : float


### PR DESCRIPTION
This pull adds a new generator, yield_storms(), to the uniform_precip.PrecipitationDistribution class.

It is designed to mirror the necessary fields for a spatially resolved precip distribution (coming soon!) exactly, and thus makes use our novel scalar grid fields, “at_grid”. This follows a suggestion by @mcflugen on the call yesterday. Note doing this requires a grid be passed where it was not before; __init__ is modified to do this in a back-compatible way.

Method name (yield_storms), output field (‘rainfall__flux’) and generator return format (tuple of storm_t, interstorm_t) all mirror what I have in spatial_precip. Thoughts welcome on suitability of these names.

Added a new doctest for the key functionality.