### PR TITLE
Barnhark/get set state methods for grid

### DIFF
--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -3281,17 +3281,19 @@ class ModelGrid(ModelDataFieldsMixIn):
                           INACTIVE_LINK)
         inactive_links[self.link_dirs_at_node == 0] = False
         self._active_link_dirs_at_node[inactive_links] = 0
-
+        
         try:
             if self.diagonal_list_created:
                 self.diagonal_list_created = False
         except AttributeError:
             pass
+        
         try:
             if self.neighbor_list_created:
                 self.neighbor_list_created = False
         except AttributeError:
             pass
+        
         try:
             self._fixed_grad_links_created
         except AttributeError:
@@ -3299,11 +3301,13 @@ class ModelGrid(ModelDataFieldsMixIn):
         else:
             self._gradient_boundary_node_links()
             self._create_fixed_gradient_boundary_node_anchor_node()
+        
         try:
-            self._patches_created
-            self._reset_patch_status()
+            if self._patches_created:
+                self._reset_patch_status()
         except AttributeError:
             pass
+        
         try:
             self.bc_set_code += 1
         except AttributeError:

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -490,7 +490,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
             
         # save status information at nodes (status at link set based on status
         # at node
-        state_dict['status_at_node'] = np.asarray(self.status_at_node)
+        state_dict['status_at_node'] = np.asarray(self._node_status)
         
         # save all fields. This is the key part, since saving ScalarDataFields, breaks
         # pickle and/or dill

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -458,6 +458,7 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                                field,
                                field_set[field]['value_array'],
                                units=field_set[field]['units'])
+        self.bc_set_code = state_dict['bc_set_code']
             
     def __getstate__(self):
         """Get state for pickling."""

--- a/landlab/io/tests/test_read_write_native.py
+++ b/landlab/io/tests/test_read_write_native.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python
+from landlab import RasterModelGrid
+from landlab.components import FlowAccumulator
+import pickle 
+from nose.tools import assert_equal
+
+def compare_dictionaries(dict_1, dict_2, dict_1_name, dict_2_name, path=""):
+    """Compare two dictionaries recursively to find non mathcing elements
+
+    Args:
+        dict_1: dictionary 1
+        dict_2: dictionary 2
+
+    Returns:
+
+    """
+    import numpy as np
+    err = ''
+    key_err = ''
+    value_err = ''
+    old_path = path
+    for k in dict_1.keys():
+        path = old_path + "[%s]" % k
+        if not k in dict_2:
+            key_err += "Key %s%s not in %s\n" % (dict_2_name, path, dict_2_name)
+        else:
+            if isinstance(dict_1[k], dict) and isinstance(dict_2[k], dict):
+                err += compare_dictionaries(dict_1[k],dict_2[k],'d1','d2', path)
+            else:
+                o1 = dict_1[k]
+                o2 = dict_2[k]
+                try:
+                    if o1  != o2:
+                        value_err += "Value of %s%s (%s) not same as %s%s (%s)\n"\
+                            % (dict_1_name, path, dict_1[k], dict_2_name, path, dict_2[k])
+                            
+                except ValueError:
+                    if np.array_equal(np.asarray(o1), np.asarray(o1)) == False:
+                        value_err += "Value of %s%s (%s) not same as %s%s (%s)\n"\
+                            % (dict_1_name, path, dict_1[k], dict_2_name, path, dict_2[k])
+                    
+    for k in dict_2.keys():
+        path = old_path + "[%s]" % k
+        if not k in dict_1:
+            key_err += "Key %s%s not in %s\n" % (dict_2_name, path, dict_1_name)
+
+    return key_err + value_err + err
+
+
+def test_pickle():
+    # Make a simple-ish grid
+    mg1 = RasterModelGrid(10,10,2.)
+    z = mg1.add_zeros('node', 'topographic__elevation')
+    z += mg1.node_x.copy()
+    fa = FlowAccumulator(mg1, flow_director='D8')
+    fa.run_one_step()
+    
+    # save it with pickle
+    with open('testsavedgrid.grid', 'wb') as f:
+        pickle.dump(mg1, f)
+    
+    # load it with pickle
+    with open('testsavedgrid.grid', 'rb') as f:
+        mg2 = pickle.load(f)
+     
+    # compare the two
+    len(mg1.__dict__) == len(mg2.__dict__)
+    mg1keys = sorted(list(mg1.__dict__.keys()))
+    mg2keys = sorted(list(mg2.__dict__.keys()))
+    
+    for i in range(len(mg1keys)):        
+        assert_equal(mg1keys[i], mg2keys[i])
+        
+    a = compare_dictionaries(mg1.__dict__,mg2.__dict__,'m1','m2')
+    assert_equal(a, '')

--- a/landlab/io/tests/test_read_write_native.py
+++ b/landlab/io/tests/test_read_write_native.py
@@ -3,6 +3,8 @@ from landlab import RasterModelGrid
 from landlab.components import FlowAccumulator
 import pickle 
 from nose.tools import assert_equal
+import os
+from landlab.io.native_landlab import save_grid, load_grid
 
 def compare_dictionaries(dict_1, dict_2, dict_1_name, dict_2_name, path=""):
     """Compare two dictionaries recursively to find non mathcing elements
@@ -73,3 +75,30 @@ def test_pickle():
         
     a = compare_dictionaries(mg1.__dict__,mg2.__dict__,'m1','m2')
     assert_equal(a, '')
+    
+    os.remove('testsavedgrid.grid')
+
+def test_save():
+    # Make a simple-ish grid
+    mg1 = RasterModelGrid(10,10,2.)
+    z = mg1.add_zeros('node', 'topographic__elevation')
+    z += mg1.node_x.copy()
+    fa = FlowAccumulator(mg1, flow_director='D8')
+    fa.run_one_step()
+    
+    save_grid(mg1, 'testsavedgrid.grid')
+    
+    mg2 = load_grid('testsavedgrid.grid')
+    
+    # compare the two
+    len(mg1.__dict__) == len(mg2.__dict__)
+    mg1keys = sorted(list(mg1.__dict__.keys()))
+    mg2keys = sorted(list(mg2.__dict__.keys()))
+    
+    for i in range(len(mg1keys)):        
+        assert_equal(mg1keys[i], mg2keys[i])
+        
+    a = compare_dictionaries(mg1.__dict__,mg2.__dict__,'m1','m2')
+    assert_equal(a, '')
+    
+    os.remove('testsavedgrid.grid')


### PR DESCRIPTION
This addresses PR #521 

I've tried to identify only the necessary elements of a `RasterModelGrid` that are needed in order to recreate the `__dict__` upon un-pickleing. 

I've made new tests (and these are functionally used by the current `save_grid` and `load_grid` methods as they serve to provide instructions to `pickle` regarding how to pickle a grid. 

@SiccarPoint @mcflugen @gregtucker take a look?

If someone can see a way to make this more parsimonious, do tell. 

In the complicated application that motivated this improvement, these methods save a grid of size (415, 438),  181770 total nodes, 90088 core nodes, with 17 at node fields at 3 at link fields in 31.1 MB. 

