### PR TITLE
Add nodes_at_link

### DIFF
--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -746,8 +746,11 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
         #  *---0-->*---1-->*---2-->*---3-->*
         #
         #   create the tail-node and head-node lists
-        (self._node_at_link_tail,
-         self._node_at_link_head) = sgrid.node_index_at_link_ends(self.shape)
+        (node_at_link_tail,
+         node_at_link_head) = sgrid.node_index_at_link_ends(self.shape)
+
+        self._nodes_at_link = np.vstack((node_at_link_tail,
+                                         node_at_link_head)).T.copy()
 
         self._status_at_link = np.full(squad_links.number_of_links(self.shape),
                                        INACTIVE_LINK, dtype=int)
@@ -1515,13 +1518,15 @@ class RasterModelGrid(ModelGrid, RasterModelGridPlotter):
                                            dtype=np.int8)
         num_links_per_row = (self.number_of_node_columns * 2) - 1
         # Sweep over all links
+        node_at_link_tail = self.node_at_link_tail
+        node_at_link_head = self.node_at_link_head
         for lk in range(self.number_of_links):
             # Find the orientation
             is_horiz = ((lk % num_links_per_row) <
                         (self.number_of_node_columns - 1))
             # Find the IDs of the tail and head nodes
-            t = self.node_at_link_tail[lk]
-            h = self.node_at_link_head[lk]
+            t = node_at_link_tail[lk]
+            h = node_at_link_head[lk]
 
             # If the link is horizontal, the index (row) in the links_at_node
             # array should be 0 (east) for the tail node, and 2 (west) for the

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -310,6 +310,16 @@ def test__active_links_at_node_with_no_args():
 
 
 @with_setup(setup_grid)
+def test_nodes_at_link():
+    """Test nodes_at_link shares data with tail and head."""
+    assert_array_equal(rmg.nodes_at_link[:, 0], rmg.node_at_link_tail)
+    assert_array_equal(rmg.nodes_at_link[:, 1], rmg.node_at_link_head)
+
+    assert_true(np.may_share_memory(rmg.nodes_at_link, rmg.node_at_link_tail))
+    assert_true(np.may_share_memory(rmg.nodes_at_link, rmg.node_at_link_head))
+
+
+@with_setup(setup_grid)
 def test_node_at_link_tail():
     assert_array_equal(
         rmg.node_at_link_tail,

--- a/landlab/grid/tests/testing_hex_grid/test_link_order.py
+++ b/landlab/grid/tests/testing_hex_grid/test_link_order.py
@@ -4,9 +4,11 @@ Created on Sat Nov 14 10:36:03 2015
 
 @author: gtucker
 """
+import numpy as np
 
 from landlab import HexModelGrid
 from numpy.testing import assert_array_equal
+from nose.tools import assert_true
 
 
 def test_hex_grid_link_order():
@@ -24,6 +26,18 @@ def test_hex_grid_link_order():
                                               6, 5])
 
 
+def test_nodes_at_link():
+    """Test nodes_at_link shares data with tail and head."""
+    grid = HexModelGrid(3, 2)
+
+    assert_array_equal(grid.nodes_at_link[:, 0], grid.node_at_link_tail)
+    assert_array_equal(grid.nodes_at_link[:, 1], grid.node_at_link_head)
+
+    assert_true(np.may_share_memory(grid.nodes_at_link,
+                                    grid.node_at_link_tail))
+    assert_true(np.may_share_memory(grid.nodes_at_link,
+                                    grid.node_at_link_head))
+
+
 if __name__=='__main__':
     test_hex_grid_link_order()
-    


### PR DESCRIPTION
This pull request adds a `nodes_at_link` property to `ModelGrid` (issued #363). `nodes_at_link` is a index array of shape `(n_links, 2)` where the first column is the node at each link tail and the second column the node at the link head. `node_at_link_tail` and `node_at_link_head` now return views of the `nodes_at_link` matrix.