### PR TITLE
new kw arg FastscapeEroder: discharge_name

### DIFF
--- a/landlab/components/stream_power/__init__.py
+++ b/landlab/components/stream_power/__init__.py
@@ -4,4 +4,5 @@ from .stream_power_smooth_threshold import StreamPowerSmoothThresholdEroder
 from .sed_flux_dep_incision import SedDepEroder
 
 
-__all__ = ['StreamPowerEroder', 'FastscapeEroder', 'SedDepEroder', 'StreamPowerSmoothThresholdEroder']
+__all__ = ['StreamPowerEroder', 'FastscapeEroder', 'SedDepEroder',
+           'StreamPowerSmoothThresholdEroder']

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -85,6 +85,12 @@ class FastscapeEroder(Component):
         For a time varying rainfall intensity, pass
         *rainfall_intensity_if_used* to `run_one_step`. For a spatially
         variable rainfall, use the StreamPowerEroder component.
+    discharge_name : string; optional
+        Name of field to use for discharge proxy. Defaults to 'drainage_area',
+        which means the component will expect the driver or another component
+        to have created and populated a 'drainage_area' field. To use a
+        different field, such as 'surface_water__discharge', give its name in
+        this argument.
 
     Examples
     --------
@@ -217,6 +223,12 @@ class FastscapeEroder(Component):
         rainfall intensity : float, array, or field name; optional
             Modifying factor on drainage area to convert it to a true water
             volume flux in (m/time). i.e., E = K * (r_i*A)**m * S**n
+        discharge_name : string; optional
+            Name of field to use for discharge proxy. Defaults to 'drainage_area',
+            which means the component will expect the driver or another component
+            to have created and populated a 'drainage_area' field. To use a
+            different field, such as 'surface_water__discharge', give its name in
+            this argument.
         """
         self._grid = grid
 


### PR DESCRIPTION
This is a simple update to FastscapeEroder that allows it to take a discharge field instead of using drainage area. The implementation is simple: the component stores a string discharge_name, which defaults to 'drainage_area'. In the erode() method, the hard-coded name 'drainage_area' is now replaced by variable discharge_name. If the user passes something else for discharge_name, such as 'surface_water__discharge', this is used instead of the default 'drainage_area' field. If it doesn't exist, the user gets a key error.

Note that testing for existence of the passed field in __init__ would make some of our tests fail, because sometimes this component is instantiated before the requested field (such as 'drainage_area') is created. This is the reason for storing the name rather than the field itself.