### PR TITLE
Add statsmodels as requirement for docs build.

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -10,3 +10,4 @@ six
 setuptools>=18.0
 pyyaml
 xarray
+statsmodels


### PR DESCRIPTION
This pull requests addresses #575. It appears that somewhere along the way we added the `statsmodels` package as a requirement (used by `landslide_probability.py`). `statsmodels` was correctly added to `requirements.txt` but not to `requirements-docs.txt`, which are the requirements for building the documentation.