### PR TITLE
Remove corner_node_at_cell

### DIFF
--- a/landlab/grid/raster_funcs.py
+++ b/landlab/grid/raster_funcs.py
@@ -93,59 +93,6 @@ def neighbor_node_at_cell(grid, inds, *args):
                 3 - inds, axis=1))
 
 
-def corner_node_at_cell(grid, inds, *args):
-    """node_id_of_cell_corner(grid, corner_ids [, cell_ids])
-
-    Return an array of the node ids for diagonal neighbors of *cell_id* cells.
-    *corner_ids* is an index into the corners of a cell as measured
-    clockwise starting from the southeast.
-
-    If *cell_ids* is not given, return neighbors for all cells in the grid.
-
-    Parameters
-    ----------
-    grid : RasterModelGrid
-        Input grid.
-    corner_ids : array_like
-        IDs of the corner nodes.
-    cell_ids : array_like, optional
-        IDs of cell about which to get corners
-
-    Examples
-    --------
-    >>> from landlab import RasterModelGrid
-    >>> from landlab.grid.raster_funcs import corner_node_at_cell
-    >>> grid = RasterModelGrid(4, 5, 1.0)
-    >>> corner_node_at_cell(grid, 0, 0)
-    array([2])
-
-    Get the lower-right and the the upper-left corners for all the cells.
-
-    >>> corner_node_at_cell(grid, 0)
-    array([2, 3, 4, 7, 8, 9])
-    >>> corner_node_at_cell(grid, 2)
-    array([10, 11, 12, 15, 16, 17])
-
-    As an alternative to the above, use fancy-indexing to get both sets of
-    corners with one call.
-
-    >>> corner_node_at_cell(grid, np.array([0, 2]), [1, 4])
-    array([[ 3, 11],
-           [ 8, 16]])
-    """
-    cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
-    node_ids = grid.node_at_cell[cell_ids]
-    diagonals = grid._get_diagonal_list(node_ids)
-
-    if not isinstance(inds, np.ndarray):
-        inds = np.array(inds)
-
-    return (
-        np.take(np.take(diagonals, range(len(cell_ids)), axis=0),
-                3 - inds, axis=1))
-    # return diagonals[range(len(cell_ids)), 3 - inds]
-
-
 def calculate_flux_divergence_at_nodes(grid, active_link_flux, out=None):
     """Net flux into or out of nodes.
 

--- a/landlab/grid/tests/test_raster_funcs/test_node_id_of_adjacent.py
+++ b/landlab/grid/tests/test_raster_funcs/test_node_id_of_adjacent.py
@@ -20,24 +20,10 @@ def setup_grid():
 
 
 @with_setup(setup_grid)
-def test_corner_with_scalar_cell_id():
-    """Test using a scalar arg for cell."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, np.array([0]), 0)
-    assert_array_equal(node_ids, np.array([[2]]))
-
-
-@with_setup(setup_grid)
 def test_face_with_scalar_cell_id():
     """Test using a scalar arg for cell."""
     node_ids = rfuncs.neighbor_node_at_cell(rmg, np.array([0]), 0)
     assert_array_equal(node_ids, np.array([[1]]))
-
-
-@with_setup(setup_grid)
-def test_corner_with_iterable_cell_id():
-    """Test using iterable arg for cell."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, np.array([0]), (5, ))
-    assert_array_equal(node_ids, np.array([[9]]))
 
 
 @with_setup(setup_grid)
@@ -48,24 +34,10 @@ def test_face_with_iterable_cell_id():
 
 
 @with_setup(setup_grid)
-def test_corner_with_no_cell_id():
-    """Test without an arg for cells to mean all cells."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, np.array([0]))
-    assert_array_equal(node_ids, np.array([[2, 3, 4, 7, 8, 9]]).T)
-
-
-@with_setup(setup_grid)
 def test_face_with_no_cell_id():
     """Test without an arg for cells to mean all cells."""
     node_ids = rfuncs.neighbor_node_at_cell(rmg, np.array([0]))
     assert_array_equal(node_ids, np.array([[1, 2, 3, 6, 7, 8]]).T)
-
-
-@with_setup(setup_grid)
-def test_corner_multiple_corners():
-    """Test getting nodes for more than one corner."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, np.array([0, 1]), (4, ))
-    assert_array_equal(node_ids, np.array([[8, 6]]))
 
 
 @with_setup(setup_grid)
@@ -76,24 +48,10 @@ def test_face_multiple_faces():
 
 
 @with_setup(setup_grid)
-def test_corner_multiple_corners_and_cells():
-    """Test getting nodes for more than one corner and more than one cell."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, np.array([0, 1]), (4, 5))
-    assert_array_equal(node_ids, np.array([[8, 6], [9, 7]]))
-
-
-@with_setup(setup_grid)
 def test_face_multiple_corners_and_cells():
     """Test getting nodes for more than one corner and more than one cell."""
     node_ids = rfuncs.neighbor_node_at_cell(rmg, np.array([0, 1]), (4, 5))
     assert_array_equal(node_ids, np.array([[7, 11], [8, 12]]))
-
-
-@with_setup(setup_grid)
-def test_corner_type_tuple():
-    """Test using tuple as corner arg."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, (0, 1), (4, 5))
-    assert_array_equal(node_ids, np.array([[8, 6], [9, 7]]))
 
 
 @with_setup(setup_grid)
@@ -104,30 +62,10 @@ def test_face_type_tuple():
 
 
 @with_setup(setup_grid)
-def test_corner_type_list():
-    """Test using list as corner arg."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, [0, 1], (4, 5))
-    assert_array_equal(node_ids, np.array([[8, 6], [9, 7]]))
-
-
-@with_setup(setup_grid)
 def test_face_type_list():
     """Test using list as face arg."""
     node_ids = rfuncs.neighbor_node_at_cell(rmg, [0, 1], (4, 5))
     assert_array_equal(node_ids, np.array([[7, 11], [8, 12]]))
-
-
-@with_setup(setup_grid)
-def test_corner_type_scalar():
-    """Test using scalar as corner arg."""
-    node_ids = rfuncs.corner_node_at_cell(rmg, 2, (4, ))
-    assert_array_equal(node_ids, np.array([16]))
-
-    node_ids = rfuncs.corner_node_at_cell(rmg, 2, (4, 5))
-    assert_array_equal(node_ids, np.array([16, 17]))
-
-    node_ids = rfuncs.corner_node_at_cell(rmg, 1)
-    assert_array_equal(node_ids, np.array([0, 1, 2, 5, 6, 7]))
 
 
 @with_setup(setup_grid)


### PR DESCRIPTION
The pull request removes the `corner_node_at_cell` function and related tests.

This function:
* is not used within the landlab package.
* is poorly-named. "corner" here does not refer to the grid element but rather to a diagonally adjacent node.
* is redundant as it can be reproduced using existing grid data structures.
* uses a non-standard element ordering (clockwise from lower right rather than the standard counterclockwise from upper right).