### PR TITLE
only apply ero/dep to core nodes

### DIFF
--- a/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
+++ b/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
@@ -11,7 +11,7 @@ TaylorNonLinearDiffuser Component
 
 from landlab import Component
 import numpy as np
-from landlab import INACTIVE_LINK, CLOSED_BOUNDARY
+from landlab import INACTIVE_LINK
 
 
 class TaylorNonLinearDiffuser(Component):
@@ -286,7 +286,6 @@ class TaylorNonLinearDiffuser(Component):
 
             # Calculate flux divergence
             dqdx = self.grid.calc_flux_div_at_node(self.flux)
-            #dqdx[self.grid.status_at_node == CLOSED_BOUNDARY] = 0.
 
             # Update topography
             self.elev[self.grid.core_nodes] -= (dqdx[self.grid.core_nodes]

--- a/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
+++ b/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
@@ -286,10 +286,11 @@ class TaylorNonLinearDiffuser(Component):
 
             # Calculate flux divergence
             dqdx = self.grid.calc_flux_div_at_node(self.flux)
-            dqdx[self.grid.status_at_node == CLOSED_BOUNDARY] = 0.
+            #dqdx[self.grid.status_at_node == CLOSED_BOUNDARY] = 0.
 
             # Update topography
-            self.elev -= dqdx * self.sub_dt
+            self.elev[self.grid.core_nodes] -= (dqdx[self.grid.core_nodes]
+                                                * self.sub_dt)
 
     def run_one_step(self, dt, **kwds):
         """


### PR DESCRIPTION
This PR fixes an issue with Taylor Nonlinear Diffuser, in which erosion/deposition was being applied to open boundary nodes. Now only applied to core nodes.