### PR TITLE
Fix "Resource temporarily unavailable" error on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,12 @@ env:
   global:
   - CONDA_PREFIX=$HOME/miniconda
   - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
-  # - secure: UxPkdFKl0xtk+H+98CNHSnYN8SJrEq5xJjLtPUPR+5UF5lLKL7godwrOdYeO0B0fXPi2Plw0vtoIID6H1AV4x+8QD/AgAizoWIh8KLim3E7rDX0v0M3WnUHctvYwt76mGCYvIGH6qR2Ziml37Ec6nz2aTuz0oex27P6dq0BKkXs=
-  # - secure: OFyhYR18rMC/MlyG1J8+cRkHWlkn/BOkQP6IM+ZBILG/t33ipoyTjH2qpNJi5Rx3wMCXBn00XnPExf7mqRBAAzSULyt6t6eDbXgInYOCSOQMMZlJ66CdmsD8dKBwDVbcFuGz06amYrIc/22guFP+6GfhsCepHvocrR93A93whug=
   - secure: wuv2O1M29pkfAjPbOK1MetIf3teDrG4VTepDOps2YFLMzcoJBlJeTqEneVcHb/q2dz5SefjxQQrbLjgZNOURiS1IT2z24srNDPbp8OAsv9nsqAGZO40eWecCRa+u+P+Wh0pZ8urz/ptTir0qFIQ/yz5hoEPx4ScktHkn23V+/fM=
 os:
 - linux
 - osx
 sudo: false
+filter_secrets: false
 before_install:
 - |
   if [[ $TRAVIS_OS_NAME == "osx" ]]; then


### PR DESCRIPTION
This pull request fixes the mysterious failing Travis CI tests. Ever since Travis updated their linux images to Trusty, our linux builds have been failing with the following error,
```
error: [Errno 11] Resource temporarily unavailable
```
We're not the only ones (travis-ci/travis-ci#8934). This is fixed by adding `filter_secrets: false` to `.travis.yml` (I have no idea what this does but it does fix the problem - see this [comment](https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-321777557) in travis-ci/travis-ci#4704).

@nathanlyons this should fix the issue you describe in #603.