### PR TITLE
Updates to channel profile and fastscape

### DIFF
--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -15,6 +15,8 @@ from landlab.utils.decorators import use_file_name_or_kwds
 
 from landlab import BAD_INDEX_VALUE as UNDEFINED_INDEX
 
+from landlab import RasterModelGrid
+
 from .cfuncs import (brent_method_erode_fixed_threshold,
                      brent_method_erode_variable_threshold)
 
@@ -315,10 +317,15 @@ class FastscapeEroder(Component):
         z = self._grid.at_node['topographic__elevation']
         defined_flow_receivers = np.not_equal(
             self._grid.at_node['flow__link_to_receiver_node'], UNDEFINED_INDEX)
-        flow_link_lengths = self._grid.length_of_d8[
-            self._grid.at_node['flow__link_to_receiver_node'][
-                defined_flow_receivers]]
 
+        if isinstance(self._grid, RasterModelGrid):
+            flow_link_lengths = self._grid.length_of_d8[
+                self._grid.at_node['flow__link_to_receiver_node'][
+                    defined_flow_receivers]]
+        else:
+            flow_link_lengths = self._grid.length_of_link[
+                self._grid.at_node['flow__link_to_receiver_node'][
+                    defined_flow_receivers]]
         # make arrays from input the right size
         if isinstance(self.K, np.ndarray):
             K_here = self.K[defined_flow_receivers]
@@ -341,7 +348,7 @@ class FastscapeEroder(Component):
             self.K = K_if_used
 
         n = float(self.n)
-        
+
         np.power(self._grid['node'][self.discharge_name], self.m,
                  out=self.A_to_the_m)
         self.alpha[defined_flow_receivers] = (

--- a/landlab/plot/channel_profile.py
+++ b/landlab/plot/channel_profile.py
@@ -47,7 +47,7 @@ Examples
 
     >>> mg = RasterModelGrid(40, 60)
     >>> z = mg.add_zeros('topographic__elevation', at='node')
-    >>> z += 200 + mg.x_of_node + mg.y_of_node + np.random.randn(mg.size('node'))
+    >>> z += 200 + mg.x_of_node + mg.y_of_node
     >>> mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True, left_is_closed=True, right_is_closed=True, top_is_closed=True)
     >>> mg.set_watershed_boundary_condition_outlet_id(0, z, -9999)
     >>> fa = FlowAccumulator(mg,
@@ -60,11 +60,11 @@ Examples
 
     >>> dt = 100
     >>> for i in range(200):
-    ...     mg.at_node['topographic__elevation'][0] -= 0.001
     ...     fa.run_one_step()
     ...     flooded = np.where(fa.depression_finder.flood_status==3)[0]
     ...     sp.run_one_step(dt=dt,  flooded_nodes=flooded)
     ...     ld.run_one_step(dt=dt)
+    ...     mg.at_node['topographic__elevation'][0] -= 0.001
 
     Now call analyze_channel_network_and_plot in order to plot the network. Note
     in general, we'd leave create_plot in its default value of create_plot=True,

--- a/landlab/plot/channel_profile.py
+++ b/landlab/plot/channel_profile.py
@@ -40,7 +40,7 @@ Examples
     >>> import numpy as np
     >>> np.random.seed(42)
     >>> from landlab import RasterModelGrid
-    >>> from landlab.components import FlowAccumulator, FastscapeEroder, LinearDiffuser, DepressionFinderAndRouter
+    >>> from landlab.components import FlowAccumulator, FastscapeEroder
     >>> from landlab.plot import analyze_channel_network_and_plot
 
     Construct a grid and evolve some topography
@@ -50,20 +50,15 @@ Examples
     >>> z += 200 + mg.x_of_node + mg.y_of_node
     >>> mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True, left_is_closed=True, right_is_closed=True, top_is_closed=True)
     >>> mg.set_watershed_boundary_condition_outlet_id(0, z, -9999)
-    >>> fa = FlowAccumulator(mg,
-    ...                      depression_finder=DepressionFinderAndRouter,
-    ...                      routing='D4')
+    >>> fa = FlowAccumulator(mg, flow_director='D8')
     >>> sp = FastscapeEroder(mg, K_sp=.0001, m_sp=.5, n_sp=1)
-    >>> ld = LinearDiffuser(mg, linear_diffusivity=0.0001)
 
     Now run a simple landscape evolution model to develop a channel network.
 
     >>> dt = 100
     >>> for i in range(200):
     ...     fa.run_one_step()
-    ...     flooded = np.where(fa.depression_finder.flood_status==3)[0]
-    ...     sp.run_one_step(dt=dt,  flooded_nodes=flooded)
-    ...     ld.run_one_step(dt=dt)
+    ...     sp.run_one_step(dt=dt)
     ...     mg.at_node['topographic__elevation'][0] -= 0.001
 
     Now call analyze_channel_network_and_plot in order to plot the network. Note
@@ -84,7 +79,7 @@ Examples
     True
 
     >>> len(profile_structure[0][0])
-    93
+    58
 
     We can change the default values to get additional channels or to plot all
     of the channels in a network.
@@ -92,9 +87,10 @@ Examples
     For the next example, lets use a hexagonal grid.
 
     >>> from landlab import HexModelGrid
+    >>> from landlab.components import DepressionFinderAndRouter, LinearDiffuser
     >>> mg = HexModelGrid(40, 20)
     >>> z = mg.add_zeros('topographic__elevation', at='node')
-    >>> z += 200 + mg.y_of_node + mg.y_of_node + np.random.randn(mg.size('node'))
+    >>> z += 200 + mg.x_of_node + mg.y_of_node + np.random.randn(mg.size('node'))
     >>> fa = FlowAccumulator(mg, depression_finder=DepressionFinderAndRouter)
     >>> sp = FastscapeEroder(mg, K_sp=.0001, m_sp=.5, n_sp=1)
     >>> ld = LinearDiffuser(mg, linear_diffusivity=0.0001)

--- a/landlab/plot/tests/test_channel_profile.py
+++ b/landlab/plot/tests/test_channel_profile.py
@@ -19,13 +19,13 @@ def test_assertion_error():
     mg = RasterModelGrid(10, 10)
     z = mg.add_zeros('topographic__elevation', at='node')
     z += 200 + mg.x_of_node + mg.y_of_node + np.random.randn(mg.size('node'))
-    
+
     mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True, left_is_closed=True, right_is_closed=True, top_is_closed=True)
     mg.set_watershed_boundary_condition_outlet_id(0, z, -9999)
-    fa = FlowAccumulator(mg, depression_finder=DepressionFinderAndRouter)
+    fa = FlowAccumulator(mg, flow_director='D8', depression_finder=DepressionFinderAndRouter)
     sp = FastscapeEroder(mg, K_sp=.0001, m_sp=.5, n_sp=1)
     ld = LinearDiffuser(mg, linear_diffusivity=0.0001)
-    
+
     dt = 100
     for i in range(200):
         fa.run_one_step()
@@ -33,11 +33,11 @@ def test_assertion_error():
         sp.run_one_step(dt=dt,  flooded_nodes=flooded)
         ld.run_one_step(dt=dt)
         mg.at_node['topographic__elevation'][0] -= 0.001 # Uplift
-        
 
-    assert_raises(AssertionError, 
-                  analyze_channel_network_and_plot, 
-                  mg, 
+
+    assert_raises(AssertionError,
+                  analyze_channel_network_and_plot,
+                  mg,
                   threshold = 100,
                   starting_nodes = [0],
                   number_of_channels=2)


### PR DESCRIPTION
I started to get testing errors related to the channel profiler and `FastscapeEroder`. 

these mostly had to do with running either on a HexGrid which doesn't have the attribute `grid.length_of_d8`. I added a type check to fix this. 

a similar issue came up with the stream profiler which was using `_length_of_link_with_diagonals`, the precursor to` length_of_d8`. I also added a type check here. 

While doing this I cleaned up the lems used in the tests to make them simpler