### PR TITLE
Set versioneer to ignore `v` prefix in tags

### DIFF
--- a/landlab/_version.py
+++ b/landlab/_version.py
@@ -41,7 +41,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440"
-    cfg.tag_prefix = ""
+    cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "landlab-"
     cfg.versionfile_source = "landlab/_version.py"
     cfg.verbose = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ vcs = git
 style = pep440
 versionfile_source = landlab/_version.py
 versionfile_build = landlab/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = landlab-
 
 [nosetests]


### PR DESCRIPTION
This pull request fixes a problem where versioneer kept the "v" in our tags as part of the version number. Now versioneer ignores the "v" in our tags. So, `v1.3.0` is actually version `1.3.0`.