### PR TITLE
Making space work with hexmodelgrid

### DIFF
--- a/landlab/components/erosion_deposition/cfuncs.pyx
+++ b/landlab/components/erosion_deposition/cfuncs.pyx
@@ -14,7 +14,7 @@ ctypedef np.int_t DTYPE_INT_t
 
 def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
                     np.ndarray[DTYPE_INT_t, ndim=1] flow_receivers,
-                    DTYPE_FLOAT_t node_spacing,
+                    np.ndarray[DTYPE_FLOAT_t, ndim=1] node_spacing,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] q,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] qs,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] qs_in,
@@ -43,8 +43,8 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
         #
         if q[node_id] > 0:
             qs[node_id] = ((qs_in[node_id]
-                            + F_c * Es[node_id] * node_spacing ** 2)
-                           / (1.0 + (v_s * node_spacing**2 / (q[node_id]))))
+                            + F_c * Es[node_id] * node_spacing[node_id] ** 2)
+                           / (1.0 + (v_s * node_spacing[node_id]**2 / (q[node_id]))))
 
             # finally, add this nodes qs to recieiving nodes qs_in.
             # if qs[node_id] == 0, then there is no need for this line to be

--- a/landlab/components/erosion_deposition/tests/test_erodep.py
+++ b/landlab/components/erosion_deposition/tests/test_erodep.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jul 27 14:23:25 2017
+
+@author: gtucker
+"""
+
+from landlab import RasterModelGrid, HexModelGrid
+from landlab.components import ErosionDeposition, FlowAccumulator
+import numpy as np
+from numpy.testing import assert_equal
+
+def test_can_run_with_hex():
+    """Test that model can run with hex model grid."""
+
+    # Set up a 5x5 grid with open boundaries and low initial elevations.
+    mg = HexModelGrid(7, 7)
+    z = mg.add_zeros('node', 'topographic__elevation')
+    z[:] = 0.01 * mg.x_of_node
+
+    # Create a D8 flow handler
+    fa = FlowAccumulator(mg, flow_director='FlowDirectorSteepest')
+
+    # Parameter values for test 1
+    K = 0.001
+    vs = 0.0001
+    U = 0.001
+    dt = 10.0
+
+    # Create the ErosionDeposition component...
+    ed = ErosionDeposition(mg, K=K, phi=0.0, v_s=vs, m_sp=0.5, n_sp=1.0,
+                           method='simple_stream_power',
+                           discharge_method='drainage_area',
+                           area_field='drainage_area',
+                           solver='adaptive')
+
+    # ... and run it to steady state.
+    for i in range(2000):
+        fa.run_one_step()
+        ed.run_one_step(dt=dt)
+        z[mg.core_nodes] += U * dt
+
+    # Test the results
+    s = mg.at_node['topographic__steepest_slope']
+    sa_factor = (1.0 + vs) * U / K
+    a18 = mg.at_node['drainage_area'][18]
+    a28 = mg.at_node['drainage_area'][28]
+    s = mg.at_node['topographic__steepest_slope']
+    s18 = sa_factor * (a18 ** -0.5)
+    s28 = sa_factor * (a28 ** -0.5)
+    assert_equal(np.round(s[18], 3), np.round(s18, 3))
+    assert_equal(np.round(s[28], 3), np.round(s28, 3))

--- a/landlab/components/erosion_deposition/tests/test_erodep_steady_state.py
+++ b/landlab/components/erosion_deposition/tests/test_erodep_steady_state.py
@@ -149,11 +149,12 @@ def test_erodep_slope_area_shear_stress_scaling():
     vs = 1.0
     U = 0.001
     dt = 10.0
-
+    m_sp = 0.33
+    n_sp = 0.67
     # Create the ErosionDeposition component...
-    ed = ErosionDeposition(rg, K=K, phi=0.0, v_s=vs, m_sp=0.33, n_sp=0.67,
+    ed = ErosionDeposition(rg, K=K, phi=0.0, v_s=vs, m_sp=m_sp, n_sp=n_sp,
                            method='simple_stream_power',
-                           discharge_method='drainage_area', 
+                           discharge_method='drainage_area',
                            area_field='drainage_area',
                            solver='adaptive')
 
@@ -165,11 +166,11 @@ def test_erodep_slope_area_shear_stress_scaling():
 
     # Test the results
     s = rg.at_node['topographic__steepest_slope']
-    sa_factor = ((1.0 + vs) * U / K) ** (1.0 / 0.67)
-    a6 = 5.0
-    a8 = 3.0
-    s6 = sa_factor * (a6 ** -(0.33 / 0.67))
-    s8 = sa_factor * (a8 ** -(0.33 / 0.67))
+    sa_factor = ((1.0 + vs) * U / K) ** (1.0 / n_sp)
+    a6 = rg.at_node['drainage_area'][6]
+    a8 = rg.at_node['drainage_area'][8]
+    s6 = sa_factor * (a6 ** -(m_sp / n_sp))
+    s8 = sa_factor * (a8 ** -(m_sp / n_sp))
     assert_equal(np.round(s[6], 2), np.round(s6, 2))
     assert_equal(np.round(s[8], 2), np.round(s8, 2))
 

--- a/landlab/components/space/cfuncs.pyx
+++ b/landlab/components/space/cfuncs.pyx
@@ -14,7 +14,7 @@ ctypedef np.int_t DTYPE_INT_t
 
 def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
                     np.ndarray[DTYPE_INT_t, ndim=1] flow_receivers,
-                    DTYPE_FLOAT_t node_spacing,
+                    np.ndarray[DTYPE_FLOAT_t, ndim=1] node_spacing,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] q,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] qs,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] qs_in,
@@ -43,8 +43,8 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
         # in an upstream to downstream loop, and cannot be vectorized.   
                              
         if q[node_id] > 0:
-            qs[node_id] = (qs_in[node_id] + (Es[node_id] + (1.0 - F_f) * (Er[node_id])) * node_spacing**2) / \
-                            (1.0 + (v_s * node_spacing**2 / (q[node_id])))
+            qs[node_id] = (qs_in[node_id] + (Es[node_id] + (1.0 - F_f) * (Er[node_id])) * node_spacing[node_id]**2) / \
+                            (1.0 + (v_s * node_spacing[node_id]**2 / (q[node_id])))
         
             # finally, add this nodes qs to recieiving nodes qs_in.
             # if qs[node_id] == 0, then there is no need for this line to be

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -625,10 +625,8 @@ class Space(Component):
     def _update_flow_link_slopes(self):
         """Updates gradient between each core node and its receiver.
 
-        Assumes uniform raster grid. Used to update slope values between
-        sub-time-steps, when we do not re-run flow routing.
-
-        (TODO: generalize to other grid types)
+        Used to update slope values between sub-time-steps, when we do not 
+        re-run flow routing.
 
         Examples
         --------
@@ -652,14 +650,11 @@ class Space(Component):
         >>> rg.at_node['topographic__steepest_slope'][5:7]
         array([ 0.14142136,  0.14142136])
         """
-        flowlink = self._grid.at_node['flow__link_to_receiver_node']
         z = self._grid.at_node['topographic__elevation']
         r = self._grid.at_node['flow__receiver_node']
         slp = self._grid.at_node['topographic__steepest_slope']
-        diag_flow_dirs, = np.where(flowlink >= self._grid.number_of_links)
-        slp[:] = (z - z[r]) / self._grid._dx
-        slp[diag_flow_dirs] /= ROOT2
-
+        slp[:] = (z - z[r]) / self.link_lengths[self.link_to_reciever]
+        
     def run_with_adaptive_time_step_solver(self, dt=1.0, flooded_nodes=[],
                                            **kwds):
         """Run step with CHILD-like solver that adjusts time steps to prevent

--- a/landlab/components/space/tests/test_space.py
+++ b/landlab/components/space/tests/test_space.py
@@ -1,0 +1,35 @@
+from landlab import RasterModelGrid, HexModelGrid
+from landlab.components import Space, FlowAccumulator
+import numpy as np
+from numpy.testing import assert_equal
+
+def test_can_run_with_hex():
+    """Test that model can run with hex model grid."""
+
+    # Set up a 5x5 grid with open boundaries and low initial elevations.
+    mg = HexModelGrid(7, 7)
+    z = mg.add_zeros('node', 'topographic__elevation')
+    z[:] = 0.01 * mg.x_of_node
+
+    # Create a D8 flow handler
+    fa = FlowAccumulator(mg, flow_director='FlowDirectorSteepest')
+
+    # Parameter values for test 1
+    K = 0.001
+    vs = 0.0001
+    U = 0.001
+    dt = 10.0
+
+    # Create the ErosionDeposition component...
+    sp = Space(mg, K_sed=0.00001, K_br=0.00000000001,
+                         F_f=0.5, phi=0.1, H_star=1., v_s=0.001,
+                         m_sp=0.5, n_sp = 1.0, sp_crit_sed=0,
+                         sp_crit_br=0, method='simple_stream_power',
+                         discharge_method=None, area_field=None,
+                         discharge_field=None)
+
+    # ... and run it to steady state.
+    for i in range(2000):
+        fa.run_one_step()
+        sp.run_one_step(dt=dt)
+        z[mg.core_nodes] += U * dt


### PR DESCRIPTION
Addresses Issue #654

@cmshobe I'd also like your review. 

I also think that this indicates that SPACE was not using diagonal link lengths even if sediment and water were routed on diagonals. 

The tests do not pass. On my computer I get two errors that indicate VERY small differences between expected and provided. I've pasted these errors below. 

They appear to be mostly in the last few decimal places. 

We can discuss if its OK to change the expected values.

```
======================================================================
FAIL: Doctest: landlab.components.space.space.Space
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/anaconda3/lib/python3.6/doctest.py", line 2199, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for landlab.components.space.space.Space
  File "/Users/barnhark/projects/landlab/landlab/landlab/components/space/space.py", line 11, in Space

----------------------------------------------------------------------
File "/Users/barnhark/projects/landlab/landlab/landlab/components/space/space.py", line 137, in landlab.components.space.space.Space
Failed example:
    mg.at_node['soil__depth'] # doctest: +NORMALIZE_WHITESPACE
Expected:
    array([ 0.50000906,  0.5       ,  0.5       ,  0.5       ,  0.5       ,
            0.5       ,  0.49537393,  0.49305759,  0.49193247,  0.5       ,
            0.5       ,  0.49304854,  0.49304459,  0.4913106 ,  0.5       ,
            0.5       ,  0.49177241,  0.4913074 ,  0.48573171,  0.5       ,
            0.5       ,  0.5       ,  0.5       ,  0.5       ,  0.5       ])
Got:
    array([ 0.50001225,  0.5       ,  0.5       ,  0.5       ,  0.5       ,
            0.5       ,  0.49537537,  0.49305836,  0.49193269,  0.5       ,
            0.5       ,  0.49304932,  0.49304881,  0.49131212,  0.5       ,
            0.5       ,  0.49177263,  0.49130891,  0.48574475,  0.5       ,
            0.5       ,  0.5       ,  0.5       ,  0.5       ,  0.5       ])
----------------------------------------------------------------------
File "/Users/barnhark/projects/landlab/landlab/landlab/components/space/space.py", line 144, in landlab.components.space.space.Space
Failed example:
    mg.at_node['topographic__elevation'] # doctest: +NORMALIZE_WHITESPACE
Expected:
    array([ 0.42290479,  1.53606698,  2.5727653 ,  3.51126678,  4.56077707,
            1.58157495,  0.42399277,  0.428743  ,  0.43834115,  5.50969486,
            2.54008677,  0.4287476 ,  0.42875161,  0.43888606,  6.52641123,
            3.55874171,  0.43848567,  0.43888881,  0.45116241,  7.55334077,
            4.55922478,  5.5409473 ,  6.57035008,  7.5038935 ,  8.51034357])
Got:
    array([ 0.42290479,  1.53606698,  2.5727653 ,  3.51126678,  4.56077707,
            1.58157495,  0.4239942 ,  0.42874378,  0.43834136,  5.50969486,
            2.54008677,  0.42874838,  0.42875582,  0.43888758,  6.52641123,
            3.55874171,  0.43848589,  0.43889032,  0.45117546,  7.55334077,
            4.55922478,  5.5409473 ,  6.57035008,  7.5038935 ,  8.51034357])

>>  raise self.failureException(self.format_failure(<_io.StringIO object at 0x10edb4798>.getvalue()))

```