### PR TITLE
Add cite_as function to landlab

### DIFF
--- a/landlab/__init__.py
+++ b/landlab/__init__.py
@@ -12,8 +12,9 @@
 from __future__ import absolute_import
 import os
 
-# from ._info import version as  __version__
 from ._registry import registry
+
+cite_as = registry.format_citations
 
 __all__ = ['registry']
 


### PR DESCRIPTION
This tiny pull request adds the convenience function `cite_as` to return the citations a user should use based on the components they are using.
```python
>>> import landlab
>>> print(landlab.cite_as())
```
prints
```
# Citations
## landlab
    @article{hobley2017creative,
    title={Creative computing with Landlab: an open-source toolkit
...
```
If you then instantiate a component,
```python
>>> from landlab.components import Flexure
>>> Flexure(landlab.RasterModelGrid((3, 4)))
>>> print(landlab.cite_as())
```
`cite_as` would return
```
# Citations
## landlab
    @article{hobley2017creative,
    title={Creative computing with Landlab: an open-source toolkit
...
## Flexure
    @article{hutton2008sedflux,
    title={Sedflux 2.0: An advanced process-response model that
...
```
