### PR TITLE
Adding 3 steady-state tests for SPACE (from the GMD paper examples)

### DIFF
--- a/landlab/components/erosion_deposition/erosion_deposition.py
+++ b/landlab/components/erosion_deposition/erosion_deposition.py
@@ -243,7 +243,8 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
 
         #topo elev is old elev + deposition - erosion
         cores = self.grid.core_nodes
-        self.topographic__elevation[cores] += ((self.depo_rate[cores]
+        self.topographic__elevation[cores] += (((self.depo_rate[cores] /
+                            (1 - self.phi))
                               - self.erosion_term[cores]) * dt)
 
     def run_with_adaptive_time_step_solver(self, dt=1.0, flooded_nodes=[],
@@ -305,7 +306,7 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
                                           * (self.v_s / self.q[self.q > 0]))
 
             # Rate of change of elevation at core nodes:
-            dzdt[cores] = self.depo_rate[cores] - self.erosion_term[cores]
+            dzdt[cores] = (self.depo_rate[cores] / (1 - self.phi)) - self.erosion_term[cores]
 
             # Difference in elevation between each upstream-downstream pair
             zdif = z - z[r]

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -18,6 +18,11 @@ class Space(_GeneralizedErosionDeposition):
     Landlab component for 2-D calculation of sediment transport, bedrock
     erosion, and landscape evolution, Geosci. Model Dev., 10, 4577-4604,
     https://doi.org/10.5194/gmd-10-4577-2017, 2017.
+    
+    Note: If timesteps are large enough that Es*dt (sediment erosion)
+    exceeds sediment thickness H, the 'adaptive' solver is necessary to
+    subdivide timesteps. Compare Es and H arrays to determine whether
+    timesteps are appropriate or too large for the 'basic' solver.
 
     Parameters
     ----------

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -288,7 +288,7 @@ class Space(_GeneralizedErosionDeposition):
         self._calc_hydrology()
         self._calc_erosion_rates()
 
-        self.qs_in[:] = self.qs_ext
+        self.qs_in[:] = 0
 
         #iterate top to bottom through the stack, calculate qs
         # cythonized version of calculating qs_in
@@ -462,7 +462,7 @@ class Space(_GeneralizedErosionDeposition):
             self.Er[flooded_nodes] = 0.0
 
             # Zero out sediment influx for new iteration
-            self.qs_in[:] = self.qs_ext
+            self.qs_in[:] = 0
 
             calculate_qs_in(np.flipud(self.stack),
                             self.flow_receivers,

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -44,7 +44,11 @@ class Space(_GeneralizedErosionDeposition):
     sp_crit_br : float, field name, or array
         Critical stream power to erode rock [E/(TL^2)]
     discharge_field : float, field name, or array
-        Discharge [L^2/T].
+        Discharge [L^2/T]. The default is to use the grid field
+        'surface_water__discharge', which is simply drainage area
+        multiplied by the default rainfall rate (1 m/yr). To use custom
+        spatially/temporally varying flow, use 'water__unit_flux_in'
+        as the discharge field.
     solver : string
         Solver to use. Options at present include:
             (1) 'basic' (default): explicit forward-time extrapolation.

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -358,6 +358,7 @@ class Space(_GeneralizedErosionDeposition):
                          (blowup==False) &
                          (self.slope > 0) &
                          (flooded==False))
+
         self.soil__depth[pos_not_flood] = (self.H_star *
             np.log((1 / ((self.depo_rate[pos_not_flood] / (1 - self.phi)) /
                     (self.sed_erosion_term[pos_not_flood]) - 1)) *
@@ -366,7 +367,7 @@ class Space(_GeneralizedErosionDeposition):
                     (((self.depo_rate[pos_not_flood] / (1 - self.phi) /
                     (self.sed_erosion_term[pos_not_flood])) - 1) *
                     np.exp(self.soil__depth[pos_not_flood] / self.H_star)  + 1) - 1)))
-
+        
         #places where slope <= 0 but not flooded:
         neg_slope_not_flooded = ((self.q > 0) &
                                  (blowup==False) &
@@ -507,7 +508,7 @@ class Space(_GeneralizedErosionDeposition):
 
             # Next we consider time to exhaust regolith
             time_to_zero_alluv[:] = remaining_time
-            dHdt = self.porosity_factor * (self.depo_rate - self.Es)
+            dHdt = self.porosity_factor * (self.depo_rate) - self.Es
             decreasing_H = np.where(dHdt < 0.0)[0]
             time_to_zero_alluv[decreasing_H] = - (TIME_STEP_FACTOR
                                                   * H[decreasing_H]

--- a/landlab/components/space/tests/test_space.py
+++ b/landlab/components/space/tests/test_space.py
@@ -1,8 +1,70 @@
 from landlab import RasterModelGrid, HexModelGrid
 from landlab.components import Space, FlowAccumulator
 import numpy as np
-from numpy.testing import assert_equal
+from numpy import testing
 
+def test_matches_detachment_solution():
+    """
+    Test that model matches the detachment-limited analytical solution
+    for slope/area relationship at steady state: S=(U/K)^(1/n)*A^(-m/n).
+    """
+    
+    #set up a 3x3 grid with one open outlet node and low initial elevations.
+    nr = 5
+    nc = 5
+    mg = RasterModelGrid((nr, nc), 10.0)
+    
+    z = mg.add_zeros('node', 'topographic__elevation')
+    br = mg.add_zeros('node', 'bedrock__elevation')
+    soil = mg.add_zeros('node', 'soil__depth')
+
+    mg['node']['topographic__elevation'] += mg.node_y / 10000 \
+        + mg.node_x / 10000 \
+        + np.random.rand(len(mg.node_y)) / 10000
+    mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True,
+                                           left_is_closed=True,
+                                           right_is_closed=True,
+                                           top_is_closed=True)
+    mg.set_watershed_boundary_condition_outlet_id(0,
+                                                  mg['node']['topographic__elevation'], 
+                                                  -9999.)
+    br[:] = z[:] - soil[:]
+        
+    # Create a D8 flow handler
+    fa = FlowAccumulator(mg, flow_director='D8')
+    
+    #Instantiate DepressionFinderAndRouter
+    
+    # Parameter values for detachment-limited test
+    K_br = 0.01
+    U = 0.0001
+    dt = 1.0
+    F_f = 1.0 #all detached rock disappears; detachment-ltd end-member
+    m_sp = 0.5
+    n_sp = 1.0
+
+    # Instantiate the Space component...
+    sp = Space(mg, K_sed=0.00001, K_br=K_br,
+                         F_f=F_f, phi=0.1, H_star=1., v_s=0.001,
+                         m_sp=m_sp, n_sp=n_sp, sp_crit_sed=0,
+                         sp_crit_br=0)
+
+    # ... and run it to steady state (2000x1-year timesteps).
+    for i in range(2000):
+        fa.run_one_step()
+        sp.run_one_step(dt=dt)
+        z[mg.core_nodes] += U * dt #m/yr
+        br[mg.core_nodes] = z[mg.core_nodes] - soil[mg.core_nodes]
+    
+    #compare numerical and analytical slope solutions
+    num_slope = mg.at_node['topographic__steepest_slope'][mg.core_nodes]
+    analytical_slope = np.power(U / K_br, 1./n_sp) \
+        * np.power(mg.at_node['drainage_area'][mg.core_nodes], -m_sp / n_sp)
+    testing.assert_array_almost_equal(num_slope, analytical_slope, 
+                                      decimal=8, 
+                                      err_msg='SPACE detachment-limited test failed',
+                                      verbose=True)
+        
 def test_can_run_with_hex():
     """Test that model can run with hex model grid."""
 
@@ -15,8 +77,6 @@ def test_can_run_with_hex():
     fa = FlowAccumulator(mg, flow_director='FlowDirectorSteepest')
 
     # Parameter values for test 1
-    K = 0.001
-    vs = 0.0001
     U = 0.001
     dt = 10.0
 

--- a/landlab/components/space/tests/test_space.py
+++ b/landlab/components/space/tests/test_space.py
@@ -58,6 +58,8 @@ def test_matches_detachment_solution():
     num_slope = mg.at_node['topographic__steepest_slope'][mg.core_nodes]
     analytical_slope = np.power(U / K_br, 1./n_sp) \
         * np.power(mg.at_node['drainage_area'][mg.core_nodes], -m_sp / n_sp)
+        
+    #test for match with analytical slope-area relationship
     testing.assert_array_almost_equal(num_slope, analytical_slope, 
                                       decimal=8, 
                                       err_msg='SPACE detachment-limited test failed',
@@ -111,7 +113,7 @@ def test_matches_transport_solution():
     
     # Instantiate the Space component...
     sp = Space(mg, K_sed=K_sed, K_br=0.01,
-                         F_f=F_f, phi=0.1, H_star=1., v_s=v_s,
+                         F_f=F_f, phi=0.0, H_star=1., v_s=v_s,
                          m_sp=m_sp, n_sp=n_sp, sp_crit_sed=0,
                          sp_crit_br=0)
 
@@ -130,9 +132,101 @@ def test_matches_transport_solution():
         * np.power(mg.at_node['drainage_area'][mg.core_nodes], m_sp)))\
         + (U / (K_sed * np.power(mg.at_node['drainage_area'][mg.core_nodes], \
         m_sp))), 1./n_sp)
+        
+    #test for match with analytical slope-area relationship
     testing.assert_array_almost_equal(num_slope, analytical_slope, 
                                       decimal=8, 
                                       err_msg='SPACE transport-limited test failed',
+                                      verbose=True)
+    
+def test_matches_bedrock_alluvial_solution():
+    """
+    Test that model matches the bedrock-alluvial analytical solution
+    for slope/area relationship at steady state: 
+    S=((U * v_s * (1 - F_f)) / (K_sed * A^m) + U / (K_br * A^m))^(1/n).
+    
+    Also test that the soil depth everywhere matches the bedrock-alluvial
+    analytical solution at steady state: 
+    H = -H_star * ln(1 - (v_s / (K_sed / (K_br * (1 - F_f)) + v_s)))
+    """
+    
+    #set up a 3x3 grid with one open outlet node and low initial elevations.
+    nr = 5
+    nc = 5
+    mg = RasterModelGrid((nr, nc), 10.0)
+    
+    z = mg.add_zeros('node', 'topographic__elevation')
+    br = mg.add_zeros('node', 'bedrock__elevation')
+    soil = mg.add_zeros('node', 'soil__depth')
+
+    mg['node']['topographic__elevation'] += mg.node_y / 100000 \
+        + mg.node_x / 100000 \
+        + np.random.rand(len(mg.node_y)) / 10000
+    mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True,
+                                           left_is_closed=True,
+                                           right_is_closed=True,
+                                           top_is_closed=True)
+    mg.set_watershed_boundary_condition_outlet_id(0,
+                                                  mg['node']['topographic__elevation'], 
+                                                  -9999.)
+    soil[:] += 0. #initial soil depth of 100 m
+    br[:] = z[:]
+    z[:] += soil[:]
+    
+    #Instantiate DepressionFinderAndRouter
+    df = DepressionFinderAndRouter(mg)
+    
+    # Create a D8 flow handler
+    fa = FlowAccumulator(mg, flow_director='D8', 
+                         depression_finder='DepressionFinderAndRouter')
+    
+    # Parameter values for detachment-limited test
+    K_br = 0.02
+    K_sed = 0.02
+    U = 0.0001
+    dt = 1.0
+    F_f = 0.2 #all detached rock disappears; detachment-ltd end-member
+    m_sp = 0.5
+    n_sp = 1.0
+    v_s = 0.25
+    H_star = 0.1
+    
+    # Instantiate the Space component...
+    sp = Space(mg, K_sed=K_sed, K_br=K_br,
+                         F_f=F_f, phi=0.0, H_star=H_star, v_s=v_s,
+                         m_sp=m_sp, n_sp=n_sp, sp_crit_sed=0,
+                         sp_crit_br=0)
+
+    # ... and run it to steady state (4000x1-year timesteps).
+    for i in range(10000):
+        fa.run_one_step()
+        flooded = np.where(df.flood_status==3)[0]
+        sp.run_one_step(dt=dt, flooded_nodes=flooded)
+        br[mg.core_nodes] += U * dt #m
+        soil[0] = 0.
+        z[:] = br[:] + soil[:]
+    
+    #compare numerical and analytical slope solutions
+    num_slope = mg.at_node['topographic__steepest_slope'][mg.core_nodes]
+    analytical_slope = np.power(((U * v_s * (1 - F_f)) / (K_sed \
+        * np.power(mg.at_node['drainage_area'][mg.core_nodes], m_sp)))\
+        + (U / (K_br * np.power(mg.at_node['drainage_area'][mg.core_nodes], \
+        m_sp))), 1./n_sp)
+        
+    #test for match with analytical slope-area relationship
+    testing.assert_array_almost_equal(num_slope, analytical_slope, 
+                                      decimal=8, 
+                                      err_msg='SPACE bedrock-alluvial slope-area test failed',
+                                      verbose=True)
+    
+    #compare numerical and analytical soil depth solutions
+    num_h = mg.at_node['soil__depth'][mg.core_nodes]
+    analytical_h = -H_star * np.log(1 - (v_s / (K_sed / (K_br * (1 - F_f)) + v_s)))
+    
+    #test for match with analytical sediment depth
+    testing.assert_array_almost_equal(num_h, analytical_h, 
+                                      decimal=5, 
+                                      err_msg='SPACE bedrock-alluvial soil thickness test failed',
                                       verbose=True)
         
 def test_can_run_with_hex():

--- a/landlab/components/space/tests/test_space.py
+++ b/landlab/components/space/tests/test_space.py
@@ -9,7 +9,7 @@ def test_matches_detachment_solution():
     for slope/area relationship at steady state: S=(U/K_br)^(1/n)*A^(-m/n).
     """
     
-    #set up a 3x3 grid with one open outlet node and low initial elevations.
+    #set up a 5x5 grid with one open outlet node and low initial elevations.
     nr = 5
     nc = 5
     mg = RasterModelGrid((nr, nc), 10.0)
@@ -75,7 +75,7 @@ def test_matches_transport_solution():
     sediment flux: Qs = U * A * (1 - phi).
     """
     
-    #set up a 3x3 grid with one open outlet node and low initial elevations.
+    #set up a 5x5 grid with one open outlet node and low initial elevations.
     nr = 5
     nc = 5
     mg = RasterModelGrid((nr, nc), 10.0)
@@ -127,7 +127,7 @@ def test_matches_transport_solution():
         flooded = np.where(df.flood_status==3)[0]
         sp.run_one_step(dt=dt, flooded_nodes=flooded)
         br[mg.core_nodes] += U * dt #m
-        soil[0] = 100.
+        soil[0] = 100. #enforce constant soil depth at boundary to keep lowering steady
         z[:] = br[:] + soil[:]
     
     #compare numerical and analytical slope solutions
@@ -165,7 +165,7 @@ def test_matches_bedrock_alluvial_solution():
     H = -H_star * ln(1 - (v_s / (K_sed / (K_br * (1 - F_f)) + v_s))).
     """
     
-    #set up a 3x3 grid with one open outlet node and low initial elevations.
+    #set up a 5x5 grid with one open outlet node and low initial elevations.
     nr = 5
     nc = 5
     mg = RasterModelGrid((nr, nc), 10.0)
@@ -184,7 +184,7 @@ def test_matches_bedrock_alluvial_solution():
     mg.set_watershed_boundary_condition_outlet_id(0,
                                                   mg['node']['topographic__elevation'], 
                                                   -9999.)
-    soil[:] += 0. #initial soil depth of 100 m
+    soil[:] += 0. #initial condition of no soil depth.
     br[:] = z[:]
     z[:] += soil[:]
     
@@ -212,13 +212,13 @@ def test_matches_bedrock_alluvial_solution():
                          m_sp=m_sp, n_sp=n_sp, sp_crit_sed=0,
                          sp_crit_br=0)
 
-    # ... and run it to steady state (4000x1-year timesteps).
+    # ... and run it to steady state (10000x1-year timesteps).
     for i in range(10000):
         fa.run_one_step()
         flooded = np.where(df.flood_status==3)[0]
         sp.run_one_step(dt=dt, flooded_nodes=flooded)
         br[mg.core_nodes] += U * dt #m
-        soil[0] = 0.
+        soil[0] = 0. #enforce 0 soil depth at boundary to keep lowering steady
         z[:] = br[:] + soil[:]
     
     #compare numerical and analytical slope solutions


### PR DESCRIPTION
1) detachment-limited solution (slope-area model vs analytical)
2) transport-limited solution (slope-area model vs analytical)
3) mixed bedrock-alluvial solution (slope-area and sediment depth model vs analytical)

ALSO enhanced documentation for 'dicharge_field' param
ALSO removed qs_in_ext capability because @kbarnhart and I agreed to deal with that in a separate PR.

@gregtucker and @kbarnhart please review!