### PR TITLE
Fix Flexure1D bug

### DIFF
--- a/landlab/components/flexure/__init__.py
+++ b/landlab/components/flexure/__init__.py
@@ -7,8 +7,11 @@
 
 from .flexure import Flexure
 from .flexure_1d import Flexure1D
-from .funcs import (get_flexure_parameter, subside_point_load,
-                    subside_point_loads)
+from .funcs import get_flexure_parameter, subside_point_load, subside_point_loads
 
-__all__ = ['Flexure', 'get_flexure_parameter', 'subside_point_load',
-           'subside_point_loads']
+__all__ = [
+    "Flexure",
+    "get_flexure_parameter",
+    "subside_point_load",
+    "subside_point_loads",
+]

--- a/landlab/components/flexure/examples/example_loading_everywhere.py
+++ b/landlab/components/flexure/examples/example_loading_everywhere.py
@@ -11,10 +11,10 @@ def get_random_load_magnitudes(n_loads):
 
 
 def put_loads_on_grid(grid, load_sizes):
-    load = grid.at_node['lithosphere__overlying_pressure_increment']
+    load = grid.at_node["lithosphere__overlying_pressure_increment"]
     load[:] = load_sizes
 
-    #for (loc, size) in zip(load_locations, load_sizes):
+    # for (loc, size) in zip(load_locations, load_sizes):
     #    load.flat[loc] = size
 
 
@@ -22,14 +22,21 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--shape', type=int, default=200,
-                        help='Number rows and columns')
-    parser.add_argument('--spacing', type=int, default=5e3,
-                        help='Spading between rows and columns (m)')
-    parser.add_argument('--n-procs', type=int, default=1,
-                        help='Number of processors to use')
-    parser.add_argument('--plot', action='store_true', default=False,
-                        help='Plot an image of the total deflection')
+    parser.add_argument(
+        "--shape", type=int, default=200, help="Number rows and columns"
+    )
+    parser.add_argument(
+        "--spacing", type=int, default=5e3, help="Spading between rows and columns (m)"
+    )
+    parser.add_argument(
+        "--n-procs", type=int, default=1, help="Number of processors to use"
+    )
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        default=False,
+        help="Plot an image of the total deflection",
+    )
 
     args = parser.parse_args()
 
@@ -40,15 +47,21 @@ def main():
 
     grid = RasterModelGrid(shape[0], shape[1], spacing[0])
 
-    flex = Flexure(grid, method='flexure')
+    flex = Flexure(grid, method="flexure")
 
     put_loads_on_grid(grid, load_sizes)
 
     flex.update(n_procs=args.n_procs)
 
     if args.plot:
-        grid.imshow('node', 'lithosphere_surface__elevation_increment',
-                    symmetric_cbar=False, cmap='spectral', show=True)
+        grid.imshow(
+            "node",
+            "lithosphere_surface__elevation_increment",
+            symmetric_cbar=False,
+            cmap="spectral",
+            show=True,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/landlab/components/flexure/examples/example_point_load.py
+++ b/landlab/components/flexure/examples/example_point_load.py
@@ -12,7 +12,8 @@ def add_load_to_middle_of_grid(grid, load):
     shape = grid.shape
 
     load_array = grid.field_values(
-        'node', 'lithosphere__overlying_pressure_increment').view()
+        "node", "lithosphere__overlying_pressure_increment"
+    ).view()
     load_array.shape = shape
     load_array[shape[0] / 2, shape[1] / 2] = load
 
@@ -23,15 +24,19 @@ def main():
 
     grid = RasterModelGrid(n_rows, n_cols, dx)
 
-    flex = Flexure(grid, method='flexure')
+    flex = Flexure(grid, method="flexure")
 
     add_load_to_middle_of_grid(grid, 1e7)
 
     flex.update()
 
-    grid.imshow('node', 'lithosphere_surface__elevation_increment',
-                symmetric_cbar=True, show=True)
+    grid.imshow(
+        "node",
+        "lithosphere_surface__elevation_increment",
+        symmetric_cbar=True,
+        show=True,
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/landlab/components/flexure/examples/example_random_point_loads.py
+++ b/landlab/components/flexure/examples/example_random_point_loads.py
@@ -15,7 +15,7 @@ def get_random_load_magnitudes(n_loads):
 
 
 def put_loads_on_grid(grid, load_locations, load_sizes):
-    load = grid.at_node['lithosphere__overlying_pressure_increment'].view()
+    load = grid.at_node["lithosphere__overlying_pressure_increment"].view()
     for (loc, size) in zip(load_locations, load_sizes):
         load.flat[loc] = size
 
@@ -24,16 +24,24 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('--n-loads', type=int, default=16,
-                        help='Number of loads to apply')
-    parser.add_argument('--shape', type=int, default=200,
-                        help='Number rows and columns')
-    parser.add_argument('--spacing', type=int, default=5e3,
-                        help='Spading between rows and columns (m)')
-    parser.add_argument('--n-procs', type=int, default=1,
-                        help='Number of processors to use')
-    parser.add_argument('--plot', action='store_true', default=False,
-                        help='Plot an image of the total deflection')
+    parser.add_argument(
+        "--n-loads", type=int, default=16, help="Number of loads to apply"
+    )
+    parser.add_argument(
+        "--shape", type=int, default=200, help="Number rows and columns"
+    )
+    parser.add_argument(
+        "--spacing", type=int, default=5e3, help="Spading between rows and columns (m)"
+    )
+    parser.add_argument(
+        "--n-procs", type=int, default=1, help="Number of processors to use"
+    )
+    parser.add_argument(
+        "--plot",
+        action="store_true",
+        default=False,
+        help="Plot an image of the total deflection",
+    )
 
     args = parser.parse_args()
 
@@ -45,15 +53,21 @@ def main():
 
     grid = RasterModelGrid(shape[0], shape[1], spacing[0])
 
-    flex = Flexure(grid, method='flexure')
+    flex = Flexure(grid, method="flexure")
 
     put_loads_on_grid(grid, load_locs, load_sizes)
 
     flex.update(n_procs=args.n_procs)
 
     if args.plot:
-        grid.imshow('node', 'lithosphere_surface__elevation_increment',
-                    symmetric_cbar=False, cmap='spectral', show=True)
+        grid.imshow(
+            "node",
+            "lithosphere_surface__elevation_increment",
+            symmetric_cbar=False,
+            cmap="spectral",
+            show=True,
+        )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/landlab/components/flexure/examples/example_two_point_load.py
+++ b/landlab/components/flexure/examples/example_two_point_load.py
@@ -8,15 +8,11 @@ from landlab import RasterModelGrid
 
 SHAPE = (100, 100)
 SPACING = (10e3, 10e3)
-LOAD_LOCS = [
-    (SHAPE[0] / 2, SHAPE[1] / 2),
-    (SHAPE[0] / 4, SHAPE[1] * 3 / 4),
-]
+LOAD_LOCS = [(SHAPE[0] / 2, SHAPE[1] / 2), (SHAPE[0] / 4, SHAPE[1] * 3 / 4)]
 
 
 def put_two_point_loads_on_grid(grid):
-    load = grid.field_values('node',
-                             'lithosphere__overlying_pressure_increment')
+    load = grid.field_values("node", "lithosphere__overlying_pressure_increment")
     load = load.view()
     load.shape = grid.shape
     for loc in LOAD_LOCS:
@@ -24,13 +20,15 @@ def put_two_point_loads_on_grid(grid):
 
 
 def create_lithosphere_elevation_with_bulge(grid):
-    grid.add_zeros('node', 'lithosphere_surface__elevation')
+    grid.add_zeros("node", "lithosphere_surface__elevation")
 
-    z = grid.field_values('node', 'lithosphere_surface__elevation').view()
+    z = grid.field_values("node", "lithosphere_surface__elevation").view()
     z.shape = grid.shape
 
-    (y, x) = np.meshgrid(np.linspace(0, np.pi * .5, grid.shape[0]),
-                         np.linspace(0, np.pi * .5, grid.shape[1]))
+    (y, x) = np.meshgrid(
+        np.linspace(0, np.pi * .5, grid.shape[0]),
+        np.linspace(0, np.pi * .5, grid.shape[1]),
+    )
     (x0, y0) = (np.pi / 3, np.pi / 8)
     np.sin((x - x0) ** 2 + (y - y0) ** 2, out=z)
 
@@ -41,16 +39,19 @@ def main():
 
     create_lithosphere_elevation_with_bulge(grid)
 
-    flex = Flexure(grid, method='flexure')
+    flex = Flexure(grid, method="flexure")
 
     put_two_point_loads_on_grid(grid)
 
     flex.update()
 
-    grid.at_node['lithosphere_surface__elevation'] += grid.at_node['lithosphere_surface__elevation_increment']
-    grid.imshow('node', 'lithosphere_surface__elevation',
-                symmetric_cbar=False, show=True)
+    grid.at_node["lithosphere_surface__elevation"] += grid.at_node[
+        "lithosphere_surface__elevation_increment"
+    ]
+    grid.imshow(
+        "node", "lithosphere_surface__elevation", symmetric_cbar=False, show=True
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/landlab/components/flexure/flexure.py
+++ b/landlab/components/flexure/flexure.py
@@ -114,7 +114,7 @@ class Flexure(Component):
     False
     """
 
-    _name = 'Flexure'
+    _name = "Flexure"
 
     _cite_as = """@article{hutton2008sedflux,
         title={Sedflux 2.0: An advanced process-response model that generates three-dimensional stratigraphy},
@@ -127,35 +127,37 @@ class Flexure(Component):
         publisher={Pergamon}
         }"""
 
-    _input_var_names = (
-        'lithosphere__overlying_pressure_increment',
-    )
+    _input_var_names = ("lithosphere__overlying_pressure_increment",)
 
-    _output_var_names = (
-        'lithosphere_surface__elevation_increment',
-    )
+    _output_var_names = ("lithosphere_surface__elevation_increment",)
 
     _var_units = {
-        'lithosphere__overlying_pressure_increment': 'Pa',
-        'lithosphere_surface__elevation_increment': 'm',
+        "lithosphere__overlying_pressure_increment": "Pa",
+        "lithosphere_surface__elevation_increment": "m",
     }
 
     _var_mapping = {
-        'lithosphere__overlying_pressure_increment': 'node',
-        'lithosphere_surface__elevation_increment': 'node',
+        "lithosphere__overlying_pressure_increment": "node",
+        "lithosphere_surface__elevation_increment": "node",
     }
 
     _var_doc = {
-        'lithosphere__overlying_pressure_increment':
-            'Applied pressure to the lithosphere over a time step',
-        'lithosphere_surface__elevation_increment':
-            'The change in elevation of the top of the lithosphere (the land '
-            'surface) in one timestep',
+        "lithosphere__overlying_pressure_increment": "Applied pressure to the lithosphere over a time step",
+        "lithosphere_surface__elevation_increment": "The change in elevation of the top of the lithosphere (the land "
+        "surface) in one timestep",
     }
 
     @use_file_name_or_kwds
-    def __init__(self, grid, eet=65e3, youngs=7e10, method='airy',
-                 rho_mantle=3300., gravity=9.80665, **kwds):
+    def __init__(
+        self,
+        grid,
+        eet=65e3,
+        youngs=7e10,
+        method="airy",
+        rho_mantle=3300.,
+        gravity=9.80665,
+        **kwds
+    ):
         """Initialize the flexure component.
 
         Parameters
@@ -173,9 +175,8 @@ class Flexure(Component):
         gravity : float, optional
             Acceleration due to gravity (m / s^2).
         """
-        if method not in ('airy', 'flexure'):
-            raise ValueError(
-                '{method}: method not understood'.format(method=method))
+        if method not in ("airy", "flexure"):
+            raise ValueError("{method}: method not understood".format(method=method))
 
         self._grid = grid
 
@@ -189,15 +190,15 @@ class Flexure(Component):
 
         for name in self._input_var_names:
             if name not in self.grid.at_node:
-                self.grid.add_zeros('node', name, units=self._var_units[name])
+                self.grid.add_zeros("node", name, units=self._var_units[name])
 
         for name in self._output_var_names:
             if name not in self.grid.at_node:
-                self.grid.add_zeros('node', name, units=self._var_units[name])
+                self.grid.add_zeros("node", name, units=self._var_units[name])
 
-        self._r = self._create_kei_func_grid(self._grid.shape,
-                                             (self.grid.dy, self.grid.dx),
-                                             self.alpha)
+        self._r = self._create_kei_func_grid(
+            self._grid.shape, (self.grid.dy, self.grid.dx), self.alpha
+        )
 
     @property
     def eet(self):
@@ -207,11 +208,11 @@ class Flexure(Component):
     @eet.setter
     def eet(self, new_val):
         if new_val <= 0:
-            raise ValueError('Effective elastic thickness must be positive.')
+            raise ValueError("Effective elastic thickness must be positive.")
         self._eet = new_val
-        self._r = self._create_kei_func_grid(self._grid.shape,
-                                             (self.grid.dy, self.grid.dx),
-                                             self.alpha)
+        self._r = self._create_kei_func_grid(
+            self._grid.shape, (self.grid.dy, self.grid.dx), self.alpha
+        )
 
     @property
     def youngs(self):
@@ -241,15 +242,17 @@ class Flexure(Component):
     @property
     def alpha(self):
         """Flexure parameter (m)."""
-        return get_flexure_parameter(self._eet, self._youngs, 2,
-                                     gamma_mantle=self.gamma_mantle)
+        return get_flexure_parameter(
+            self._eet, self._youngs, 2, gamma_mantle=self.gamma_mantle
+        )
 
     @staticmethod
     def _create_kei_func_grid(shape, spacing, alpha):
         from scipy.special import kei
 
-        dx, dy = np.meshgrid(np.arange(shape[1]) * spacing[1],
-                             np.arange(shape[0]) * spacing[0])
+        dx, dy = np.meshgrid(
+            np.arange(shape[1]) * spacing[1], np.arange(shape[0]) * spacing[0]
+        )
 
         return kei(np.sqrt(dx ** 2 + dy ** 2) / alpha)
 
@@ -261,18 +264,17 @@ class Flexure(Component):
         n_procs : int, optional
             Number of processors to use for calculations.
         """
-        load = self.grid.at_node['lithosphere__overlying_pressure_increment']
-        deflection = self.grid.at_node['lithosphere_surface__elevation_increment']
+        load = self.grid.at_node["lithosphere__overlying_pressure_increment"]
+        deflection = self.grid.at_node["lithosphere_surface__elevation_increment"]
 
         new_load = load.copy()
 
         deflection.fill(0.)
 
-        if self._method == 'airy':
+        if self._method == "airy":
             deflection[:] = new_load / self.gamma_mantle
         else:
-            self.subside_loads(new_load, deflection=deflection,
-                               n_procs=n_procs)
+            self.subside_loads(new_load, deflection=deflection, n_procs=n_procs)
 
     def subside_loads(self, loads, deflection=None, n_procs=1):
         """Subside surface due to multiple loads.
@@ -299,8 +301,13 @@ class Flexure(Component):
         w = deflection.reshape(self._grid.shape)
         load = loads.reshape(self._grid.shape)
 
-        subside_grid_in_parallel(w, load * self._grid.dx * self._grid.dy,
-                                 self._r, self.alpha, self.gamma_mantle,
-                                 n_procs)
+        subside_grid_in_parallel(
+            w,
+            load * self._grid.dx * self._grid.dy,
+            self._r,
+            self.alpha,
+            self.gamma_mantle,
+            n_procs,
+        )
 
         return deflection

--- a/landlab/components/flexure/flexure_1d.py
+++ b/landlab/components/flexure/flexure_1d.py
@@ -216,6 +216,8 @@ class Flexure1D(Component):
 
         self._rows = (rows, ) or Ellipsis
 
+        self._x_at_node = self.grid.x_of_node.reshape(self.grid.shape).copy()
+
     @property
     def eet(self):
         """Effective elastic thickness (m)."""
@@ -330,7 +332,7 @@ class Flexure1D(Component):
 
     @property
     def x_at_node(self):
-        return self.grid.x_of_node.reshape(self.grid.shape)
+        return self._x_at_node
 
     @property
     def load_at_node(self):

--- a/landlab/components/flexure/funcs.py
+++ b/landlab/components/flexure/funcs.py
@@ -34,7 +34,7 @@ def get_flexure_parameter(h, E, n_dim, gamma_mantle=33000.):
     """
     D = E * pow(h, 3) / 12. / (1. - pow(_POISSON, 2))
 
-    assert(n_dim == 1 or n_dim == 2)
+    assert n_dim == 1 or n_dim == 2
 
     if n_dim == 2:
         alpha = pow(D / gamma_mantle, .25)
@@ -46,17 +46,15 @@ def get_flexure_parameter(h, E, n_dim, gamma_mantle=33000.):
 
 def _calculate_distances(locs, coords):
     if isinstance(locs[0], (float, int)):
-        return np.sqrt(pow(coords[0] - locs[0], 2) +
-                       pow(coords[1] - locs[1], 2))
+        return np.sqrt(pow(coords[0] - locs[0], 2) + pow(coords[1] - locs[1], 2))
     else:
         r = pow(coords[0][:, np.newaxis] - locs[0], 2)
         r += pow(coords[1][:, np.newaxis] - locs[1], 2)
         return np.sqrt(r, out=r)
 
 
-def _calculate_deflections(load, locs, coords, alpha, out=None,
-                           gamma_mantle=33000.):
-    c = - load / (2. * np.pi * gamma_mantle * pow(alpha, 2.))
+def _calculate_deflections(load, locs, coords, alpha, out=None, gamma_mantle=33000.):
+    c = -load / (2. * np.pi * gamma_mantle * pow(alpha, 2.))
     r = _calculate_distances(locs, coords) / alpha
 
     if isinstance(c, (float, int)):
@@ -137,12 +135,12 @@ def subside_point_load(load, loc, coords, params=None, out=None):
     5.265e-07
     """
     params = params or dict(eet=6500., youngs=7.e10)
-    eet, youngs = params['eet'], params['youngs']
-    gamma_mantle = params.get('gamma_mantle', 33000.)
+    eet, youngs = params["eet"], params["youngs"]
+    gamma_mantle = params.get("gamma_mantle", 33000.)
 
-    assert(len(loc) in [1, 2])
-    assert(len(coords) == len(loc))
-    assert(len(coords[0].shape) == 1)
+    assert len(loc) in [1, 2]
+    assert len(coords) == len(loc)
+    assert len(coords[0].shape) == 1
 
     if not isinstance(load, (int, float, np.ndarray)):
         load = np.array(load)
@@ -150,12 +148,12 @@ def subside_point_load(load, loc, coords, params=None, out=None):
     if out is None:
         out = np.empty(coords[0].size, dtype=np.float)
 
-    alpha = get_flexure_parameter(eet, youngs, len(loc),
-                                  gamma_mantle=gamma_mantle)
+    alpha = get_flexure_parameter(eet, youngs, len(loc), gamma_mantle=gamma_mantle)
 
     if len(loc) == 2:
-        _calculate_deflections(load, loc, coords, alpha, out=out,
-                               gamma_mantle=gamma_mantle)
+        _calculate_deflections(
+            load, loc, coords, alpha, out=out, gamma_mantle=gamma_mantle
+        )
     else:
         c = load / (2. * alpha * gamma_mantle)
         r = abs(coords[0] - loc[0]) / alpha
@@ -164,8 +162,7 @@ def subside_point_load(load, loc, coords, params=None, out=None):
     return out
 
 
-def subside_point_loads(loads, locs, coords, params=None, deflection=None,
-                        n_procs=1):
+def subside_point_loads(loads, locs, coords, params=None, deflection=None, n_procs=1):
     """Calculate deflection at points due multiple point loads.
 
     Calculate lithospheric deflections due to *loads* at coordinates
@@ -197,25 +194,26 @@ def subside_point_loads(loads, locs, coords, params=None, deflection=None,
         Array of deflections.
     """
     params = params or dict(eet=6500., youngs=7.e10)
-    eet, youngs = params['eet'], params['youngs']
-    gamma_mantle = params.get('gamma_mantle', 33000.)
+    eet, youngs = params["eet"], params["youngs"]
+    gamma_mantle = params.get("gamma_mantle", 33000.)
 
     if deflection is None:
         deflection = np.empty(coords[0].size, dtype=np.float)
 
-    assert(len(coords) in [1, 2])
-    assert(len(locs) == len(coords))
-    assert(loads.size == locs[0].size)
+    assert len(coords) in [1, 2]
+    assert len(locs) == len(coords)
+    assert loads.size == locs[0].size
 
     if n_procs > 1:
-        _subside_in_parallel(deflection, loads, locs, coords, eet, youngs,
-                             gamma_mantle, n_procs=n_procs)
+        _subside_in_parallel(
+            deflection, loads, locs, coords, eet, youngs, gamma_mantle, n_procs=n_procs
+        )
     else:
         for index in loads.nonzero()[0]:
             loc = [dim.flat[index] for dim in locs]
-            deflection += subside_point_load(loads.flat[index], loc,
-                                             coords, eet, youngs,
-                                             gamma_mantle)
+            deflection += subside_point_load(
+                loads.flat[index], loc, coords, eet, youngs, gamma_mantle
+            )
     return deflection
 
 
@@ -223,13 +221,11 @@ def _subside_point_load_helper(args):
     return subside_point_load(*args)
 
 
-def _subside_in_parallel(dz, loads, locs, coords, eet, youngs, gamma_mantle,
-                         n_procs=4):
+def _subside_in_parallel(dz, loads, locs, coords, eet, youngs, gamma_mantle, n_procs=4):
     args = []
     for index in loads.nonzero()[0]:
         loc = (locs[0].flat[index], locs[1].flat[index])
-        args.append((loads.flat[index], loc, coords, eet, youngs,
-                     gamma_mantle))
+        args.append((loads.flat[index], loc, coords, eet, youngs, gamma_mantle))
 
     pool = Pool(processes=n_procs)
 
@@ -242,6 +238,7 @@ def _subside_in_parallel(dz, loads, locs, coords, eet, youngs, gamma_mantle,
             dz += result
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import doctest
+
     doctest.testmod()

--- a/landlab/components/flexure/tests/test_flexure.py
+++ b/landlab/components/flexure/tests/test_flexure.py
@@ -3,6 +3,7 @@
 Unit tests for landlab.components.flexure.flexure
 """
 from nose.tools import assert_equal, assert_true, assert_raises, with_setup
+
 try:
     from nose.tools import assert_is_instance
 except ImportError:
@@ -19,39 +20,36 @@ _ARGS = (_SHAPE, _SPACING, _ORIGIN)
 
 def setup_grid():
     from landlab import RasterModelGrid
+
     grid = RasterModelGrid((20, 20), spacing=10e3)
     flex = Flexure(grid)
-    globals().update({
-        'flex': Flexure(grid)
-    })
+    globals().update({"flex": Flexure(grid)})
 
 
 @with_setup(setup_grid)
 def test_name():
-    assert_equal(flex.name, 'Flexure')
+    assert_equal(flex.name, "Flexure")
 
 
 @with_setup(setup_grid)
 def test_input_var_names():
-    assert_equal(flex.input_var_names,
-                 ('lithosphere__overlying_pressure_increment', ))
+    assert_equal(flex.input_var_names, ("lithosphere__overlying_pressure_increment",))
 
 
 @with_setup(setup_grid)
 def test_output_var_names():
-    assert_equal(flex.output_var_names,
-                 ('lithosphere_surface__elevation_increment',))
+    assert_equal(flex.output_var_names, ("lithosphere_surface__elevation_increment",))
 
 
 @with_setup(setup_grid)
 def test_var_units():
-    assert_equal(set(flex.input_var_names) |
-                 set(flex.output_var_names),
-                 set(dict(flex.units).keys()))
+    assert_equal(
+        set(flex.input_var_names) | set(flex.output_var_names),
+        set(dict(flex.units).keys()),
+    )
 
-    assert_equal(flex.var_units('lithosphere_surface__elevation_increment'), 'm')
-    assert_equal(flex.var_units('lithosphere__overlying_pressure_increment'),
-                 'Pa')
+    assert_equal(flex.var_units("lithosphere_surface__elevation_increment"), "m")
+    assert_equal(flex.var_units("lithosphere__overlying_pressure_increment"), "Pa")
 
 
 @with_setup(setup_grid)
@@ -72,18 +70,19 @@ def test_grid_y_extent():
 
 @with_setup(setup_grid)
 def test_field_getters():
-    for name in flex.grid['node']:
-        field = flex.grid['node'][name]
+    for name in flex.grid["node"]:
+        field = flex.grid["node"][name]
         assert_is_instance(field, np.ndarray)
-        assert_equal(field.shape,
-                     (flex.grid.number_of_node_rows *
-                      flex.grid.number_of_node_columns, ))
+        assert_equal(
+            field.shape,
+            (flex.grid.number_of_node_rows * flex.grid.number_of_node_columns,),
+        )
 
-    assert_raises(KeyError, lambda: flex.grid['not_a_var_name'])
+    assert_raises(KeyError, lambda: flex.grid["not_a_var_name"])
 
 
 @with_setup(setup_grid)
 def test_field_initialized_to_zero():
-    for name in flex.grid['node']:
-        field = flex.grid['node'][name]
+    for name in flex.grid["node"]:
+        field = flex.grid["node"][name]
         assert_true(np.all(field == 0.))

--- a/landlab/components/flexure/tests/test_flexure_1d.py
+++ b/landlab/components/flexure/tests/test_flexure_1d.py
@@ -255,7 +255,6 @@ def test_x_at_node():
         flex.x_at_node,
         [[0., 1., 2., 3., 4.], [0., 1., 2., 3., 4.], [0., 1., 2., 3., 4.]],
     )
-    assert_true(np.may_share_memory(flex.x_at_node, flex.grid.x_of_node))
 
 
 def test_dz_at_node():

--- a/landlab/components/flexure/tests/test_flexure_1d.py
+++ b/landlab/components/flexure/tests/test_flexure_1d.py
@@ -254,3 +254,21 @@ def test_load_at_node():
 
     assert_true(np.may_share_memory(vals, flex.load_at_node))
     assert_equal(flex.load_at_node.shape, (3, 5))
+
+
+def test_x_is_contiguous():
+    """Test that x_at_node is contiguous."""
+    flex = Flexure1D(RasterModelGrid((3, 5)))
+    assert_true(flex.x_at_node.flags['C_CONTIGUOUS'])
+
+
+def test_dz_is_contiguous():
+    """Test that dz_at_node is contiguous."""
+    flex = Flexure1D(RasterModelGrid((3, 5)))
+    assert_true(flex.dz_at_node.flags['C_CONTIGUOUS'])
+
+
+def test_load_is_contiguous():
+    """Test that load_at_node is contiguous."""
+    flex = Flexure1D(RasterModelGrid((3, 5)))
+    assert_true(flex.load_at_node.flags['C_CONTIGUOUS'])

--- a/landlab/components/flexure/tests/test_flexure_1d.py
+++ b/landlab/components/flexure/tests/test_flexure_1d.py
@@ -1,8 +1,21 @@
 #! /usr/bin/env python
 """Unit tests for landlab.components.flexure.Flexure1D."""
-from nose.tools import (assert_equal, assert_true, assert_raises, with_setup,
-                        assert_in, assert_is, assert_greater, assert_not_equal)
-from numpy.testing import assert_array_equal, assert_array_less, assert_array_almost_equal, assert_almost_equal
+from nose.tools import (
+    assert_equal,
+    assert_true,
+    assert_raises,
+    with_setup,
+    assert_in,
+    assert_is,
+    assert_greater,
+    assert_not_equal,
+)
+from numpy.testing import (
+    assert_array_equal,
+    assert_array_less,
+    assert_array_almost_equal,
+    assert_almost_equal,
+)
 
 try:
     from nose.tools import assert_is_instance
@@ -20,11 +33,10 @@ _ARGS = (_SHAPE, _SPACING, _ORIGIN)
 
 def setup_grid():
     from landlab import RasterModelGrid
+
     grid = RasterModelGrid((20, 20), spacing=10e3)
     flex = Flexure1D(grid)
-    globals().update({
-        'flex': Flexure1D(grid)
-    })
+    globals().update({"flex": Flexure1D(grid)})
 
 
 @with_setup(setup_grid)
@@ -65,8 +77,9 @@ def test_var_mapping():
     for name in flex.input_var_names + flex.output_var_names:
         assert_in(name, flex._var_mapping)
         assert_is_instance(flex._var_mapping[name], str)
-        assert_in(flex._var_mapping[name], ('node', 'link', 'patch',
-                                            'corner', 'face', 'cell'))
+        assert_in(
+            flex._var_mapping[name], ("node", "link", "patch", "corner", "face", "cell")
+        )
 
 
 @with_setup(setup_grid)
@@ -80,7 +93,7 @@ def test_var_doc():
 
 def test_calc_airy():
     """Test airy isostasy."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy')
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy")
     flex.load_at_node[:] = flex.gamma_mantle
 
     assert_array_equal(flex.dz_at_node, 0.)
@@ -90,7 +103,7 @@ def test_calc_airy():
 
 def test_run_one_step():
     """Test the run_one_step method."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy')
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy")
     flex.load_at_node[:] = flex.gamma_mantle
 
     assert_array_equal(flex.dz_at_node, 0.)
@@ -100,7 +113,7 @@ def test_run_one_step():
 
 def test_with_one_row():
     """Test calculating on one row."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy', rows=1)
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy", rows=1)
     flex.load_at_node[:] = flex.gamma_mantle
 
     assert_array_equal(flex.dz_at_node, 0.)
@@ -112,8 +125,8 @@ def test_with_one_row():
 
 def test_with_one_row():
     """Test calculating on one row."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy', rows=(0, 2))
-    flex.load_at_node[:] = - flex.gamma_mantle
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy", rows=(0, 2))
+    flex.load_at_node[:] = -flex.gamma_mantle
 
     assert_array_equal(flex.dz_at_node, 0.)
     flex.update()
@@ -124,13 +137,13 @@ def test_with_one_row():
 
 def test_field_is_updated():
     """Test the output field is updated."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy', rows=(0, 2))
-    flex.load_at_node[:] = - flex.gamma_mantle
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy", rows=(0, 2))
+    flex.load_at_node[:] = -flex.gamma_mantle
 
     assert_array_equal(flex.dz_at_node, 0.)
     flex.update()
 
-    dz = flex.grid.at_node['lithosphere_surface__increment_of_elevation']
+    dz = flex.grid.at_node["lithosphere_surface__increment_of_elevation"]
     assert_array_equal(flex.dz_at_node.flatten(), dz)
 
 
@@ -172,52 +185,62 @@ def test_calc_flexure():
 
 def test_setter_updates():
     """Test that the setters update dependant parameters."""
-    setters = {'eet': ('rigidity', 'alpha', ),
-               'youngs': ('rigidity', 'alpha', ),
-               'rho_water': ('gamma_mantle', 'alpha', ),
-               'rho_mantle': ('gamma_mantle', 'alpha', ),
-               'gravity': ('gamma_mantle', 'alpha', ),
-              }
+    setters = {
+        "eet": ("rigidity", "alpha"),
+        "youngs": ("rigidity", "alpha"),
+        "rho_water": ("gamma_mantle", "alpha"),
+        "rho_mantle": ("gamma_mantle", "alpha"),
+        "gravity": ("gamma_mantle", "alpha"),
+    }
     EPS = 1e-6
     for setter, names in setters.items():
         for name in names:
+
             def _check_dependant_is_updated(setter, name):
                 flex = Flexure1D(RasterModelGrid((3, 5)))
                 val_before = 1. * getattr(flex, name)
                 setattr(flex, setter, getattr(flex, setter) * (1. + EPS) + EPS)
                 assert_not_equal(val_before, getattr(flex, name))
-            _check_dependant_is_updated.description = 'Test {0} updates {1}'.format(setter, name)
+
+            _check_dependant_is_updated.description = "Test {0} updates {1}".format(
+                setter, name
+            )
 
             yield _check_dependant_is_updated, setter, name
 
 
 def test_method_keyword():
     """Test using the method keyword."""
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='airy')
-    assert_equal(flex.method, 'airy')
-    flex = Flexure1D(RasterModelGrid((3, 5)), method='flexure')
-    assert_equal(flex.method, 'flexure')
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="airy")
+    assert_equal(flex.method, "airy")
+    flex = Flexure1D(RasterModelGrid((3, 5)), method="flexure")
+    assert_equal(flex.method, "flexure")
     with assert_raises(ValueError):
-        Flexure1D(RasterModelGrid((3, 5)), method='Flexure')
+        Flexure1D(RasterModelGrid((3, 5)), method="Flexure")
 
 
 def test_constants_keywords():
     """Test the keywords for physical constants."""
-    names = ('eet', 'youngs', 'rho_mantle', 'rho_water', 'gravity')
+    names = ("eet", "youngs", "rho_mantle", "rho_water", "gravity")
     for name in names:
+
         def _check_is_set(name):
             flex = Flexure1D(RasterModelGrid((3, 5)), **{name: 1.})
             assert_equal(getattr(flex, name), 1.)
+
         def _check_is_float(name):
             flex = Flexure1D(RasterModelGrid((3, 5)), **{name: 1})
             assert_is_instance(getattr(flex, name), float)
+
         def _check_error_if_negative(name):
             with assert_raises(ValueError):
                 flex = Flexure1D(RasterModelGrid((3, 5)), **{name: -1})
 
-        _check_is_set.description = 'Test {name} keyword'.format(name=name)
-        _check_is_float.description = 'Test {name} attribute is float'.format(name=name)
-        _check_error_if_negative.description = 'Test {name} must not be negative'.format(name=name)
+        _check_is_set.description = "Test {name} keyword".format(name=name)
+        _check_is_float.description = "Test {name} attribute is float".format(name=name)
+        _check_error_if_negative.description = "Test {name} must not be negative".format(
+            name=name
+        )
 
         yield _check_is_set, name
         yield _check_is_float, name
@@ -228,9 +251,10 @@ def test_x_at_node():
     """Test x_at_node is reshaped and shares memory with the grid."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
 
-    assert_array_equal(flex.x_at_node, [[0., 1., 2., 3., 4.,],
-                                        [0., 1., 2., 3., 4.,],
-                                        [0., 1., 2., 3., 4.,]])
+    assert_array_equal(
+        flex.x_at_node,
+        [[0., 1., 2., 3., 4.], [0., 1., 2., 3., 4.], [0., 1., 2., 3., 4.]],
+    )
     assert_true(np.may_share_memory(flex.x_at_node, flex.grid.x_of_node))
 
 
@@ -238,7 +262,7 @@ def test_dz_at_node():
     """Test dz_at_node is reshaped and shares memory with its field."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
 
-    vals = flex.grid.at_node['lithosphere_surface__increment_of_elevation']
+    vals = flex.grid.at_node["lithosphere_surface__increment_of_elevation"]
     assert_array_equal(vals, 0.)
 
     assert_true(np.may_share_memory(vals, flex.dz_at_node))
@@ -249,7 +273,7 @@ def test_load_at_node():
     """Test load_at_node is reshaped and shares memory with its field."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
 
-    vals = flex.grid.at_node['lithosphere__increment_of_overlying_pressure']
+    vals = flex.grid.at_node["lithosphere__increment_of_overlying_pressure"]
     assert_array_equal(vals, 0.)
 
     assert_true(np.may_share_memory(vals, flex.load_at_node))
@@ -259,16 +283,16 @@ def test_load_at_node():
 def test_x_is_contiguous():
     """Test that x_at_node is contiguous."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
-    assert_true(flex.x_at_node.flags['C_CONTIGUOUS'])
+    assert_true(flex.x_at_node.flags["C_CONTIGUOUS"])
 
 
 def test_dz_is_contiguous():
     """Test that dz_at_node is contiguous."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
-    assert_true(flex.dz_at_node.flags['C_CONTIGUOUS'])
+    assert_true(flex.dz_at_node.flags["C_CONTIGUOUS"])
 
 
 def test_load_is_contiguous():
     """Test that load_at_node is contiguous."""
     flex = Flexure1D(RasterModelGrid((3, 5)))
-    assert_true(flex.load_at_node.flags['C_CONTIGUOUS'])
+    assert_true(flex.load_at_node.flags["C_CONTIGUOUS"])


### PR DESCRIPTION
This pull request fixes a small bug in the `Flexure1D` component when using the *flexure* method. The problem was that the component assumed that `x_at_node` was C-contiguous, but it wasn't. Both `x_at_node` and `y_at_node` of `RasterModelGrid` are *not* contiguous because they are views of `xy_at_node`, which is of shape *(n_nodes, 2)*.