### PR TITLE
Update test instuctions in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,9 +38,11 @@ This open-source manuscript is a gateway for entering the Landlab world:
 
 http://www.earth-surf-dynam.net/5/21/2017/
 
-After installation, tests can be run with:
+After installation, check that you have the latest 
+version (Python shell command):
 
-    $ python -c 'import landlab; landlab.test()'
+    >>> import landlab
+    >>> landlab.__version__
 
 The most current development version is always available from our git
 repository:

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -194,7 +194,7 @@ Testing the Landlab installation
 ================================
 
 The easiest way to test your install is to check the version from inside 
-the Pythonbinterpreter::
+the Python interpreter::
 
   >>> import landlab
   >>> landlab.__version__ 

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -121,7 +121,7 @@ Installing Landlab in developer mode
 .. note::
 
     This assumes **you have never put Landlab on your machine before**. If you've
-    previously used pip to install Landlab, we recommmend you take that version
+    previously used pip to install Landlab, we recommend you take that version
     off first. At a command prompt, use the command: *pip uninstall landlab*
 
 Now that you have a working copy of the Landlab code on you computer, you need to
@@ -243,14 +243,6 @@ responsible for the failures, please fix them until the tests pass. Note that
 you do not need to send a new pull request after committing for fixes. They
 will be added to the current pull request and the tests automatically rerun.
 
-You can also run unit tests locally with the ``test-installed-landlab.py``
-script found in the ``scripts`` folder::
-
-    $ python test-installed-landlab.py
-
-Note that this script will test whatever version of landlab you have installed,
-which may or may not be the one you are working on in your current working
-directory. These test will not work with numpy 1.14.
 
 Troubleshooting
 ===============
@@ -259,14 +251,14 @@ What do I do if my pull request cannot be automatically merged?
 ---------------------------------------------------------------
 
 Get the latest upstream/master and go to the `master` branch. Remember,
-*do not develop here*.  Always develop in a feature branch. Merge the lastest
+*do not develop here*.  Always develop in a feature branch. Merge the latest
 upstream master with your master::
 
   > git fetch upstream
   > git checkout master
   > git merge upstream/master
 
-Go to the branch on which you are developing and merge the lastest upstream
+Go to the branch on which you are developing and merge the latest upstream
 master with your branch::
 
   > git checkout <branch_name>

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -143,9 +143,9 @@ folder) run the following command::
 With Landlab uninstalled, you will not longer be able to import Landlab
 from outside to root folder of your working copy.
 
-To check you have correctly installed Landlab, run the Landlab tests.
+To check you have correctly installed Landlab, check your installed version.
 Do this by importing landlab in an interactive Python shell, then calling
-*landlab.test()*.
+*landlab.__version__*.
 
 
 Fetching updates to the trunk
@@ -193,15 +193,11 @@ tools.
 Testing the Landlab installation
 ================================
 
-The easiest way to run the Landlab tests is to do so from inside the Python
-interpreter::
+The easiest way to test your install is to check the version from inside 
+the Pythonbinterpreter::
 
   >>> import landlab
-  >>> landlab.test()
-
-This will run a series of tests and print our the result of each test. If
-there are any failures, you can report that at the `landlab issue tracker <https://github.com/landlab/landlab/issues>`_. 
-Note that these tests will fail if you try to run them in a spyder iPython console. They should not fail if you start Python (or iPython) from a command line. These tests will not work with numpy 1.14. 
+  >>> landlab.__version__ 
 
 
 Coding Style


### PR DESCRIPTION
:memo: 
Address [issue 758](https://github.com/landlab/landlab/issues/758)
Update instructions on how to test your install, in README and docs, suggesting to test version with `landlab.__version__` as opposed to using `landlab.test()`, which no longer works.