### PR TITLE
don't plot grain hill test of CA

### DIFF
--- a/landlab/ca/tests/grain_hill.py
+++ b/landlab/ca/tests/grain_hill.py
@@ -154,7 +154,7 @@ class GrainHill(CTSModel):
 
         Examples
         --------
-        >>> gh = GrainHill((5, 7))
+        >>> gh = GrainHill((5, 7), show_plots=False)
         >>> gh.grid.at_node['node_state']        
         array([8, 7, 7, 8, 7, 7, 7, 0, 7, 7, 0, 7, 7, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
@@ -248,7 +248,7 @@ class GrainHill(CTSModel):
         >>> ns = hg.add_zeros('node', 'node_state', dtype=int)
         >>> ns[[0, 3, 1, 6, 4, 9, 2]] = 8
         >>> ns[[8, 13, 11, 16, 14]] = 7
-        >>> gh = GrainHill((3, 7))  # grid size arbitrary here
+        >>> gh = GrainHill((3, 7), show_plots=False)  # grid size arbitrary
         >>> (elev, thickness) = gh.get_profile_and_soil_thickness(hg, ns)
         >>> elev
         array([ 0. ,  2.5,  3. ,  2.5,  0. ])


### PR DESCRIPTION
Dis-allow plotting in two doctests that check the CA model