### PR TITLE
Barnhark/fix broken docs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "docs/scipy-sphinx-theme"]
 	path = docs/scipy-sphinx-theme
 	url = https://github.com/scipy/scipy-sphinx-theme
-[submodule "docs/sphinxext"]
-	path = docs/sphinxext
-	url = https://github.com/numpy/numpydoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,7 @@ script:
   fi
 - |
   if [[ "$BUILD_DOCS" == "1" ]]; then
-    echo "WARNING: NOT BUILDING DOCS"
-    # (cd docs && make html)
+    (cd docs && make html)
   fi
 - |
   if [[ "$DEPLOY" == "1" ]]; then

--- a/docs/build_grid_func_docs.py
+++ b/docs/build_grid_func_docs.py
@@ -71,7 +71,7 @@ def create_dicts_of_cats():
  fails_allgrid) = create_dicts_of_cats()
 
 for grid_to_modify in grid_name_to_class.keys():
-    f = open('./text_for_' + grid_to_modify + '.py.txt', "rb")
+    f = open('./text_for_' + grid_to_modify + '.py.txt', "rt")
     text = f.read()
     f.close()
     for LLCAT in LLCATS:
@@ -99,6 +99,6 @@ for grid_to_modify in grid_name_to_class.keys():
 
         text = text.replace('LLCATKEY: ' + LLCAT, text_to_add)
 
-    f = open('./landlab.grid.' + grid_to_modify + '.rst', "wb")
+    f = open('./landlab.grid.' + grid_to_modify + '.rst', "wt")
     f.write(text)
     f.close()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ sys.path.insert(0, '.')
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.todo',
-              'sphinx.ext.mathjax', 'numpydoc', 'sphinx.ext.autosummary']
+              'sphinx.ext.mathjax', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary']
 
 if os.getenv('READTHEDOCS'):
         template_bridge = 'landlab_ext.MyTemplateLoader'
@@ -320,6 +320,9 @@ epub_copyright = u'2013, Author'
 todo_include_todos = True
 #latex_elements = dict(preamble='\\usepackage{amsmath}')
 
-numpydoc_class_members_toctree = False
-numpydoc_show_class_members = False
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+napoleon_include_init_with_doc = True
+napoleon_include_special_with_doc = True
+
 html_style = 'landlab.css'

--- a/docs/dev_guide_install.rst
+++ b/docs/dev_guide_install.rst
@@ -251,7 +251,7 @@ You can also run unit tests locally in the top `landlab` directory and typing::
 
     $ pytest
 
-Note that this script will test whatever version of landlab you have installed,
+Note that this will test whatever version of landlab you have installed,
 which may or may not be the one you are working on in your current working
 directory. These test will not work with numpy 1.14.
 


### PR DESCRIPTION
This PR addresses Issue #734 

Summary of things this does:
- removes numpydoc
- uses napoleon instead of numpydoc in building docs
- fixes two bits of the `build_grid_func_docs.py` file that had python 2/3 string/byte issues.
- turns building docs back on in travis

On my computer docs still don't build correctly and `make html` ends with this error. @mcflugen any ideas?

```
/Users/barnhark/projects/landlab/landlab/landlab/graph/object/at_node.py:docstring of landlab.graph.object.at_node.get_links_at_node:: WARNING: more than one target found for cross-reference 'Graph': landlab.graph.graph.Graph, landlab.graph.Graph

Exception occurred:
  File "/anaconda3/lib/python3.6/site-packages/sphinx/domains/cpp.py", line 3543, in matches
    if s.identOrOp != identOrOp:
AttributeError: 'Symbol' object has no attribute 'identOrOp'
The full traceback has been saved in /var/folders/d_/zvv65dd52_g_k8xht41v676r0000gn/T/sphinx-err-hctxp_pm.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [html] Error 2
```
