### PR TITLE
Fix appending data with write_raster_netcdf

### DIFF
--- a/landlab/io/netcdf/tests/test_read_netcdf.py
+++ b/landlab/io/netcdf/tests/test_read_netcdf.py
@@ -8,17 +8,17 @@ import pytest
 from landlab.io.netcdf import read_netcdf, WITH_NETCDF4
 
 
-_TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
+_TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
 
 def test_read_netcdf3_64bit():
     """Test read_netcdf for with 64-bit netcdf3 format."""
-    grid = read_netcdf(os.path.join(_TEST_DATA_DIR, 'test-netcdf3-64bit.nc'))
+    grid = read_netcdf(os.path.join(_TEST_DATA_DIR, "test-netcdf3-64bit.nc"))
     assert grid.shape == (4, 3)
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_read_netcdf4():
     """Test read_netcdf with netcdf4 format."""
-    grid = read_netcdf(os.path.join(_TEST_DATA_DIR, 'test-netcdf4.nc'))
+    grid = read_netcdf(os.path.join(_TEST_DATA_DIR, "test-netcdf4.nc"))
     assert grid.shape == (4, 3)

--- a/landlab/io/netcdf/tests/test_write_netcdf.py
+++ b/landlab/io/netcdf/tests/test_write_netcdf.py
@@ -17,19 +17,17 @@ except ImportError:
 def test_netcdf_write_int64_field_netcdf4(tmpdir):
     """Test write_netcdf with a grid that has an int64 field."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation',
-                    np.arange(12, dtype=np.int64))
+    field.add_field("node", "topographic__elevation", np.arange(12, dtype=np.int64))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF4')
+        write_netcdf("test.nc", field, format="NETCDF4")
 
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        for name in ['topographic__elevation']:
+        for name in ["topographic__elevation"]:
             assert name in root.variables
-            assert_array_equal(root.variables[name][:].flatten(),
-                               field.at_node[name])
-            assert root.variables[name][:].dtype == 'int64'
+            assert_array_equal(root.variables[name][:].flatten(), field.at_node[name])
+            assert root.variables[name][:].dtype == "int64"
 
         root.close()
 
@@ -37,19 +35,17 @@ def test_netcdf_write_int64_field_netcdf4(tmpdir):
 def test_netcdf_write_uint8_field_netcdf4(tmpdir):
     """Test write_netcdf with a grid that has an uint8 field."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation',
-                    np.arange(12, dtype=np.uint8))
+    field.add_field("node", "topographic__elevation", np.arange(12, dtype=np.uint8))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF4')
+        write_netcdf("test.nc", field, format="NETCDF4")
 
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        for name in ['topographic__elevation']:
+        for name in ["topographic__elevation"]:
             assert name in root.variables
-            assert_array_equal(root.variables[name][:].flatten(),
-                               field.at_node[name])
-            assert root.variables[name][:].dtype == 'uint8'
+            assert_array_equal(root.variables[name][:].flatten(), field.at_node[name])
+            assert root.variables[name][:].dtype == "uint8"
 
         root.close()
 
@@ -59,15 +55,15 @@ def test_netcdf_write_as_netcdf3_64bit(tmpdir):
     from scipy.io import netcdf
 
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', 2. * np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", 2. * np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF3_64BIT')
+        write_netcdf("test.nc", field, format="NETCDF3_64BIT")
 
-        f = netcdf.netcdf_file('test.nc', 'r')
+        f = netcdf.netcdf_file("test.nc", "r")
 
-        for name in ['topographic__elevation', 'uplift_rate']:
+        for name in ["topographic__elevation", "uplift_rate"]:
             assert name in f.variables
             assert_array_equal(f.variables[name][:].flatten(), field.at_node[name])
 
@@ -79,124 +75,130 @@ def test_netcdf_write_as_netcdf3_classic(tmpdir):
     from scipy.io import netcdf
 
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', 2. * np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", 2. * np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF3_CLASSIC')
+        write_netcdf("test.nc", field, format="NETCDF3_CLASSIC")
 
-        f = netcdf.netcdf_file('test.nc', 'r')
+        f = netcdf.netcdf_file("test.nc", "r")
 
-        for name in ['topographic__elevation', 'uplift_rate']:
+        for name in ["topographic__elevation", "uplift_rate"]:
             assert name in f.variables
             assert_array_equal(f.variables[name][:].flatten(), field.at_node[name])
 
         f.close()
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write(tmpdir):
     """Test generic write_netcdf."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF4')
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        write_netcdf("test.nc", field, format="NETCDF4")
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        assert set(root.dimensions) == set(['ni', 'nj', 'nt'])
-        assert len(root.dimensions['ni']) == 3
-        assert len(root.dimensions['nj']) == 4
-        assert len(root.dimensions['nt']) == 1
-        assert root.dimensions['nt'].isunlimited()
+        assert set(root.dimensions) == set(["ni", "nj", "nt"])
+        assert len(root.dimensions["ni"]) == 3
+        assert len(root.dimensions["nj"]) == 4
+        assert len(root.dimensions["nt"]) == 1
+        assert root.dimensions["nt"].isunlimited()
 
-        assert set(root.variables) == set(['x', 'y', 'topographic__elevation'])
+        assert set(root.variables) == set(["x", "y", "topographic__elevation"])
 
-        assert_array_equal(root.variables['x'][:].flatten(),
-                           np.array([0., 1., 2., 0., 1., 2., 0., 1., 2.,
-                                     0., 1., 2., ]))
-        assert_array_equal(root.variables['y'][:].flatten(),
-                           np.array([0., 0., 0., 1., 1., 1., 2., 2., 2.,
-                                     3., 3., 3., ]))
-        assert_array_equal(root.variables['topographic__elevation'][:].flatten(),
-                           field.at_node['topographic__elevation'])
+        assert_array_equal(
+            root.variables["x"][:].flatten(),
+            np.array([0., 1., 2., 0., 1., 2., 0., 1., 2., 0., 1., 2.]),
+        )
+        assert_array_equal(
+            root.variables["y"][:].flatten(),
+            np.array([0., 0., 0., 1., 1., 1., 2., 2., 2., 3., 3., 3.]),
+        )
+        assert_array_equal(
+            root.variables["topographic__elevation"][:].flatten(),
+            field.at_node["topographic__elevation"],
+        )
 
         root.close()
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write_as_netcdf4_classic(tmpdir):
     """Test write_netcdf to netcdf4 classic format."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, format='NETCDF4_CLASSIC')
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4_CLASSIC')
+        write_netcdf("test.nc", field, format="NETCDF4_CLASSIC")
+        root = nc.Dataset("test.nc", "r", format="NETCDF4_CLASSIC")
 
-        for name in ['topographic__elevation', 'uplift_rate']:
+        for name in ["topographic__elevation", "uplift_rate"]:
             assert name in root.variables
-            assert_array_equal(root.variables[name][:].flatten(),
-                               field.at_node[name])
+            assert_array_equal(root.variables[name][:].flatten(), field.at_node[name])
 
         root.close()
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write_names_keyword_as_list(tmpdir):
     """Test write_netcdf using a list for the *names* keyword."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, names=['topographic__elevation'],
-                     format='NETCDF4')
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        write_netcdf(
+            "test.nc", field, names=["topographic__elevation"], format="NETCDF4"
+        )
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        assert 'topographic__elevation' in root.variables
-        assert 'uplift_rate' not in root.variables
-        assert_array_equal(root.variables['topographic__elevation'][:].flatten(),
-                           field.at_node['topographic__elevation'])
+        assert "topographic__elevation" in root.variables
+        assert "uplift_rate" not in root.variables
+        assert_array_equal(
+            root.variables["topographic__elevation"][:].flatten(),
+            field.at_node["topographic__elevation"],
+        )
 
         root.close()
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write_names_keyword_as_str(tmpdir):
     """Test write_netcdf using a ``str`` for the *names* keyword."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, names='uplift_rate', format='NETCDF4')
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        write_netcdf("test.nc", field, names="uplift_rate", format="NETCDF4")
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        assert 'topographic__elevation' not in root.variables
-        assert 'uplift_rate' in root.variables
-        assert_array_equal(root.variables['uplift_rate'][:].flatten(),
-                           field.at_node['uplift_rate'])
+        assert "topographic__elevation" not in root.variables
+        assert "uplift_rate" in root.variables
+        assert_array_equal(
+            root.variables["uplift_rate"][:].flatten(), field.at_node["uplift_rate"]
+        )
 
         root.close()
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write_names_keyword_as_none(tmpdir):
     """Test write_netcdf using ``None`` for the *names* keyword."""
     field = RasterModelGrid(4, 3)
-    field.add_field('node', 'topographic__elevation', np.arange(12.))
-    field.add_field('node', 'uplift_rate', np.arange(12.))
+    field.add_field("node", "topographic__elevation", np.arange(12.))
+    field.add_field("node", "uplift_rate", np.arange(12.))
 
     with tmpdir.as_cwd():
-        write_netcdf('test.nc', field, names=None, format='NETCDF4')
-        root = nc.Dataset('test.nc', 'r', format='NETCDF4')
+        write_netcdf("test.nc", field, names=None, format="NETCDF4")
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
 
-        for name in ['topographic__elevation', 'uplift_rate']:
+        for name in ["topographic__elevation", "uplift_rate"]:
             assert name in root.variables
-            assert_array_equal(root.variables[name][:].flatten(),
-                               field.at_node[name])
+            assert_array_equal(root.variables[name][:].flatten(), field.at_node[name])
 
         root.close()
 
@@ -243,45 +245,45 @@ def test_2d_switched_coords():
 
 def test_1d_unit_spacing():
     """Test _get_raster_spacing with a 1D grid with unit spacing."""
-    spacing = _get_raster_spacing((np.arange(5.), ))
+    spacing = _get_raster_spacing((np.arange(5.),))
     assert spacing == 1.
 
 
 def test_1d_non_unit_spacing():
     """Test _get_raster_spacing with a 1D grid with non-unit spacing."""
-    spacing = _get_raster_spacing((np.arange(5.) * 2, ))
+    spacing = _get_raster_spacing((np.arange(5.) * 2,))
     assert spacing == 2.
 
 
 def test_1d_uneven_spacing():
     """Test _get_raster_spacing with a 1D grid with uneven spacing in y."""
     with pytest.raises(NotRasterGridError):
-        _get_raster_spacing((np.logspace(0., 2., num=5), ))
+        _get_raster_spacing((np.logspace(0., 2., num=5),))
 
 
-@pytest.mark.skipif(not WITH_NETCDF4, reason='netCDF4 package not installed')
+@pytest.mark.skipif(not WITH_NETCDF4, reason="netCDF4 package not installed")
 def test_netcdf_write_at_cells(tmpdir):
     """Test write_netcdf using with cell fields"""
     field = RasterModelGrid((4, 3))
-    field.add_field('cell', 'topographic__elevation',
-                    np.arange(field.number_of_cells))
-    field.add_field('cell', 'uplift_rate', np.arange(field.number_of_cells))
+    field.add_field("cell", "topographic__elevation", np.arange(field.number_of_cells))
+    field.add_field("cell", "uplift_rate", np.arange(field.number_of_cells))
 
     with tmpdir.as_cwd():
-        write_netcdf('test-cells.nc', field, format='NETCDF4')
-        root = nc.Dataset('test-cells.nc', 'r', format='NETCDF4')
+        write_netcdf("test-cells.nc", field, format="NETCDF4")
+        root = nc.Dataset("test-cells.nc", "r", format="NETCDF4")
 
-        for name in ['topographic__elevation', 'uplift_rate']:
+        for name in ["topographic__elevation", "uplift_rate"]:
             assert name in root.variables
-            assert_array_equal(root.variables[name][:].flatten(),
-                               field.at_cell[name])
+            assert_array_equal(root.variables[name][:].flatten(), field.at_cell[name])
 
-        assert set(root.dimensions) == set(['nv', 'ni', 'nj', 'nt'])
-        assert len(root.dimensions['nv']) == 4
-        assert len(root.dimensions['ni']) == 1
-        assert len(root.dimensions['nj']) == 2
-        assert len(root.dimensions['nt']) == 1
-        assert root.dimensions['nt'].isunlimited()
+        assert set(root.dimensions) == set(["nv", "ni", "nj", "nt"])
+        assert len(root.dimensions["nv"]) == 4
+        assert len(root.dimensions["ni"]) == 1
+        assert len(root.dimensions["nj"]) == 2
+        assert len(root.dimensions["nt"]) == 1
+        assert root.dimensions["nt"].isunlimited()
 
-        assert set(root.variables) == set(['x_bnds', 'y_bnds', 'topographic__elevation', 'uplift_rate'])
+        assert set(root.variables) == set(
+            ["x_bnds", "y_bnds", "topographic__elevation", "uplift_rate"]
+        )
         root.close()

--- a/landlab/io/netcdf/tests/test_write_raster_netcdf.py
+++ b/landlab/io/netcdf/tests/test_write_raster_netcdf.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from landlab import RasterModelGrid
+from landlab.io.netcdf import WITH_NETCDF4, NotRasterGridError, write_raster_netcdf
+
+
+def test_append_with_time(tmpdir):
+    field = RasterModelGrid(4, 3)
+    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+
+    with tmpdir.as_cwd():
+        write_raster_netcdf(
+            "test.nc", field, append=False, format="NETCDF4", with_time=True
+        )
+        field.at_node["topographic__elevation"] *= 2
+        write_raster_netcdf("test.nc", field, append=True, format="NETCDF4")
+
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
+
+        for name in ["topographic__elevation"]:
+            assert name in root.variables
+            assert_array_equal(
+                root.variables[name][:],
+                [
+                    [[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]],
+                    [[2, 2, 2], [2, 2, 2], [2, 2, 2], [2, 2, 2]],
+                ],
+            )
+            assert root.variables[name][:].dtype == "int64"
+            assert "nt" in root.dimensions
+            assert len(root.dimensions["nt"]) == 2
+
+        root.close()
+
+
+def test_without_time(tmpdir):
+    field = RasterModelGrid(4, 3)
+    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+
+    with tmpdir.as_cwd():
+        write_raster_netcdf(
+            "test.nc", field, append=False, format="NETCDF4", with_time=False
+        )
+
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
+
+        for name in ["topographic__elevation"]:
+            assert name in root.variables
+            assert_array_equal(
+                root.variables[name][:], [[[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]]
+            )
+            assert root.variables[name][:].dtype == "int64"
+            assert "nt" in root.dimensions
+            assert len(root.dimensions["nt"]) == 1
+
+        root.close()
+
+
+def test_with_time(tmpdir):
+    field = RasterModelGrid(4, 3)
+    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+
+    with tmpdir.as_cwd():
+        write_raster_netcdf(
+            "test.nc", field, append=False, format="NETCDF4", with_time=True
+        )
+
+        root = nc.Dataset("test.nc", "r", format="NETCDF4")
+
+        for name in ["topographic__elevation"]:
+            assert name in root.variables
+            assert_array_equal(
+                root.variables[name][:], [[[1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]]
+            )
+            assert root.variables[name][:].dtype == "int64"
+            assert "nt" in root.dimensions
+            assert len(root.dimensions["nt"]) == 1
+
+        root.close()

--- a/landlab/io/netcdf/write.py
+++ b/landlab/io/netcdf/write.py
@@ -639,15 +639,16 @@ def write_netcdf(path, fields, attrs=None, append=False,
 
 
 def write_raster_netcdf(path, fields, attrs=None, append=False,
-                        format='NETCDF4', names=None, at=None):
+                        with_time=False, format='NETCDF4', names=None,
+                        at=None):
     
     """Write Raster Model Grid landlab fields to netcdf.
 
     Write the data and grid information for *fields* to *path* as NetCDF.
-    
+
     This method is for Raster Grids only and takes advantage of regular x and
     y spacing to save memory. 
-    
+
     If the *append* keyword argument in True, append the data to an existing
     file, if it exists. Otherwise, clobber an existing files.
 
@@ -660,6 +661,8 @@ def write_raster_netcdf(path, fields, attrs=None, append=False,
         be a Raster type. 
     append : boolean, optional
         Append data to an existing file, otherwise clobber the file.
+    with_time : boolean, optional
+        Include a time dimension for variables.
     format : {'NETCDF4'}
         Format of output netcdf file.
     attrs : dict
@@ -748,6 +751,8 @@ def write_raster_netcdf(path, fields, attrs=None, append=False,
     _set_netcdf_attributes(root, attrs)
    
     _set_netcdf_structured_dimensions(root, fields.shape)
+    if with_time or "nt" in root.dimensions:
+        _add_time_variable(root, 0.)
     _set_netcdf_raster_variables(root, fields, names=names)
 
     root.close()


### PR DESCRIPTION
This pull request addresses #777.

* Added `with_time` keyword to `write_raster_netcdf` to indicate if variables should be added with a time dimension. If so, when the file is appended to (`append=True`), fields are added along that dimension.
* Added new unit tests for this functionality.