### PR TITLE
Address Issue 779: Travis fails due to the pytest version

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   requires:
-    - pytest
+    - pytest 3.7.4
   commands:
     - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   requires:
-    - pytest 3.7.2
+    - pytest
   commands:
     - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   requires:
-    - pytest
+    - pytest==3.7.2
   commands:
     - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   requires:
-    - pytest==3.7.2
+    - pytest 3.7.2
   commands:
     - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
-- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest pytest-cov
+- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest==3.7.4 pytest-cov
 - conda info -a && conda list
 script:
 - conda install --file=requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
-- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest pytest-cov
+- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest==3.7.2 pytest-cov
 - conda info -a && conda list
 script:
 - conda install --file=requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
-- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest==3.7.2 pytest-cov
+- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest pytest-cov
 - conda info -a && conda list
 script:
 - conda install --file=requirements.txt


### PR DESCRIPTION
Only thing changed here is the pytest version in the `.conda-recipe/meta.yaml` and the `.travis.yaml` files. 

Should address #779.