### PR TITLE
Remove version requirement for pytest

### DIFF
--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
 
 test:
   requires:
-    - pytest 3.7.1
+    - pytest
   commands:
     - pytest --pyargs landlab --doctest-modules -o doctest_optionflags="NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
-- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest==3.7.2 pytest-cov
+- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest pytest-cov
 - conda info -a && conda list
 script:
 - conda install --file=requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - conda config --set always_yes yes --set changeps1 no
 - conda create -n _testing python=$TRAVIS_PYTHON_VERSION
 - source activate _testing
-- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest==3.7.1 pytest-cov
+- conda install -q conda-build=3.0 anaconda-client coverage coveralls sphinx pytest pytest-cov
 - conda info -a && conda list
 script:
 - conda install --file=requirements.txt


### PR DESCRIPTION
pytest v3.7.3 was broken on Mac (as described in #779) so, to get our tests working, we had to specify a working version of pytest (v3.7.1) in the `.travis.yml` and the conda `meta.yaml` files. Since pytest v3.7.4 is now available on the default channel, we no longer need to specify an older version. 