### PR TITLE
DataRecord init options

### DIFF
--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -73,12 +73,12 @@ class DataRecord(Dataset):
         ----------
         grid : ModelGrid
         time : list or 1-D array of float or int (optional)
-            The initial time coordinates to add to the recorded. A time
-            coordinate is not created if the value is 'None' (default).
+            The initial time(s) to add to the record. A time dimension is not
+            created if the value is 'None' (default).
         items : dict (optional)
-            No item is created if the value is 'None' (default). Otherwise,
-            dictionary describes the position of generic items on the grid. The
-            structure is:
+            Generic items that live on grid elements. No item is created if the
+            value is 'None' (default). Otherwise, dictionary describes the
+            position of generic items on the grid. The structure is:
                 {'grid_element' : [grid_element],
                  'element_id' : [element_id]}
             where:


### PR DESCRIPTION
The change I made to init options described  [in this comment](https://github.com/landlab/landlab/issues/769#issuecomment-421528527) seem to be covered by the tests you have already created, so I did not make additional tests. 

The run time improvement described in the linked comment is due to this line change in the `set data` method:
```python
# previous line
time_index = int(self.time_coordinates.index(time[0]))

# faster
time_index = np.where(self.time.values == time)[0][0]
```

Questions and other minor things I hoped to save you from having to doing:
- Editted first bit of method docstrings to be limited to one line of text.
- Are the adjacent double parenthesis needed? For example:
```python
raise TypeError(('time must be a list or a 1-d array'))
```
- Are `_input_var_names`, etc necessary given that this is not a component?
- avoided inline comments (PEP8)
- sometimes its written 'Datarecord' and sometimes 'DataRecord'. I modified occurences in print statements to consistently be 'DataRecord'. I advocate for it to always to be this only because I as a user wonder if different capitalization has significance. (Maybe there is a significance I'm not getting.)
