### PR TITLE
Fix #843; remove as_id_array cruft

### DIFF
--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -179,24 +179,6 @@ def as_id_array(array):
         return np.asarray(array, dtype=np.int)
 
 
-if np.dtype(np.intp) == np.int:
-
-    def _as_id_array(array):
-        if array.dtype == np.intp or array.dtype == np.int:
-            return array.view(np.int)
-        else:
-            return array.astype(np.int)
-
-
-else:
-
-    def _as_id_array(array):
-        if array.dtype == np.int:
-            return array.view(np.int)
-        else:
-            return array.astype(np.int)
-
-
 def make_optional_arg_into_id_array(number_of_elements, *args):
     """Transform an optional argument into an array of element ids.
 

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -169,6 +169,13 @@ def as_id_array(array):
     array([0, 1, 2, 3, 4])
     >>> y.dtype == np.int
     True
+
+    >>> x = np.arange(5, dtype=np.intp)
+    >>> y = np.where(x < 3)[0]
+    >>> y.dtype == np.intp
+    True
+    >>> as_id_array(y).dtype == np.int
+    True
     """
     try:
         if array.dtype == np.int:

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -179,7 +179,7 @@ def as_id_array(array):
     """
     try:
         if array.dtype == np.int:
-            return array
+            return array.view(np.int)
         else:
             return array.astype(np.int)
     except AttributeError:

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -179,7 +179,7 @@ def as_id_array(array):
     """
     try:
         if array.dtype == np.int:
-            return array.view(np.int)
+            return array
         else:
             return array.astype(np.int)
     except AttributeError:


### PR DESCRIPTION
This pull request removes `as_id_array` cruft from `landlab/utils.py` as described in #843. I've also changed `as_id_array` to return the input array when possible instead of a view. I think that should be ok. There's another doctest, which uses `np.where`, too.