### PR TITLE
Fix issue 861

### DIFF
--- a/landlab/components/lithology/lithology.py
+++ b/landlab/components/lithology/lithology.py
@@ -6,10 +6,11 @@ import numpy as np
 import xarray as xr
 from scipy.interpolate import interp1d
 
+from landlab import Component
 from landlab.layers import EventLayers, MaterialLayers
 
 
-class Lithology(object):
+class Lithology(Component):
 
     """Create a Lithology object.
 

--- a/landlab/components/lithology/tests/test_litholayers.py
+++ b/landlab/components/lithology/tests/test_litholayers.py
@@ -10,7 +10,13 @@ import numpy as np
 import pytest
 
 from landlab import RasterModelGrid
+from landlab.bmi import wrap_as_bmi
 from landlab.components import LithoLayers
+
+
+def test_litholayers_as_bmi():
+    """Test Litholayers can be wrapped with a BMI."""
+    wrap_as_bmi(LithoLayers)
 
 
 def test_z0s_ids_different_shape():

--- a/landlab/components/lithology/tests/test_lithology.py
+++ b/landlab/components/lithology/tests/test_lithology.py
@@ -10,7 +10,13 @@ import pytest
 from numpy.testing import assert_array_equal  # , assert_array_almost_equal
 
 from landlab import RasterModelGrid
+from landlab.bmi import wrap_as_bmi
 from landlab.components import LithoLayers, Lithology
+
+
+def test_lithology_as_bmi():
+    """Test Lithology can be wrapped with a BMI."""
+    wrap_as_bmi(Lithology)
 
 
 def test_bad_layer_method():
@@ -302,7 +308,7 @@ def test_rock_block_xarray():
     mg = RasterModelGrid((3, 3), 1)
     mg.add_zeros("node", "topographic__elevation")
     layer_ids = np.tile([0, 1, 2, 3], 5)
-    layer_elevations = 3. * np.arange(-10, 10)
+    layer_elevations = 3.0 * np.arange(-10, 10)
     layer_elevations[-1] = layer_elevations[-2] + 100
     attrs = {"K_sp": {0: 0.0003, 1: 0.0001, 2: 0.0002, 3: 0.0004}}
 
@@ -312,16 +318,16 @@ def test_rock_block_xarray():
     ds = lith.rock_cube_to_xarray(sample_depths)
     expected_array = np.array(
         [
-            [[3., 2., 2.], [2., 2., 2.], [2., 2., 1.]],
-            [[3., 3., 2.], [3., 2., 2.], [2., 2., 2.]],
-            [[3., 3., 3.], [3., 3., 2.], [3., 2., 2.]],
-            [[0., 3., 3.], [3., 3., 3.], [3., 3., 2.]],
-            [[0., 0., 3.], [0., 3., 3.], [3., 3., 3.]],
-            [[0., 0., 0.], [0., 0., 3.], [0., 3., 3.]],
-            [[1., 0., 0.], [0., 0., 0.], [0., 0., 3.]],
-            [[1., 1., 0.], [1., 0., 0.], [0., 0., 0.]],
-            [[1., 1., 1.], [1., 1., 0.], [1., 0., 0.]],
-            [[2., 1., 1.], [1., 1., 1.], [1., 1., 0.]],
+            [[3.0, 2.0, 2.0], [2.0, 2.0, 2.0], [2.0, 2.0, 1.0]],
+            [[3.0, 3.0, 2.0], [3.0, 2.0, 2.0], [2.0, 2.0, 2.0]],
+            [[3.0, 3.0, 3.0], [3.0, 3.0, 2.0], [3.0, 2.0, 2.0]],
+            [[0.0, 3.0, 3.0], [3.0, 3.0, 3.0], [3.0, 3.0, 2.0]],
+            [[0.0, 0.0, 3.0], [0.0, 3.0, 3.0], [3.0, 3.0, 3.0]],
+            [[0.0, 0.0, 0.0], [0.0, 0.0, 3.0], [0.0, 3.0, 3.0]],
+            [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 3.0]],
+            [[1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+            [[1.0, 1.0, 1.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0]],
+            [[2.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 0.0]],
         ]
     )
 


### PR DESCRIPTION
This pull request fixes issue #861. The `Lithology` (and so `Litholayers`) component could not be wrapped with a BMI because it did not inherit from `landlab.Component`. This pull request adds:
1. `Component` as a parent to `Lithology`, and
1.  a couple tests to ensure that both `Lithology` and `Litholayers` can be wrapped with a BMI using `wrap_as_bmi`.