### PR TITLE
Automatically find and compile all pyx files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python
 
 import os
+import re
 from distutils.extension import Extension
 
 import pkg_resources
@@ -13,101 +14,16 @@ import versioneer
 numpy_incl = pkg_resources.resource_filename("numpy", "core/include")
 
 
-ext_modules = [
-    Extension("landlab.ca.cfuncs", ["landlab/ca/cfuncs.pyx"]),
-    Extension("landlab.grid.cfuncs", ["landlab/grid/cfuncs.pyx"]),
-    Extension(
-        "landlab.components.flexure.cfuncs", ["landlab/components/flexure/cfuncs.pyx"]
-    ),
-    Extension(
-        "landlab.components.flexure.ext.flexure1d",
-        ["landlab/components/flexure/ext/flexure1d.pyx"],
-    ),
-    Extension(
-        "landlab.components.flow_accum.cfuncs",
-        ["landlab/components/flow_accum/cfuncs.pyx"],
-    ),
-    Extension(
-        "landlab.components.flow_director.cfuncs",
-        ["landlab/components/flow_director/cfuncs.pyx"],
-    ),
-    Extension(
-        "landlab.components.stream_power.cfuncs",
-        ["landlab/components/stream_power/cfuncs.pyx"],
-    ),
-    Extension(
-        "landlab.components.space.cfuncs", ["landlab/components/space/cfuncs.pyx"]
-    ),
-    Extension(
-        "landlab.components.drainage_density.cfuncs",
-        ["landlab/components/drainage_density/cfuncs.pyx"],
-    ),
-    Extension(
-        "landlab.components.erosion_deposition.cfuncs",
-        ["landlab/components/erosion_deposition/cfuncs.pyx"],
-    ),
-    Extension("landlab.utils.ext.jaggedarray", ["landlab/utils/ext/jaggedarray.pyx"]),
-    Extension(
-        "landlab.graph.structured_quad.ext.at_node",
-        ["landlab/graph/structured_quad/ext/at_node.pyx"],
-    ),
-    Extension(
-        "landlab.graph.structured_quad.ext.at_link",
-        ["landlab/graph/structured_quad/ext/at_link.pyx"],
-    ),
-    Extension(
-        "landlab.graph.structured_quad.ext.at_patch",
-        ["landlab/graph/structured_quad/ext/at_patch.pyx"],
-    ),
-    Extension(
-        "landlab.graph.structured_quad.ext.at_cell",
-        ["landlab/graph/structured_quad/ext/at_cell.pyx"],
-    ),
-    Extension(
-        "landlab.graph.structured_quad.ext.at_face",
-        ["landlab/graph/structured_quad/ext/at_face.pyx"],
-    ),
-    Extension("landlab.graph.hex.ext.hex", ["landlab/graph/hex/ext/hex.pyx"]),
-    Extension(
-        "landlab.graph.sort.ext.remap_element",
-        ["landlab/graph/sort/ext/remap_element.pyx"],
-    ),
-    Extension("landlab.graph.sort.ext.argsort", ["landlab/graph/sort/ext/argsort.pyx"]),
-    Extension(
-        "landlab.graph.sort.ext.spoke_sort", ["landlab/graph/sort/ext/spoke_sort.pyx"]
-    ),
-    Extension(
-        "landlab.graph.voronoi.ext.voronoi", ["landlab/graph/voronoi/ext/voronoi.pyx"]
-    ),
-    Extension(
-        "landlab.graph.voronoi.ext.delaunay", ["landlab/graph/voronoi/ext/delaunay.pyx"]
-    ),
-    Extension(
-        "landlab.graph.object.ext.at_node", ["landlab/graph/object/ext/at_node.pyx"]
-    ),
-    Extension(
-        "landlab.graph.object.ext.at_patch", ["landlab/graph/object/ext/at_patch.pyx"]
-    ),
-    Extension(
-        "landlab.graph.quantity.ext.of_link", ["landlab/graph/quantity/ext/of_link.pyx"]
-    ),
-    Extension(
-        "landlab.graph.quantity.ext.of_patch",
-        ["landlab/graph/quantity/ext/of_patch.pyx"],
-    ),
-    Extension(
-        "landlab.graph.matrix.ext.matrix", ["landlab/graph/matrix/ext/matrix.pyx"]
-    ),
-    Extension(
-        "landlab.grid.structured_quad.cfuncs",
-        ["landlab/grid/structured_quad/cfuncs.pyx"],
-    ),
-    Extension(
-        "landlab.grid.structured_quad.c_faces",
-        ["landlab/grid/structured_quad/c_faces.pyx"],
-    ),
-    Extension("landlab.layers.ext.eventlayers", ["landlab/layers/ext/eventlayers.pyx"]),
-]
+def find_extensions(path="."):
+    extensions = []
+    for root, dirs, files in os.walk(os.path.normpath(path)):
+        extensions += [
+            os.path.join(root, fname) for fname in files if fname.endswith(".pyx")
+        ]
+    return [
+        Extension(re.sub(os.path.sep, ".", ext[: -len(".pyx")]), [ext])
+        for ext in extensions
+    ]
 
 
 def register(**kwds):
@@ -187,5 +103,5 @@ setup(
     ),
     entry_points={"console_scripts": ["landlab=landlab.cmd.landlab:main"]},
     include_dirs=[numpy_incl],
-    ext_modules=ext_modules,
+    ext_modules=find_extensions("landlab"),
 )


### PR DESCRIPTION
This pull request adds a `find_extensions` function to *setup.py* that scans the *landlab* folder for `.pyx` files and compiles them. This allows us to add new cython files without having to add the files manually to *setup.py*.