### PR TITLE
Allow watershed methods to take a field name

### DIFF
--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python
 """Store collections of data fields."""
 
+import numpy as np
+import six
 from .scalar_data_fields import ScalarDataFields
 
 
@@ -379,6 +381,92 @@ class ModelDataFields(object):
         LLCATS: FIELDIO
         """
         return self[group][field]
+
+    def return_array_or_field_values(self, group, field):
+        """Return field given a field name, or array of with the correct shape.
+
+        Given a *group* and a *field*, return a reference to the associated
+        data array. *field* is either a string that is a field in the group
+        or an array of the correct size.
+
+        This function is meant to serve like the ``use_field_name_or_array``
+        decorator for bound functions.
+
+        Parameters
+        ----------
+        group: str
+            Name of the group.
+        field: str or array
+            Name of the field withing *group*.
+
+        Returns
+        -------
+        array
+            The values of the field.
+
+        Raises
+        ------
+        GroupError
+            If *group* does not exits
+        FieldError
+            If *field* does not exits
+
+        Examples
+        --------
+        Create a group of fields called *node*.
+
+        >>> import numpy as np
+        >>> from landlab.field import ModelDataFields
+        >>> fields = ModelDataFields()
+        >>> fields.new_field_location('node', 4)
+
+        Add a field, initialized to ones, called *topographic__elevation*
+        to the *node* group. The *field_values* method returns a reference
+        to the field's data.
+
+        >>> _ = fields.add_ones('node', 'topographic__elevation')
+        >>> fields.field_values('node', 'topographic__elevation')
+        array([ 1.,  1.,  1.,  1.])
+
+        Alternatively, if the second argument is an array, its size is
+        checked and returned if correct.
+
+        >>> vals = np.array([4., 5., 7., 3.])
+        >>> fields.return_array_or_field_values('node', vals)
+        array([ 4.,  5.,  7.,  3.])
+
+        Raise FieldError if *field* does not exist in *group*.
+
+        >>> fields.return_array_or_field_values('node', 'surface__temperature')
+        ...     # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        FieldError: surface__temperature
+
+        If *group* does not exists, Raise GroupError.
+
+        >>> fields.return_array_or_field_values('cell', 'topographic__elevation')
+        ...     # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        GroupError: cell
+
+        And if the array of values provided is incorrect, raise a ValueError.
+
+        >>> vals = np.array([3., 2., 1.])
+        >>> fields.return_array_or_field_values('node', vals)
+        ...     # doctest: +IGNORE_EXCEPTION_DETAIL
+        Traceback (most recent call last):
+        ValueError: Array has incorrect size.
+
+        LLCATS: FIELDIO
+        """
+        if isinstance(field, six.string_types):
+            vals = self.field_values(group, field)
+        else:
+            vals = np.asarray(field)
+            if vals.size != self[group].size:
+                msg = ("Array has incorrect size.")
+                raise ValueError(msg)
+        return vals
 
     def field_units(self, group, field):
         """Get units for a field.

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import six
+
 from .scalar_data_fields import ScalarDataFields
 
 
@@ -464,7 +465,7 @@ class ModelDataFields(object):
         else:
             vals = np.asarray(field)
             if vals.size != self[group].size:
-                msg = ("Array has incorrect size.")
+                msg = "Array has incorrect size."
                 raise ValueError(msg)
         return vals
 

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -1013,10 +1013,15 @@ class HexModelGrid(VoronoiDelaunayGrid):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
+
         # make ring of no data nodes
         self.status_at_node[self.boundary_nodes] = CLOSED_BOUNDARY
+
         # set no data nodes to inactive boundaries
         self.set_nodata_nodes_to_closed(node_data, nodata_value)
+
         # set the boundary condition (fixed value) at the outlet_node
         self.status_at_node[outlet_id] = FIXED_VALUE_BOUNDARY
 
@@ -1080,6 +1085,9 @@ class HexModelGrid(VoronoiDelaunayGrid):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
+
         # make ring of no data nodes
         self.status_at_node[self.boundary_nodes] = CLOSED_BOUNDARY
 

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -980,8 +980,9 @@ class HexModelGrid(VoronoiDelaunayGrid):
         ----------
         outlet_id : integer
             id of the outlet node
-        node_data : ndarray
-            Data values.
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         nodata_value : float, optional
             Value that indicates an invalid value.
 
@@ -1053,8 +1054,9 @@ class HexModelGrid(VoronoiDelaunayGrid):
 
         Parameters
         ----------
-        node_data : ndarray
-            Data values.
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         nodata_value : float, optional
             Value that indicates an invalid value.
         return_outlet_id : boolean, optional

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -4107,6 +4107,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
+
         # For this to be a watershed, need to make sure that there is a ring
         # of closed boundary nodes around the outside of the watershed,
         # barring the outlet location.  So enforce that all perimeter nodes
@@ -4259,9 +4262,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         >>> mg2.set_watershed_boundary_condition(z2)
         >>> mg2.status_at_node.reshape(mg2.shape)
         array([[4, 4, 4, 4, 4, 4],
-              [4, 0, 0, 4, 0, 4],
-              [4, 0, 1, 4, 4, 4],
-              [4, 4, 4, 4, 4, 4]], dtype=uint8)
+               [4, 0, 0, 4, 0, 4],
+               [4, 0, 1, 4, 4, 4],
+               [4, 4, 4, 4, 4, 4]], dtype=uint8)
         >>> mg2.set_open_nodes_disconnected_from_watershed_to_closed(z2)
         >>> np.allclose(mg1.status_at_node, mg2.status_at_node)
         True
@@ -4280,6 +4283,8 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
 
         if outlet_id is None:
             # verify that there is one and only one node with the status
@@ -4429,6 +4434,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
+
         # make ring of no data nodes
         self.set_closed_boundaries_at_grid_edges(True, True, True, True)
 
@@ -4493,10 +4501,15 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         LLCATS: BC
         """
+        # get node_data if a field name
+        node_data = self.return_array_or_field_values("node", node_data)
+
         # make ring of no data nodes
         self.set_closed_boundaries_at_grid_edges(True, True, True, True)
+
         # set no data nodes to inactive boundaries
         self.set_nodata_nodes_to_closed(node_data, nodata_value)
+
         # set the boundary condition (fixed value) at the outlet_node
         self.status_at_node[outlet_id] = FIXED_VALUE_BOUNDARY
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -4049,8 +4049,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         Parameters
         ----------
-        node_data : ndarray
-            Data values.
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         nodata_value : float, optional
             Value that indicates an invalid value.
         return_outlet_id : boolean, optional
@@ -4104,6 +4105,22 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         >>> rmg2.set_watershed_boundary_condition(node_data2, -9999.)
         >>> rmg2.status_at_node
         array([4, 4, 4, 4, 4, 0, 0, 1, 4, 0, 0, 4, 4, 4, 4, 4], dtype=uint8)
+
+        The node data can also be provided as a model grid field.
+
+        >>> rmg = RasterModelGrid((4,4))
+        >>> node_data = np.array([-9999., -9999., -9999., -9999.,
+        ...                      -9999.,    67.,    67., -9999.,
+        ...                      -9999.,    67.,     0., -9999.,
+        ...                      -9999., -9999., -9999., -9999.])
+        >>> _ = rmg.add_field('node', 'topographic__elevation', node_data)
+        >>> out_id = rmg.set_watershed_boundary_condition('topographic__elevation',
+        ...                                               -9999.,
+        ...                                               True)
+        >>> out_id
+        array([10])
+        >>> rmg.status_at_node
+        array([4, 4, 4, 4, 4, 0, 0, 4, 4, 0, 1, 4, 4, 4, 4, 4], dtype=uint8)
 
         LLCATS: BC
         """
@@ -4229,18 +4246,16 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
 
         Parameters
         ----------
-        node_data : ndarray
-            Data values.
-
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         outlet_id : one element numpy array, optional.
             The node ID of the outlet that all open nodes must be connected to.
             If a node ID is provided, it does not need have the status
             FIXED_VALUE_BOUNDARY. However, it must not have the status of
             CLOSED_BOUNDARY.
-
         nodata_value : float, optional, default is -9999.
             Value that indicates an invalid value.
-
         adjacency_method : string, optional. Default is 'D8'.
             Sets the connection method.
 
@@ -4403,8 +4418,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         ----------
         outlet_coords : list - two integer values
             row, column of outlet, NOT THE ABSOLUTE X AND Y LOCATIONS
-        node_data : ndarray
-            Data values.
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         nodata_value : float, optional
             Value that indicates an invalid value.
 
@@ -4470,8 +4486,9 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         ----------
         outlet_id : integer
             id of the outlet node
-        node_data : ndarray
-            Data values.
+        node_data : field name or ndarray
+            At-node field name or at-node data values to use for identifying
+            watershed location.
         nodata_value : float, optional
             Value that indicates an invalid value.
 


### PR DESCRIPTION
Addresses #867 

@mcflugen I did this by adding a new method to `ModelDataFieldsMixIn`.

My thinking was that I want something like the `use_field_name_or_array` decorator that can work for model grids. 

I didn't want to make an `if isinstance(field, stringtypes` block in all six watershed methods (and then to test them all). 

Note, I did not use `np.array(field).flatten()` because that returns a copy of the array. 