### PR TITLE
Change all pytest.warns(DeprecationWarning) to pytest.deprecated_call():

### DIFF
--- a/landlab/grid/create.py
+++ b/landlab/grid/create.py
@@ -84,7 +84,7 @@ def create_and_initialize_grid(input_source):
     ... 2.5
     ... ''')
     >>> from landlab import create_and_initialize_grid
-    >>> with pytest.warns(DeprecationWarning):
+    >>> with pytest.deprecated_call():
     ...    grid = create_and_initialize_grid(test_file)
     >>> grid.number_of_nodes
     20

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -3050,10 +3050,10 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         >>> import pytest
         >>> from landlab import RasterModelGrid
         >>> mg = RasterModelGrid((4, 5))
-        >>> with pytest.warns(DeprecationWarning):
+        >>> with pytest.deprecated_call():
         ...     mg.face_connecting_cell_pair(0, 1)
         array([4])
-        >>> with pytest.warns(DeprecationWarning):
+        >>> with pytest.deprecated_call():
         ...     mg.face_connecting_cell_pair(0, 2).size  # empty array returned
         0
 
@@ -3304,7 +3304,7 @@ class RasterModelGrid(DiagonalsMixIn, ModelGrid, RasterModelGridPlotter):
         >>> z = np.array([0., 0., 0., 0.,
         ...               3., 3., 3., 3,
         ...               6., 6., 6., 6.])
-        >>> with pytest.warns(DeprecationWarning):
+        >>> with pytest.deprecated_call():
         ...     (slope, aspect) = (
         ...              grid.calculate_slope_aspect_at_nodes_burrough(vals=z))
         >>> np.tan(slope)

--- a/landlab/grid/tests/test_grid_reference.py
+++ b/landlab/grid/tests/test_grid_reference.py
@@ -121,7 +121,7 @@ def test_move_reference_radial(random_xy):
 
 
 def test_radial_deprecate_origin_x():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RadialModelGrid(num_shells=1, dr=1.0, origin_x=10)
     assert mg._xy_of_center == (10.0, 0.0)
     pts, npts = mg._create_radial_points(1, 1, xy_of_center=mg._xy_of_center)
@@ -130,7 +130,7 @@ def test_radial_deprecate_origin_x():
 
 
 def test_radial_deprecate_origin_y():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RadialModelGrid(num_shells=1, dr=1.0, origin_y=10)
     assert mg._xy_of_center == (0.0, 10.0)
     pts, npts = mg._create_radial_points(1, 1, xy_of_center=mg._xy_of_center)
@@ -149,7 +149,7 @@ def test_raster_with_negative_shape():
 
 
 def test_raise_deprecation_dx():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, dx=3)
     X, Y = np.meshgrid([0.0, 3.0, 6.0], [0.0, 3.0, 6.0])
     assert_array_equal(mg.x_of_node, X.flatten())
@@ -157,7 +157,7 @@ def test_raise_deprecation_dx():
 
 
 def test_raise_deprecation_dxdx():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, dx=(4, 5))
     X, Y = np.meshgrid([0.0, 5.0, 10.0], [0.0, 4.0, 8.0])
     assert_array_equal(mg.x_of_node, X.flatten())
@@ -165,7 +165,7 @@ def test_raise_deprecation_dxdx():
 
 
 def test_raise_deprecation_spacing():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, spacing=(4, 5))
     X, Y = np.meshgrid([0.0, 5.0, 10.0], [0.0, 4.0, 8.0])
     assert_array_equal(mg.x_of_node, X.flatten())
@@ -173,7 +173,7 @@ def test_raise_deprecation_spacing():
 
 
 def test_raise_deprecation_spacing_as_arg():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, 3)
     X, Y = np.meshgrid([0.0, 3.0, 6.0], [0.0, 3.0, 6.0])
     assert_array_equal(mg.x_of_node, X.flatten())
@@ -181,7 +181,7 @@ def test_raise_deprecation_spacing_as_arg():
 
 
 def test_raise_deprecation_spacing2_as_arg():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, (4, 5))
     X, Y = np.meshgrid([0.0, 5.0, 10.0], [0.0, 4.0, 8.0])
     assert_array_equal(mg.x_of_node, X.flatten())
@@ -199,7 +199,7 @@ def test_bad_type_xy_spacing():
 
 
 def test_deprecate_origin():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg = RasterModelGrid(3, 3, origin=(10, 13))
     X, Y = np.meshgrid([0.0, 1.0, 2.0], [0.0, 1.0, 2.0])
     assert_array_equal(mg.x_of_node, X.flatten() + 10.0)
@@ -212,7 +212,7 @@ def test_bad_origin():
 
 
 def test_curent_vs_past_origin():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg1 = RasterModelGrid(3, 3, origin=(10, 13))
     mg2 = RasterModelGrid(3, 3, xy_of_lower_left=(10, 13))
     assert_array_equal(mg1.x_of_node, mg2.x_of_node)
@@ -220,7 +220,7 @@ def test_curent_vs_past_origin():
 
 
 def test_curent_vs_past_spacing():
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         mg1 = RasterModelGrid(3, 3, spacing=(5, 4))
     mg2 = RasterModelGrid(3, 3, xy_spacing=(4, 5))
     assert_array_equal(mg1.x_of_node, mg2.x_of_node)

--- a/landlab/grid/tests/test_raster_funcs/test_gradients_at_links.py
+++ b/landlab/grid/tests/test_raster_funcs/test_gradients_at_links.py
@@ -49,7 +49,7 @@ def test_unit_spacing():
             dtype=float,
         ),
     )
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         diffs = grid.calculate_diff_at_links(values_at_nodes)
     assert_array_equal(grads, diffs)
 

--- a/landlab/grid/tests/test_raster_grid/test_init.py
+++ b/landlab/grid/tests/test_raster_grid/test_init.py
@@ -14,7 +14,7 @@ def test_init_with_kwds_classic():
     assert grid.dy == 1
     assert grid.dx == 1
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.deprecated_call():
         grid = RasterModelGrid(3, 7, 2)
 
     assert grid.number_of_node_rows == 3


### PR DESCRIPTION
This may help address #886 and https://github.com/conda-forge/landlab-feedstock/pull/5

@mcflugen I don't know why those tests did not issue DeprecationWarnings in the `Landlab-feedstock` PR.

I don't know that this will fix the issue for sure, but I do know that using `pytest.deprecated_call()` is generally the right choice. 

Passes locally.

Assuming this passes and can be merged into `landlab\master`, I think what we need to do is:

- [ ] Remove existing 1.7 tags
- [ ] Create a new release that includes this PR. 