### PR TITLE
Gt/hex grid args

### DIFF
--- a/examples/ca/cts_lattice_grain_silo.py
+++ b/examples/ca/cts_lattice_grain_silo.py
@@ -426,7 +426,7 @@ def main():
 
     # Create a grid
     hmg = HexModelGrid(
-        nr, nc, 1.0, orientation="vertical", shape="rect", reorient_links=True
+        nr, nc, 1.0, orientation="vertical", node_layout="rect", reorient_links=True
     )
 
     # Set up the states and pair transitions.

--- a/examples/grid/hex_grid_types.py
+++ b/examples/grid/hex_grid_types.py
@@ -17,7 +17,7 @@ from landlab import HexModelGrid
 # Case 1: Make and display a hex-shaped grid with horizontal rows of nodes
 
 # Create the grid
-hg1 = HexModelGrid(5, 3, 1.0, orientation="horizontal", shape="hex")
+hg1 = HexModelGrid(5, 3, 1.0, orientation="horizontal", node_layout="hex")
 
 # Make some data
 d = hg1.add_zeros("node", "mydata")
@@ -33,7 +33,7 @@ show()
 # Case 2: Make and display a hex-shaped grid with vertical columns of nodes
 
 # Create the grid
-hg2 = HexModelGrid(3, 5, 1.0, orientation="vertical", shape="hex")
+hg2 = HexModelGrid(3, 5, 1.0, orientation="vertical", node_layout="hex")
 
 # Make some data
 d = hg2.add_zeros("node", "mydata")
@@ -50,7 +50,7 @@ show()
 # of nodes
 
 # Create the grid
-hg3 = HexModelGrid(5, 5, 1.0, orientation="horizontal", shape="rect")
+hg3 = HexModelGrid(5, 5, 1.0, orientation="horizontal", node_layout="rect")
 
 # Make some data
 d = hg3.add_zeros("node", "mydata")
@@ -67,7 +67,7 @@ show()
 # nodes
 
 # Create the grid
-hg4 = HexModelGrid(5, 5, 1.0, orientation="vertical", shape="rect")
+hg4 = HexModelGrid(5, 5, 1.0, orientation="vertical", node_layout="rect")
 
 # Make some data
 d = hg4.add_zeros("node", "mydata")

--- a/landlab/ca/boundaries/hex_lattice_tectonicizer.py
+++ b/landlab/ca/boundaries/hex_lattice_tectonicizer.py
@@ -162,7 +162,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     >>> pid = np.arange(25, dtype=int)
     >>> pdata = np.arange(25)
     >>> ns = np.arange(25, dtype=int)
-    >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical', 
+    >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical',
     ...                     node_layout='rect')
     >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
     >>> lnf.first_fw_col
@@ -177,7 +177,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     >>> pid = np.arange(16, dtype=int)
     >>> ns = np.arange(16, dtype=int)
     >>> pdata = np.arange(16)
-    >>> grid = HexModelGrid(4, 4, 1.0, orientation='vertical', 
+    >>> grid = HexModelGrid(4, 4, 1.0, orientation='vertical',
     ...                     node_layout='rect')
     >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
     >>> lnf.num_fw_rows

--- a/landlab/ca/boundaries/hex_lattice_tectonicizer.py
+++ b/landlab/ca/boundaries/hex_lattice_tectonicizer.py
@@ -5,7 +5,7 @@
 hex_lattice_tectonicizer.py.
 
 Models discrete normal-fault offset on a 2D hex lattice with a rectangular
-shape and with one orientation of the nodes being vertical.
+node layout and with one orientation of the nodes being vertical.
 
 The intention here is to use a particle (LCA) model to represent the evolution
 of a 2D hillslope, with the hex_lattice_tectonicizer serving to shift the nodes
@@ -59,7 +59,8 @@ def is_perim_link(link, grid):
     --------
     >>> from landlab import HexModelGrid
     >>> import numpy as np
-    >>> mg = HexModelGrid(3, 4, 1.0, orientation='vertical', shape='rect')
+    >>> mg = HexModelGrid(3, 4, 1.0, orientation='vertical',
+    ...                   node_layout='rect')
     >>> is_perim_link(6, mg)
     True
     >>> is_perim_link(17, mg)
@@ -102,7 +103,7 @@ class HexLatticeTectonicizer(object):
         Examples
         --------
         >>> from landlab import HexModelGrid
-        >>> hg = HexModelGrid(6, 6, shape='rect')
+        >>> hg = HexModelGrid(6, 6, node_layout='rect')
         >>> hlt = HexLatticeTectonicizer()
         >>> hlt.grid.number_of_nodes
         25
@@ -120,7 +121,7 @@ class HexLatticeTectonicizer(object):
                 num_cols,
                 dx=1.0,
                 orientation="vertical",
-                shape="rect",
+                node_layout="rect",
                 reorient_links=True,
             )
         else:
@@ -151,7 +152,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     """Handles normal-fault displacement in CellLab-CTS models.
 
     Represents a 60 degree, left-dipping normal fault, and handles discrete
-    offsets for a hex grid that has vertical columns and a rectangular shape.
+    offsets for a hex grid with vertical columns and rectangular node_layout.
 
     Examples
     --------
@@ -161,8 +162,8 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     >>> pid = np.arange(25, dtype=int)
     >>> pdata = np.arange(25)
     >>> ns = np.arange(25, dtype=int)
-    >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical', shape='rect',
-    ...                     reorient_links=True)
+    >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical', 
+    ...                     node_layout='rect')
     >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
     >>> lnf.first_fw_col
     1
@@ -176,8 +177,8 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     >>> pid = np.arange(16, dtype=int)
     >>> ns = np.arange(16, dtype=int)
     >>> pdata = np.arange(16)
-    >>> grid = HexModelGrid(4, 4, 1.0, orientation='vertical', shape='rect',
-    ...                     reorient_links=True)
+    >>> grid = HexModelGrid(4, 4, 1.0, orientation='vertical', 
+    ...                     node_layout='rect')
     >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
     >>> lnf.num_fw_rows
     array([0, 1, 3, 4])
@@ -194,8 +195,8 @@ class LatticeNormalFault(HexLatticeTectonicizer):
     >>> pid = np.arange(20, dtype=int)
     >>> ns = np.arange(20, dtype=int)
     >>> pdata = np.arange(20)
-    >>> grid = HexModelGrid(4, 5, 1.0, orientation='vertical', shape='rect',
-    ...                     reorient_links=True)
+    >>> grid = HexModelGrid(4, 5, 1.0, orientation='vertical',
+    ...                     node_layout='rect')
     >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
     >>> lnf.incoming_node
     array([1, 3, 4, 6])
@@ -232,7 +233,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(25)
         >>> ns = np.arange(25, dtype=int)
         >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical',
-        ...                     shape='rect', reorient_links=True)
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(-0.01, grid, ns, pid, pdata, 0.0)
         >>> lnf.first_fw_col
         0
@@ -247,7 +248,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(16)
         >>> ns = np.arange(16, dtype=int)
         >>> grid = HexModelGrid(4, 4, 1.0, orientation='vertical',
-        ...                     shape='rect', reorient_links=True)
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
         >>> lnf.first_fw_col
         1
@@ -262,7 +263,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(45)
         >>> ns = np.arange(45, dtype=int)
         >>> grid = HexModelGrid(5, 9, 1.0, orientation='vertical',
-        ...                     shape='rect', reorient_links=True)
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
         >>> lnf.first_fw_col
         1
@@ -458,7 +459,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(25)
         >>> ns = np.arange(25, dtype=int)
         >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical',
-        ...                     shape='rect')
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(-0.01, grid, ns, pid, pdata, 0.0)
         >>> lnf.link_offset_id[16:24]
         array([37, 17, 18, 19, 40, 21, 22, 43])
@@ -471,7 +472,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(36)
         >>> ns = np.arange(36, dtype=int)
         >>> grid = HexModelGrid(6, 6, 1.0, orientation='vertical',
-        ...                     shape='rect')
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(-0.1, grid, ns, pid, pdata, 0.0)
         >>> lnf.first_link_shifted_from
         19
@@ -519,7 +520,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         Examples
         --------
         >>> from landlab import HexModelGrid
-        >>> hg = HexModelGrid(5, 5, orientation='vert', shape='rect')
+        >>> hg = HexModelGrid(5, 5, orientation='vert', node_layout='rect')
         >>> lu = LatticeNormalFault(fault_x_intercept=-0.01, grid=hg)
         >>> lu.first_link_shifted_to
         37
@@ -575,7 +576,8 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> from landlab.ca.celllab_cts import Transition
         >>> import numpy as np
 
-        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical', shape='rect')
+        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical',
+        ...                   node_layout='rect')
         >>> nsd = {0 : 'yes', 1 : 'no'}
         >>> xnlist = []
         >>> xnlist.append(Transition((0,0,0), (1,1,0), 1.0, 'test'))
@@ -620,7 +622,8 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> from landlab.ca.celllab_cts import Transition
         >>> import numpy as np
 
-        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical', shape='rect')
+        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical',
+        ...                   node_layout='rect')
         >>> nsd = {0 : 'yes', 1 : 'no'}
         >>> xnlist = []
         >>> xnlist.append(Transition((1,0,0), (1,1,0), 1.0, 'frogging'))
@@ -687,7 +690,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         >>> pdata = np.arange(25)
         >>> ns = np.arange(25, dtype=int)
         >>> grid = HexModelGrid(5, 5, 1.0, orientation='vertical',
-        ...                     shape='rect', reorient_links=True)
+        ...                     node_layout='rect')
         >>> lnf = LatticeNormalFault(0.0, grid, ns, pid, pdata, 0.0)
         >>> lnf.do_offset(rock_state=25)
         >>> ns
@@ -795,8 +798,8 @@ class LatticeUplifter(HexLatticeTectonicizer):
         >>> lu.inner_base_row_nodes
         array([1, 3, 4])
 
-        >>> hg = HexModelGrid(5, 6, 1.0, orientation='vertical', shape='rect',
-        ...                   reorient_links=True)
+        >>> hg = HexModelGrid(5, 6, 1.0, orientation='vertical',
+        ...                   node_layout='rect')
         >>> lu = LatticeUplifter(grid=hg)
         >>> lu.inner_base_row_nodes
         array([1, 2, 3, 4])
@@ -844,13 +847,13 @@ class LatticeUplifter(HexLatticeTectonicizer):
         Examples
         --------
         >>> from landlab import HexModelGrid
-        >>> hg = HexModelGrid(6, 6, orientation='vert', shape='rect')
+        >>> hg = HexModelGrid(6, 6, orientation='vert', node_layout='rect')
         >>> lu = LatticeUplifter(grid=hg)
         >>> lu.links_to_update
         array([ 8,  9, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 22, 24, 25, 26, 30,
                34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 72, 73, 74, 75, 76, 77, 79,
                80])
-        >>> hg = HexModelGrid(5, 5, orientation='vert', shape='rect')
+        >>> hg = HexModelGrid(5, 5, orientation='vert', node_layout='rect')
         >>> lu = LatticeUplifter(grid=hg)
         >>> lu.links_to_update
         array([ 7, 10, 11, 13, 14, 15, 16, 17, 18, 20, 22, 25, 28, 31, 35, 38, 41,
@@ -881,7 +884,8 @@ class LatticeUplifter(HexLatticeTectonicizer):
         >>> from landlab import HexModelGrid
         >>> from landlab.ca.hex_cts import HexCTS
         >>> from landlab.ca.celllab_cts import Transition
-        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical', shape='rect')
+        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical',
+        ...                   node_layout='rect')
         >>> nsd = {}  # node state dict
         >>> for i in range(10):
         ...     nsd[i] = i
@@ -1041,7 +1045,8 @@ class LatticeUplifter(HexLatticeTectonicizer):
         >>> from landlab import HexModelGrid
         >>> from landlab.ca.hex_cts import HexCTS
         >>> from landlab.ca.celllab_cts import Transition
-        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical', shape='rect')
+        >>> mg = HexModelGrid(5, 5, 1.0, orientation='vertical',
+        ...                   node_layout='rect')
         >>> nsd = {}
         >>> for i in range(26):
         ...     nsd[i] = i

--- a/landlab/ca/boundaries/tests/test_hex_normal_fault.py
+++ b/landlab/ca/boundaries/tests/test_hex_normal_fault.py
@@ -22,7 +22,7 @@ def test_links_to_update():
     """Test that update list includes lower 2 rows and fault-crossing links"""
 
     # Create a 6x6 test grid
-    hg = HexModelGrid(6, 6, shape="rect", orientation="vert")
+    hg = HexModelGrid(6, 6, node_layout="rect", orientation="vert")
 
     lnf = LatticeNormalFault(grid=hg, fault_x_intercept=-0.1)
 
@@ -77,7 +77,7 @@ def test_links_to_update():
 def test_shift_link_and_transition_data_upward():
     """Test the LatticeUplifter method that uplifts link data and tr'ns."""
 
-    mg = HexModelGrid(4, 3, 1.0, orientation="vertical", shape="rect")
+    mg = HexModelGrid(4, 3, 1.0, orientation="vertical", node_layout="rect")
     nsd = {0: "yes", 1: "no"}
     xnlist = []
     xnlist.append(Transition((0, 0, 0), (1, 1, 0), 1.0, "frogging"))

--- a/landlab/ca/tests/cts_model.py
+++ b/landlab/ca/tests/cts_model.py
@@ -22,7 +22,7 @@ class CTSModel(object):
         grid_size=(5, 5),
         report_interval=5.0,
         grid_orientation="vertical",
-        grid_shape="rect",
+        node_layout="rect",
         show_plots=False,
         cts_type="oriented_hex",
         run_duration=1.0,
@@ -35,7 +35,7 @@ class CTSModel(object):
             grid_size,
             report_interval,
             grid_orientation,
-            grid_shape,
+            node_layout,
             show_plots,
             cts_type,
             run_duration,
@@ -49,7 +49,7 @@ class CTSModel(object):
         grid_size=(5, 5),
         report_interval=5.0,
         grid_orientation="vertical",
-        grid_shape="rect",
+        node_layout="rect",
         show_plots=False,
         cts_type="oriented_hex",
         run_duration=1.0,
@@ -72,7 +72,7 @@ class CTSModel(object):
 
         # Create a grid
         self.create_grid_and_node_state_field(
-            grid_size[0], grid_size[1], grid_orientation, grid_shape, cts_type
+            grid_size[0], grid_size[1], grid_orientation, node_layout, cts_type
         )
 
         # Create the node-state dictionary
@@ -108,7 +108,7 @@ class CTSModel(object):
             self.initialize_plotting(**kwds)
 
     def create_grid_and_node_state_field(
-        self, num_rows, num_cols, grid_orientation, grid_shape, cts_type
+        self, num_rows, num_cols, grid_orientation, node_layout, cts_type
     ):
         """Create the grid and the field containing node states."""
 
@@ -124,7 +124,7 @@ class CTSModel(object):
                 num_cols,
                 xy_spacing=1.0,
                 orientation=grid_orientation,
-                shape=grid_shape,
+                node_layout=node_layout,
             )
 
         self.grid.add_zeros("node", "node_state", dtype=int)

--- a/landlab/ca/tests/grain_hill.py
+++ b/landlab/ca/tests/grain_hill.py
@@ -95,7 +95,7 @@ class GrainHill(CTSModel):
             grid_size=grid_size,
             report_interval=report_interval,
             grid_orientation="vertical",
-            grid_shape="rect",
+            node_layout="rect",
             show_plots=show_plots,
             cts_type="oriented_hex",
             run_duration=run_duration,
@@ -302,7 +302,7 @@ class GrainHill(CTSModel):
         Examples
         --------
         >>> from landlab import HexModelGrid
-        >>> hg = HexModelGrid(4, 5, shape='rect', orientation='vert')
+        >>> hg = HexModelGrid(4, 5, node_layout='rect', orientation='vert')
         >>> ns = hg.add_zeros('node', 'node_state', dtype=int)
         >>> ns[[0, 3, 1, 6, 4, 9, 2]] = 8
         >>> ns[[8, 13, 11, 16, 14]] = 7

--- a/landlab/components/discharge_diffuser/diffuse_by_discharge.py
+++ b/landlab/components/discharge_diffuser/diffuse_by_discharge.py
@@ -51,7 +51,7 @@ class DischargeDiffuser(Component):
     >>> from landlab import HexModelGrid
     >>> from landlab.components import PotentialityFlowRouter
     >>> import numpy as np
-    >>> mg = HexModelGrid(4, 6, dx=2., shape='rect', orientation='vertical')
+    >>> mg = HexModelGrid(4, 6, dx=2., node_layout='rect', orientation='vertical')
     >>> z = mg.add_zeros('node', 'topographic__elevation')
     >>> Q_in = mg.add_ones('node', 'water__unit_flux_in')
     >>> z += mg.node_y.copy()

--- a/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
+++ b/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
@@ -59,7 +59,7 @@ class PotentialityFlowRouter(Component):
     --------
     >>> from landlab import HexModelGrid
     >>> import numpy as np
-    >>> mg = HexModelGrid(4, 6, dx=2., shape='rect', orientation='vertical')
+    >>> mg = HexModelGrid(4, 6, dx=2., node_layout='rect', orientation='vertical')
     >>> z = mg.add_zeros('node', 'topographic__elevation')
     >>> Q_in = mg.add_ones('node', 'water__unit_flux_in')
     >>> z += mg.node_y.copy()

--- a/landlab/components/potentiality_flowrouting/route_flow_by_boundary_1st.py
+++ b/landlab/components/potentiality_flowrouting/route_flow_by_boundary_1st.py
@@ -66,7 +66,7 @@ class PotentialityFlowRouter(Component):
     --------
     >>> from landlab import HexModelGrid
     >>> import numpy as np
-    >>> mg = HexModelGrid(4, 6, dx=2., shape='rect', orientation='vertical')
+    >>> mg = HexModelGrid(4, 6, dx=2., node_layout='rect', orientation='vertical')
     >>> z = mg.add_zeros('node', 'topographic__elevation')
     >>> Q_in = mg.add_ones('node', 'water__unit_flux_in')
     >>> z += mg.node_y.copy()

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -42,9 +42,11 @@ class HexModelGrid(VoronoiDelaunayGrid):
     orientation : string, optional
         One of the 3 cardinal directions in the grid, either 'horizontal'
         (default) or 'vertical'
-    shape : string, optional
+    node_layout : string, optional
         Controls the shape of the bounding hull, i.e., are the nodes arranged
         in a hexagon, or a rectangle? Either 'hex' (default) or 'rect'.
+    shape : tuple of 2 int
+        Alternative way to specify (base_num_rows, base_num_cols)
 
     Returns
     -------
@@ -57,7 +59,7 @@ class HexModelGrid(VoronoiDelaunayGrid):
     have 2 nodes, and the second nodes.
 
     >>> from landlab import HexModelGrid
-    >>> hmg = HexModelGrid(3, 2, 1.0)
+    >>> hmg = HexModelGrid(shape=(3, 2), dx=1.0)
     >>> hmg.number_of_nodes
     7
     """
@@ -250,8 +252,9 @@ class HexModelGrid(VoronoiDelaunayGrid):
         # (note: in LL2.0, shape should refer ONLY to rows and columns)
         if type(shape) is str:  # "old" (LL < 2.0) usage
             node_layout = shape
-            warn(message="Use node_layout to specify 'rect' or 'hex' layout",
-                 category=DeprecationWarning)
+            message = ("Use node_layout to specify 'rect' or 'hex' layout "
+                       + "(usage will be enforced in Landlab 2.0+).")
+            warn(message=message, category=DeprecationWarning)
         elif type(shape) is tuple:
             (base_num_rows, base_num_cols) = shape
 

--- a/landlab/grid/tests/test_grid_reference.py
+++ b/landlab/grid/tests/test_grid_reference.py
@@ -56,7 +56,7 @@ def test_hex_lower_left_as_iterables(random_xy, to_iterable):
         5,
         xy_of_lower_left=to_iterable(random_xy),
         orientation="horizontal",
-        shape="rect",
+        node_layout="rect",
     )
     assert isinstance(grid.xy_of_lower_left, tuple)
     assert grid.xy_of_lower_left == expected
@@ -72,17 +72,17 @@ def test_radial_center_as_iterables(random_xy, to_iterable):
 
 
 @pytest.mark.parametrize("orientation", ["horizontal", "vertical"])
-@pytest.mark.parametrize("shape", ["rect"])
+@pytest.mark.parametrize("node_layout", ["rect"])
 @pytest.mark.parametrize("n_cols", [12, 11, 10, 9])
 @pytest.mark.parametrize("n_rows", [12, 11, 10, 9])
-def test_move_reference_hex(random_xy, n_rows, n_cols, shape, orientation):
+def test_move_reference_hex(random_xy, n_rows, n_cols, node_layout, orientation):
     mg = HexModelGrid(
         n_rows,
         n_cols,
         dx=2.0,
         xy_of_lower_left=random_xy,
         orientation=orientation,
-        shape=shape,
+        node_layout=node_layout,
     )
 
     assert mg.xy_of_lower_left == random_xy

--- a/landlab/grid/tests/test_hex_grid/test_shape_dep_warning.py
+++ b/landlab/grid/tests/test_hex_grid/test_shape_dep_warning.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Nov 14 10:36:03 2015
+
+@author: gtucker
+"""
+import warnings
+from landlab import HexModelGrid
+
+
+def test_shape_dep_warning():
+    """Test dep warning on use of shape keyword instead of node_layout."""
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Trigger the deprecation warning.
+        HexModelGrid(3, 2, shape='rect')
+        # Verify some things
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "node_layout" in str(w[-1].message)


### PR DESCRIPTION
This PR adds a keyword argument "node_layout" to HexModelGrid. This new keyword replaces "shape", which can now be repurposed as a 2-element tuple with (rows, cols), consistent with RasterModelGrid and Numpy usage. This change implements the following behavior that maintains backward compatibility as follows:

1) If user sends shape as a str ('rect' or 'hex'), it is interpreted as node_layout, and a deprecation warning is given.
2) If user sends shape as a type, it is interpreted as (base_num_rows, base_num_cols) (and overrides the corresponding positional arguments.

Note that this PR does NOT handle the case of a user sending a tuple as the first positional argument. In other words, if they want to pass tuple, they have to use the (now modified) shape keyword.

This PR addresses most of issue #864 
