### PR TITLE
Add boundary conditions to BMI

### DIFF
--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -256,15 +256,9 @@ def wrap_as_bmi(cls):
             self._input_var_names = tuple(
                 set(self._cls._input_var_names) | {"boundary_condition_flag"}
             )
-            # self._cls._input_var_names = tuple(
-            #     set(self._cls._input_var_names) | {"boundary_condition_flag"}
-            # )
             self._output_var_names = tuple(
                 set(self._cls._output_var_names) | {"boundary_condition_flag"}
             )
-            # self._cls._output_var_names = tuple(
-            #     set(self._cls._output_var_names) | {"boundary_condition_flag"}
-            # )
             self._var_mapping = self._cls._var_mapping.copy()
             self._var_units = self._cls._var_units.copy()
             self._var_doc = self._cls._var_doc.copy()
@@ -272,9 +266,6 @@ def wrap_as_bmi(cls):
             self._var_mapping["boundary_condition_flag"] = "node"
             self._var_units["boundary_condition_flag"] = ""
             self._var_doc["boundary_condition_flag"] = "boundary condition flag of grid nodes"
-            # self._cls._var_mapping["boundary_condition_flag"] = "node"
-            # self._cls._var_units["boundary_condition_flag"] = ""
-            # self._cls._var_doc["boundary_condition_flag"] = "boundary condition flag of grid nodes"
 
         def get_component_name(self):
             """Name of the component."""
@@ -408,7 +399,7 @@ def wrap_as_bmi(cls):
 
         def get_var_units(self, name):
             """Get the unit used by a variable."""
-            return self._cls.var_units(name)
+            return self._var_units[name]
 
         def get_value_ref(self, name):
             """Get a reference to a variable's data."""

--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -77,10 +77,11 @@ class TimeStepper(object):
     [1.0, 3.0, 5.0, 7.0, 9.0, 11.0]
     """
 
-    def __init__(self, start=0.0, stop=None, step=1.0):
+    def __init__(self, start=0.0, stop=None, step=1.0, units="s"):
         self._start = start
         self._stop = stop
         self._step = step
+        self._units = units
 
         self._time = start
 
@@ -119,6 +120,11 @@ class TimeStepper(object):
     def step(self, new_val):
         """Change the time step."""
         self._step = new_val
+
+    @property
+    def units(self):
+        """Time units."""
+        return self._units
 
     def advance(self):
         """Advance the time stepper by one time step."""
@@ -285,7 +291,7 @@ def wrap_as_bmi(cls):
 
         def get_time_units(self):
             """Time units used by the component."""
-            return "s"
+            return self._clock.units
 
         def initialize(self, config_file):
             """Initialize the component from a file.

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -633,7 +633,7 @@ class FlowAccumulator(Component):
         "drainage_area",
         "surface_water__discharge",
         "flow__upstream_node_order",
-        "flow__nodes_not_in_stack",
+        # "flow__nodes_not_in_stack",
         "flow__data_structure_delta",
         "flow__data_structure_D",
     )
@@ -647,7 +647,7 @@ class FlowAccumulator(Component):
         "flow__upstream_node_order": "-",
         "flow__data_structure_delta": "-",
         "flow__data_structure_D": "-",
-        "flow__nodes_not_in_stack": "-",
+        # "flow__nodes_not_in_stack": "-",
     }
 
     _var_mapping = {
@@ -657,7 +657,7 @@ class FlowAccumulator(Component):
         "drainage_area": "node",
         "surface_water__discharge": "node",
         "flow__upstream_node_order": "node",
-        "flow__nodes_not_in_stack": "grid",
+        # "flow__nodes_not_in_stack": "grid",
         "flow__data_structure_delta": "node",
         "flow__data_structure_D": "grid",
     }
@@ -677,8 +677,8 @@ class FlowAccumulator(Component):
         "upstream node array",
         "flow__data_structure_D": "Array containing the data structure D used for construction"
         "of the downstream-to-upstream node array. Stored at Grid.",
-        "flow__nodes_not_in_stack": "Boolean value indicating if there are any nodes that have not yet"
-        "been added to the stack stored in flow__upstream_node_order.",
+        # "flow__nodes_not_in_stack": "Boolean value indicating if there are any nodes that have not yet"
+        # "been added to the stack stored in flow__upstream_node_order.",
     }
 
     def __init__(

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "netcdf4",
         "pyyaml",
         "pyshp",
-        "scipy",
+        "scipy<1.3",
         "six",
         "statsmodels",
         "xarray",


### PR DESCRIPTION
This pull request adds boundary conditions (*status_at_node*) to the BMI wrapping of landlab components. When a landlab component is wrapped to expose a BMI, a new input/output var is added to the BMI component called "boundary_condition_flag", which is an interface to the landlab component's *status_at_node* field. Since BMI doesn't have any special way of representing boundary conditions, it must be done through BMI variables.

@kbarnhart , I made one other small change. In wrapping the *FlowAccumulator*, I noticed that the *flow__nodes_not_in_stack* field was never used. Because the field was never created, this caused problems for the wrapping. Anyway, I removed it from the class metadata (*_output_var_names* etc.). What do you think?