### PR TITLE
Fix BMI for corner_x/y of dual graphs

### DIFF
--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -350,9 +350,12 @@ def wrap_as_bmi(cls):
             if hasattr(self._base, "update"):
                 self._base.update()
             elif hasattr(self._base, "run_one_step"):
-                nargs = len(inspect.signature(self._base.run_one_step).parameters)
+                args = []
+                for name, arg in inspect.signature(self._base.run_one_step).parameters.items():
+                    if arg.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD:
+                        args.append(name)
 
-                if nargs == 0:
+                if len(args) == 0 or "dt" not in args:
                     self._base.run_one_step()
                 else:
                     self._base.run_one_step(self._clock.step)
@@ -428,7 +431,10 @@ def wrap_as_bmi(cls):
             if grid == 0:
                 origin[:] = (self._base.grid.node_y[0], self._base.grid.node_x[0])
             elif grid == 1:
-                origin[:] = (self._base.grid.corner_y[0], self._base.grid.corner_x[0])
+                origin[:] = (
+                    self._base.grid.node_y[0] + self._base.grid.dy * .5,
+                    self._base.grid.node_x[0] + self._base.grid.dx * .5,
+                )
             return origin
 
         def get_grid_rank(self, grid):


### PR DESCRIPTION
This pull request fixes an error in wrapping landlab components that use *corners*. That is, any component that has fields defined at *corners*, *faces*, or *cells*. Unfortunately, *landlab* grids don't have a *corner_x* (or *x_of_corner*) attribute so the BMI wrapping process fails when trying to get, for example, the grid origin for the dual graph. To fix this, I just use `node_x[0] + 0.5 * dx` for the origin. This is definitely not an ideal fix but it will have to do until, probably, landlab 2.0.

There is another small fix that solves a problem when trying to figure out what "update" method to call on a BMI-wrapped component (i.e. *update()* vs. *run_one_step()* vs. *run_one_step(dt)*). This is also not an ideal fix but will also have to do until landlab 2.0, me thinks.

@kbarnhart If you could give this a review, I would be grateful!