### PR TITLE
add return_array_at_link

### DIFF
--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -15,7 +15,6 @@ exposes a Basic Modelling Interface.
 import inspect
 
 import numpy as np
-
 from bmipy import Bmi
 
 from ..core import load_params

--- a/landlab/ca/hex_cts.py
+++ b/landlab/ca/hex_cts.py
@@ -60,7 +60,7 @@ class HexCTS(CellLabCTSModel):
         initial_node_states,
         prop_data=None,
         prop_reset_value=None,
-        seed=0
+        seed=0,
     ):
         """
         HexCTS constructor: sets number of orientations to 1 and calls
@@ -103,5 +103,5 @@ class HexCTS(CellLabCTSModel):
             initial_node_states,
             prop_data,
             prop_reset_value,
-            seed
+            seed,
         )

--- a/landlab/ca/tests/test_celllab_cts.py
+++ b/landlab/ca/tests/test_celllab_cts.py
@@ -127,10 +127,7 @@ def test_raster_cts():
     nsg[6] = 0
     pd = mg.add_zeros("node", "property_data", dtype=int)
     pd[5] = 50
-    ca = RasterCTS(
-        mg, ns_dict, xn_list, nsg, prop_data=pd,
-        prop_reset_value=0, seed=1
-    )
+    ca = RasterCTS(mg, ns_dict, xn_list, nsg, prop_data=pd, prop_reset_value=0, seed=1)
     prior_first_event_time = event_time
     (event_time, index, event_link) = ca.priority_queue.pop()
     assert event_time != prior_first_event_time, "event times should differ"

--- a/landlab/components/fracture_grid/fracture_grid.py
+++ b/landlab/components/fracture_grid/fracture_grid.py
@@ -9,6 +9,7 @@ Last significant modification: conversion to proper component 7/2019 GT
 """
 
 import numpy as np
+
 from landlab import Component
 
 
@@ -182,21 +183,13 @@ class FractureGridGenerator(Component):
 
     _input_var_names = ()
 
-    _output_var_names = (
-        "fracture_at_node",
-    )
+    _output_var_names = ("fracture_at_node",)
 
-    _var_units = {
-        "fracture_at_node": "-",
-    }
+    _var_units = {"fracture_at_node": "-"}
 
-    _var_mapping = {
-        "fracture_at_node": "node",
-    }
+    _var_mapping = {"fracture_at_node": "node"}
 
-    _var_doc = {
-        "fracture_at_node": "presence (1) or absence (0) of fracture",
-    }
+    _var_doc = {"fracture_at_node": "presence (1) or absence (0) of fracture"}
 
     def __init__(self, grid, frac_spacing=10.0, seed=0):
         """Initialize the FractureGridGenerator."""
@@ -209,7 +202,7 @@ class FractureGridGenerator(Component):
         # TODO: delete this once we have generation of output fields in
         # base class
         if "fracture_at_node" not in grid.at_node:
-            grid.add_zeros('node', 'fracture_at_node', dtype=np.int8)
+            grid.add_zeros("node", "fracture_at_node", dtype=np.int8)
 
     def run_one_step(self):
         """Run FractureGridGenerator and create a random fracture grid."""

--- a/landlab/components/fracture_grid/tests/test_fracture_grid.py
+++ b/landlab/components/fracture_grid/tests/test_fracture_grid.py
@@ -24,7 +24,7 @@ def test_frac_grid():
     fg.run_one_step()
 
     assert_array_equal(
-        grid.at_node['fracture_at_node'].reshape((9, 9)),
+        grid.at_node["fracture_at_node"].reshape((9, 9)),
         [
             [1, 0, 0, 0, 0, 0, 1, 1, 0],
             [0, 0, 0, 0, 1, 1, 0, 0, 0],

--- a/landlab/utils/__init__.py
+++ b/landlab/utils/__init__.py
@@ -5,6 +5,7 @@ from .add_halo import add_halo
 # import landlab.utils.count_repeats
 # from landlab.utils.count_repeats import count_repeats
 from .count_repeats import count_repeated_values
+from .return_array import return_array_at_link, return_array_at_node
 from .source_tracking_algorithm import (
     convert_arc_flow_directions_to_landlab_node_ids,
     find_unique_upstream_hsd_ids_and_fractions,
@@ -18,7 +19,6 @@ from .watershed import (
     get_watershed_nodes,
     get_watershed_outlet,
 )
-from .return_array import return_array_at_node, return_array_at_link
 
 __all__ = [
     "add_halo",

--- a/landlab/utils/__init__.py
+++ b/landlab/utils/__init__.py
@@ -18,6 +18,7 @@ from .watershed import (
     get_watershed_nodes,
     get_watershed_outlet,
 )
+from .return_array import return_array_at_node, return_array_at_link
 
 __all__ = [
     "add_halo",

--- a/landlab/utils/__init__.py
+++ b/landlab/utils/__init__.py
@@ -32,4 +32,6 @@ __all__ = [
     "get_watershed_outlet",
     "get_watershed_masks",
     "StablePriorityQueue",
+    "return_array_at_node",
+    "return_array_at_link",
 ]

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -305,7 +305,10 @@ class use_field_name_or_array(object):
         def _wrapped(grid, vals, *args, **kwds):
             """Convert the second argument to an array."""
             if isinstance(vals, six.string_types):
-                vals = grid[self._at][vals]
+                if vals in grid[self._at]:
+                    vals = grid[self._at][vals]
+                else:
+                    raise FieldError(vals)                    
             else:
                 vals = np.asarray(vals).flatten()
 

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -308,7 +308,7 @@ class use_field_name_or_array(object):
                 if vals in grid[self._at]:
                     vals = grid[self._at][vals]
                 else:
-                    raise FieldError(vals)                    
+                    raise FieldError(vals)
             else:
                 vals = np.asarray(vals).flatten()
 

--- a/landlab/utils/return_array.py
+++ b/landlab/utils/return_array.py
@@ -20,3 +20,22 @@ def return_array_at_node(grid, value):
     array : ndarray of shape `(n_nodes, )`
     """
     return value
+
+
+@use_field_name_array_or_value("link")
+def return_array_at_link(grid, value):
+    """Function to return an array stored at node or of shape `(n_nodes,)`.
+
+    This function exists to take advantange of the use_field_name_array_or_value
+    decorator which permits providing the surface as a field name or array.
+
+    Parameters
+    ----------
+    grid : ModelGrid
+    value : field name, ndarray of shape `(n_nodes, )`, or single value.
+
+    Returns
+    -------
+    array : ndarray of shape `(n_nodes, )`
+    """
+    return value

--- a/landlab/utils/tests/test_return_grid.py
+++ b/landlab/utils/tests/test_return_grid.py
@@ -16,6 +16,11 @@ def test_no_field():
 def test_return_array():
     mg = RasterModelGrid((10, 10))
     node_vals = np.arange(mg.number_of_nodes)
-    return_array_at_node(mg, node_vals)
+    out = return_array_at_node(mg, node_vals)
+
+    np.testing.assert_array_equal(np.arange(mg.number_of_nodes), out)
+
     link_vals = np.arange(mg.number_of_links)
-    return_array_at_link(mg, link_vals)
+    out = return_array_at_link(mg, link_vals)
+
+    np.testing.assert_array_equal(np.arange(mg.number_of_links), out)

--- a/landlab/utils/tests/test_return_grid.py
+++ b/landlab/utils/tests/test_return_grid.py
@@ -1,9 +1,8 @@
+import numpy as np
 import pytest
 
-import numpy as np
 from landlab import FieldError, RasterModelGrid
-from landlab.utils.return_array import (return_array_at_node,
-                                        return_array_at_link)
+from landlab.utils.return_array import return_array_at_link, return_array_at_node
 
 
 def test_no_field():
@@ -12,6 +11,7 @@ def test_no_field():
         return_array_at_node(mg, "spam")
     with pytest.raises(FieldError):
         return_array_at_link(mg, "spam")
+
 
 def test_return_array():
     mg = RasterModelGrid((10, 10))

--- a/landlab/utils/tests/test_return_grid.py
+++ b/landlab/utils/tests/test_return_grid.py
@@ -1,10 +1,21 @@
 import pytest
 
+import numpy as np
 from landlab import FieldError, RasterModelGrid
-from landlab.utils.return_array import return_array_at_node
+from landlab.utils.return_array import (return_array_at_node,
+                                        return_array_at_link)
 
 
 def test_no_field():
     mg = RasterModelGrid((10, 10))
     with pytest.raises(FieldError):
         return_array_at_node(mg, "spam")
+    with pytest.raises(FieldError):
+        return_array_at_link(mg, "spam")
+
+def test_return_array():
+    mg = RasterModelGrid((10, 10))
+    node_vals = np.arange(mg.number_of_nodes)
+    return_array_at_node(mg, node_vals)
+    link_vals = np.arange(mg.number_of_links)
+    return_array_at_link(mg, link_vals)


### PR DESCRIPTION
Add a return_array_at_link function, as a complement to the existing return_array_at_node. Also put both in __init__ so they're visible to landlab.utils, and catch an exception in one of the decorators.