### PR TITLE
Barnhark/fix909 datarecord

### DIFF
--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -240,7 +240,7 @@ class DataRecord(object):
 
             # check that grid_element and element_id exist on the grid and
             # have valid format:
-            _grid_elements = self._check_grid_element_and_id(
+            _grid_elements, _element_ids = self._check_grid_element_and_id(
                 _grid_elements, _element_ids
             )
 
@@ -356,7 +356,7 @@ class DataRecord(object):
                         " for this grid type"
                     )
 
-        return grid_element
+        return grid_element, element_id
 
     def _check_element_id_values(self, grid_element, element_id):
         """Check that element_id values are valid."""
@@ -697,7 +697,7 @@ class DataRecord(object):
                 }
                 # check that grid_element and element_id exist
                 # on the grid and have valid format
-                _grid_elements = self._check_grid_element_and_id(
+                _grid_elements, _element_ids = self._check_grid_element_and_id(
                     _grid_elements, _element_ids
                 )
 

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -1017,13 +1017,14 @@ class DataRecord(object):
         >>> from landlab.data_record import DataRecord
         >>> from landlab import RasterModelGrid
         >>> grid = RasterModelGrid((3,3))
-        >>> element_id = [0, 0, 0, 0, 1, 2, 3, 4, 5]
-        >>> volumes = [4, 5, 1, 2, 3, 4, 5, 6, 7]
-        >>> ages = [10, 11, 12, 13, 14, 15, 16, 8, 10]
+        >>> element_id = [0, 0, 0, 0, 1, 2, 3, 4, 5, 9999]
+        >>> volumes = [4, 5, 1, 2, 3, 4, 5, 6, 7, 1234]
+        >>> ages = [10, 11, 12, 13, 14, 15, 16, 8, 10, 3456]
         >>> grid_element = 'node'
         >>> data = {'ages': ages,
         ...         'volumes': volumes}
         >>> dr = DataRecord(grid,
+        ...                 dummy_elements={"node": [9999]},
         ...                 items={'grid_element' : 'node',
         ...                           'element_id' : np.array(element_id)},
         ...                 data_vars={'ages' : (['item_id'], np.array(ages)),

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -1063,32 +1063,22 @@ class DataRecord(object):
 
         """
 
-        #    (From ItemCollection:)
-        #        To add to Example, when I can make it work:
-        #        You can even pass functions that require additional positional
-        #        arguments or keyword arguments. For example, in order to get the 25th
-        #        percentile, we we do the following.
-        #
-        #        >>> s = ic.calc_aggregate_value(np.percentile, 'ages', q=25)
-        #        >>> print(s)
-        #        [ 10.75  14.    15.    16.     8.    10.      nan    nan    nan]
-
         filter_at = self.dataset["grid_element"] == at
 
+        valid = np.arange(self._grid[at].size)
+
+        filter_valid_element = np.isin(self.dataset["element_id"], valid)
+
         if filter_array is None:
-            my_filter = filter_at
+            my_filter = filter_at & filter_valid_element
         else:
-            my_filter = filter_at & filter_array
+            my_filter = filter_at & filter_array & filter_valid_element
 
         # Filter DataRecord with my_filter and groupby element_id:
         filtered = self.dataset.where(my_filter).groupby("element_id")
 
         vals = filtered.apply(func, *args, **kwargs)  # .reduce
-        #        vals = xr.apply_ufunc(func,
-        #                            filtered,
-        #                            #input_core_dims=[['item_id']],
-        #                            **kwargs)
-
+ 
         # create a nan array that we will fill with the results of the sum
         # this should be the size of the number of elements, even if there are
         # no items living at some grid elements.

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -315,7 +315,7 @@ class DataRecord(object):
             data_vars=data_vars_dict, coords=coords, attrs=attrs, compat=compat
         )
 
-    def _check_grid_element_and_id(self, grid_element, element_id, flag=None):
+    def _check_grid_element_and_id(self, grid_element, element_id):
         """Check the location and size of grid_element and element_id."""
         if isinstance(grid_element, string_types):
             # all items are on same type of grid_element
@@ -509,8 +509,8 @@ class DataRecord(object):
                             )
                         # check that grid_element and element_id exist
                         # on the grid and have valid format:
-                        new_grid_element = self._check_grid_element_and_id(
-                            new_grid_element, new_element_id, flag=1
+                        new_grid_element, new_element_id = self._check_grid_element_and_id(
+                            new_grid_element, new_element_id
                         )
 
                         # check that element IDs do not exceed number
@@ -932,7 +932,7 @@ class DataRecord(object):
                 assoc_element_id = new_value
                 assoc_grid_element = self.get_data(time, item_id, "grid_element")[0]
             self._check_grid_element_and_id(
-                assoc_grid_element, assoc_element_id, flag=1
+                assoc_grid_element, assoc_element_id
             )
             if assoc_element_id >= self._grid[assoc_grid_element].size:
                 raise ValueError(

--- a/landlab/data_record/tests/test_data_record_2dim.py
+++ b/landlab/data_record/tests/test_data_record_2dim.py
@@ -39,10 +39,10 @@ def test_permitted_locations(dr_2dim):
 
 
 def test_coordinates(dr_2dim):
-    assert len(dr_2dim.dims) == 2
-    assert list(dr_2dim.time.values) == time
+    assert len(dr_2dim.dataset.dims) == 2
+    assert list(dr_2dim.dataset.time.values) == time
     assert list(dr_2dim.time_coordinates) == time
-    assert list(dr_2dim.item_id.values) == [0, 1]
+    assert list(dr_2dim.dataset.item_id.values) == [0, 1]
     assert list(dr_2dim.item_coordinates) == [0, 1]
     # properties:
     assert dr_2dim.number_of_timesteps == 1
@@ -73,16 +73,16 @@ def test_add_record(dr_2dim):
         time=[20.0], new_record={"mean_elevation": (["time"], np.array([130.0]))}
     )
     assert (
-        dr_2dim["grid_element"].values[1, 1],
-        dr_2dim["mean_elevation"].values[2],
+        dr_2dim.dataset["grid_element"].values[1, 1],
+        dr_2dim.dataset["mean_elevation"].values[2],
     ) == ("cell", 130.0)
-    assert np.isnan(dr_2dim["element_id"].values[1, 2])
+    assert np.isnan(dr_2dim.dataset["element_id"].values[1, 2])
     dr_2dim.add_record(
         time=[10.0],
         item_id=[1],
         new_record={"size": (["item_id", "time"], np.array([[0.3]]))},
     )
-    assert np.isnan(dr_2dim["size"].values[0, 0])
+    assert np.isnan(dr_2dim.dataset["size"].values[0, 0])
 
 
 def test_add_item(dr_2dim):
@@ -95,9 +95,9 @@ def test_add_item(dr_2dim):
         new_item_spec={"size": (["item_id"], [10, 5])},
     )
     assert (
-        dr_2dim["grid_element"].values[3, 1],
-        dr_2dim["element_id"].values[2, 1],
-        dr_2dim["size"].values[3],
+        dr_2dim.dataset["grid_element"].values[3, 1],
+        dr_2dim.dataset["element_id"].values[2, 1],
+        dr_2dim.dataset["size"].values[3],
     ) == ("cell", 2.0, 5.0)
 
 
@@ -114,8 +114,8 @@ def test_set_data(dr_2dim):
         time=[0.0], item_id=[1], data_variable="grid_element", new_value="node"
     )
     dr_2dim.set_data(time=[0.0], data_variable="mean_elevation", new_value=150.0)
-    assert all(dr_2dim["grid_element"].values == "node")
-    assert dr_2dim["mean_elevation"].values[0] == 150.0
+    assert all(dr_2dim.dataset["grid_element"].values == "node")
+    assert dr_2dim.dataset["mean_elevation"].values[0] == 150.0
 
 
 def test_ffill_grid_element_and_id(dr_2dim):
@@ -123,7 +123,9 @@ def test_ffill_grid_element_and_id(dr_2dim):
         time=[20.0], new_record={"mean_elevation": (["time"], np.array([130.0]))}
     )
     dr_2dim.ffill_grid_element_and_id()
-    assert dr_2dim["grid_element"].values[0, 0] == (
-        dr_2dim["grid_element"].values[0, 1]
+    assert dr_2dim.dataset["grid_element"].values[0, 0] == (
+        dr_2dim.dataset["grid_element"].values[0, 1]
     )
-    assert dr_2dim["element_id"].values[0, 0] == (dr_2dim["element_id"].values[0, 1])
+    assert dr_2dim.dataset["element_id"].values[0, 0] == (
+        dr_2dim.dataset["element_id"].values[0, 1]
+    )

--- a/landlab/data_record/tests/test_data_record_item.py
+++ b/landlab/data_record/tests/test_data_record_item.py
@@ -34,8 +34,8 @@ def test_permitted_locations(dr_item):
 
 
 def test_coordinates(dr_item):
-    assert len(dr_item.dims) == 1
-    assert list(dr_item.item_id.values) == [0, 1]
+    assert len(dr_item.dataset.dims) == 1
+    assert list(dr_item.dataset.item_id.values) == [0, 1]
     assert list(dr_item.item_coordinates) == [0, 1]
     assert dr_item.number_of_items == len(my_items2["element_id"])
     with pytest.raises(AttributeError):
@@ -65,9 +65,9 @@ def test_add_item(dr_item):
         new_item_spec={"size": (["item_id"], [10, 5])},
     )
     assert (
-        dr_item["grid_element"].values[3],
-        dr_item["element_id"].values[3],
-        dr_item["size"].values[3],
+        dr_item.dataset["grid_element"].values[3],
+        dr_item.dataset["element_id"].values[3],
+        dr_item.dataset["size"].values[3],
     ) == ("node", 4.0, 5.0)
 
 
@@ -78,4 +78,4 @@ def test_get_data(dr_item):
 
 def test_set_data(dr_item):
     dr_item.set_data(item_id=[1], data_variable="element_id", new_value=2)
-    assert dr_item["element_id"].values[1] == 2
+    assert dr_item.dataset["element_id"].values[1] == 2

--- a/landlab/data_record/tests/test_data_record_time.py
+++ b/landlab/data_record/tests/test_data_record_time.py
@@ -33,8 +33,8 @@ def test_permitted_locations(dr_time):
 
 
 def test_coordinates(dr_time):
-    assert len(dr_time.dims) == 1
-    assert list(dr_time.time.values) == list(np.array(time))
+    assert len(dr_time.dataset.dims) == 1
+    assert list(dr_time.dataset.time.values) == list(np.array(time))
     assert list(dr_time.time_coordinates) == list(np.array(time))
     # properties:
     assert dr_time.number_of_timesteps == 1
@@ -61,7 +61,7 @@ def test_add_record(dr_time):
     dr_time.add_record(
         time=[100.0], new_record={"new_variable": (["time"], ["new_data"])}
     )
-    assert np.isnan(dr_time["mean_elevation"].values[2])
+    assert np.isnan(dr_time.dataset["mean_elevation"].values[2])
 
 
 def test_get_data(dr_time):
@@ -71,4 +71,4 @@ def test_get_data(dr_time):
 
 def test_set_data(dr_time):
     dr_time.set_data(time=[0.0], data_variable="mean_elevation", new_value=105.0)
-    assert dr_time["mean_elevation"].values[0] == 105.0
+    assert dr_time.dataset["mean_elevation"].values[0] == 105.0

--- a/landlab/data_record/tests/test_dummy.py
+++ b/landlab/data_record/tests/test_dummy.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from landlab import RasterModelGrid
+from landlab.data_record import DataRecord
+
+
+def test_ok_dummy():
+    grid = RasterModelGrid((3, 3))
+    element_id = [0, 0, 0, -9999, 1, 2, 3, 4, 5]
+    volumes = [4, 5, 1, 2, 3, 4, 5, 6, 7]
+    grid_element = "node"
+    data = {"volumes": volumes}
+    dr = DataRecord(
+        grid,
+        dummy_elements={"link": [9999, 1234, -9999], "node": [9999, 1234, -9999]},
+        items={"grid_element": "node", "element_id": np.array(element_id)},
+        data_vars={"volumes": (["item_id"], np.array(volumes))},
+    )
+
+    dr.add_item(
+        new_item={"grid_element": np.array(["node"]), "element_id": np.array([9999])},
+        new_item_spec={"volumes": (["item_id"], [5])},
+    )
+
+
+@pytest.mark.parametrize("dmmy", [0, 8])
+def test_bad_dummy_init(dmmy):
+    grid = RasterModelGrid((3, 3))
+    element_id = [0, 0, 0, -9999, 1, 2, 3, 4, 5]
+    volumes = [4, 5, 1, 2, 3, 4, 5, 6, 7]
+    grid_element = "node"
+    data = {"volumes": volumes}
+    with pytest.raises(ValueError):
+        dr = DataRecord(
+            grid,
+            dummy_elements={"node": [dmmy]},
+            items={"grid_element": "node", "element_id": np.array(element_id)},
+            data_vars={"volumes": (["item_id"], np.array(volumes))},
+        )
+
+
+@pytest.mark.parametrize("dmmy", [-100, 9, 999])
+def test_add_bad_dummy(dmmy):
+    grid = RasterModelGrid((3, 3))
+    element_id = [0, 0, 0, -9999, 1, 2, 3, 4, 5]
+    volumes = [4, 5, 1, 2, 3, 4, 5, 6, 7]
+    grid_element = "node"
+    data = {"volumes": volumes}
+    dr = DataRecord(
+        grid,
+        dummy_elements={"link": [9999, 1234, -9999], "node": [9999, 1234, -9999]},
+        items={"grid_element": "node", "element_id": np.array(element_id)},
+        data_vars={"volumes": (["item_id"], np.array(volumes))},
+    )
+    with pytest.raises(ValueError):
+        dr.add_item(
+            new_item={
+                "grid_element": np.array(["node"]),
+                "element_id": np.array([dmmy]),
+            },
+            new_item_spec={"volumes": (["item_id"], [5])},
+        )

--- a/landlab/data_record/tests/test_errors.py
+++ b/landlab/data_record/tests/test_errors.py
@@ -15,142 +15,143 @@ import pytest
 from landlab import HexModelGrid, RadialModelGrid, RasterModelGrid, VoronoiDelaunayGrid
 from landlab.data_record import DataRecord
 
-grid = RasterModelGrid((3, 3))
 
+def test_misc():
+    grid = RasterModelGrid((3, 3))
 
-# test bad dimension:
-with pytest.raises(ValueError):
-    DataRecord(
-        grid,
-        time=[0.0],
-        data_vars={"mean_elev": (["time"], [100.0]), "test": (["bad_dim"], [12])},
-    )
-# should return ValueError('Data variable dimensions must be time and/or'
-#                              'item_id')
-# test bad time format:
-with pytest.raises(TypeError):
-    DataRecord(grid=grid, time="bad_time")
-# should return TypeError: Time must be a list or an array of length 1
+    # test bad dimension:
+    with pytest.raises(ValueError):
+        DataRecord(
+            grid,
+            time=[0.0],
+            data_vars={"mean_elev": (["time"], [100.0]), "test": (["bad_dim"], [12])},
+        )
+    # should return ValueError('Data variable dimensions must be time and/or'
+    #                              'item_id')
+    # test bad time format:
+    with pytest.raises(TypeError):
+        DataRecord(grid=grid, time="bad_time")
+    # should return TypeError: Time must be a list or an array of length 1
 
-# test bad datavars format:
-with pytest.raises(TypeError):
-    DataRecord(grid, time=[0.0], data_vars=["not a dict"])
-# should return TypeError(('Data variables (data_vars) passed to'
-#                                 ' DataRecord must be a dictionary (see '
-#                                 'documentation for valid structure)'))
+    # test bad datavars format:
+    with pytest.raises(TypeError):
+        DataRecord(grid, time=[0.0], data_vars=["not a dict"])
+    # should return TypeError(('Data variables (data_vars) passed to'
+    #                                 ' DataRecord must be a dictionary (see '
+    #                                 'documentation for valid structure)'))
 
-# test bad items format:
-with pytest.raises(TypeError):
-    DataRecord(
-        grid,
-        time=[0.0],
-        items=["not a dict"],
-        data_vars={"mean_elevation": (["time"], np.array([100]))},
-        attrs={"time_units": "y"},
-    )
-# Should return TypeError(('You must provide an ''items'' dictionary '
-#                                 '(see documentation for required format)'))
-#
-with pytest.raises(TypeError):
-    """Test bad items keys"""
-    DataRecord(
-        grid,
-        time=[0.0],
-        items={
-            "grid_element": np.array([["node"], ["link"]]),
-            "bad_key": np.array([[1], [3]]),
-        },
-        data_vars={"mean_elevation": (["time"], np.array([100]))},
-        attrs={"time_units": "y"},
-    )
-# Should return TypeError(('You must provide an ''items'' dictionary '
-#                                  '(see documentation for required format)'))
-with pytest.raises(TypeError):
-    """Test bad attrs"""
-    DataRecord(
-        grid,
-        time=[0.0],
-        items={
-            "grid_element": np.array([["node"], ["link"]]),
-            "element_id": np.array([[1], [3]]),
-        },
-        data_vars={"mean_elevation": (["time"], np.array([100]))},
-        attrs=["not a dict"],
-    )
-# Should return except AttributeError:
-#                 raise TypeError(('Attributes (attrs) passed to DataRecord'
-#                                 'must be a dictionary'))
-#
-# test bad loc and id:
-rmg = RasterModelGrid((3, 3))
-hmg = HexModelGrid(3, 2, 1.0)
-radmg = RadialModelGrid(num_shells=1, dr=1.0, xy_of_center=(0.0, 0.0))
-vdmg = VoronoiDelaunayGrid(np.random.rand(25), np.random.rand(25))
-my_items_bad_loc = {
-    "grid_element": np.array(["node", "bad_loc"]),
-    "element_id": np.array([1, 3]),
-}
-my_items_bad_loc2 = {"grid_element": "bad_loc", "element_id": np.array([1, 3])}
-my_items_bad_loc3 = {
-    "grid_element": np.array(["node", "node", "node"]),
-    "element_id": np.array([1, 3]),
-}
-my_items_bad_id = {
-    "grid_element": np.array(["node", "link"]),
-    "element_id": np.array([1, 300]),
-}
-my_items_bad_id2 = {
-    "grid_element": np.array(["node", "link"]),
-    "element_id": np.array([1, -300]),
-}
-my_items_bad_id3 = {
-    "grid_element": np.array(["node", "link"]),
-    "element_id": np.array([1, 2.0]),
-}
-my_items_bad_id4 = {
-    "grid_element": np.array(["node", "link"]),
-    "element_id": np.array([1, 2, 3]),
-}
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_loc)
-with pytest.raises(ValueError):
-    DataRecord(hmg, items=my_items_bad_loc)
-with pytest.raises(ValueError):
-    DataRecord(radmg, items=my_items_bad_loc)
-with pytest.raises(ValueError):
-    DataRecord(vdmg, items=my_items_bad_loc)
-# should return ValueError(('One or more of the grid elements provided is/are'
-#                             ' not permitted location for this grid type.'))
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_loc2)
-# should return ValueError: Location provided: bad_loc is not a permitted
-#  location for this grid type.
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_loc3)
-# should return ValueError(('grid_element passed to DataRecord must be '
-#  ' the same length as the number of items or 1.'))
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_id)
-with pytest.raises(ValueError):
-    DataRecord(hmg, items=my_items_bad_id)
-with pytest.raises(ValueError):
-    DataRecord(radmg, items=my_items_bad_id)
-with pytest.raises(ValueError):
-    DataRecord(vdmg, items=my_items_bad_id)
-# should return ValueError(('An item residing at ' + at + ' has an '
-#  'element_id larger than the number of'+ at + 'on the grid.'))
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_id2)
-#  should return ValueError(('An item residing at ' + at + ' has '
-# 'an element id below zero. This is not permitted.'))
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_id3)
-# should return ValueError(('You have passed a non-integer element_id to '
-#                              'DataRecord, this is not permitted.'))
-with pytest.raises(ValueError):
-    DataRecord(rmg, items=my_items_bad_id4)
-# should return ValueError(('The number of grid_element passed '
-#  ' to Datarecord must be 1 or equal  to the number of element_id '))
+    # test bad items format:
+    with pytest.raises(TypeError):
+        DataRecord(
+            grid,
+            time=[0.0],
+            items=["not a dict"],
+            data_vars={"mean_elevation": (["time"], np.array([100]))},
+            attrs={"time_units": "y"},
+        )
+    # Should return TypeError(('You must provide an ''items'' dictionary '
+    #                                 '(see documentation for required format)'))
+    #
+    with pytest.raises(TypeError):
+        """Test bad items keys"""
+        DataRecord(
+            grid,
+            time=[0.0],
+            items={
+                "grid_element": np.array([["node"], ["link"]]),
+                "bad_key": np.array([[1], [3]]),
+            },
+            data_vars={"mean_elevation": (["time"], np.array([100]))},
+            attrs={"time_units": "y"},
+        )
+    # Should return TypeError(('You must provide an ''items'' dictionary '
+    #                                  '(see documentation for required format)'))
+    with pytest.raises(TypeError):
+        """Test bad attrs"""
+        DataRecord(
+            grid,
+            time=[0.0],
+            items={
+                "grid_element": np.array([["node"], ["link"]]),
+                "element_id": np.array([[1], [3]]),
+            },
+            data_vars={"mean_elevation": (["time"], np.array([100]))},
+            attrs=["not a dict"],
+        )
+    # Should return except AttributeError:
+    #                 raise TypeError(('Attributes (attrs) passed to DataRecord'
+    #                                 'must be a dictionary'))
+    #
+    # test bad loc and id:
+    rmg = RasterModelGrid((3, 3))
+    hmg = HexModelGrid(3, 2, 1.0)
+    radmg = RadialModelGrid(num_shells=1, dr=1.0, xy_of_center=(0.0, 0.0))
+    vdmg = VoronoiDelaunayGrid(np.random.rand(25), np.random.rand(25))
+    my_items_bad_loc = {
+        "grid_element": np.array(["node", "bad_loc"]),
+        "element_id": np.array([1, 3]),
+    }
+    my_items_bad_loc2 = {"grid_element": "bad_loc", "element_id": np.array([1, 3])}
+    my_items_bad_loc3 = {
+        "grid_element": np.array(["node", "node", "node"]),
+        "element_id": np.array([1, 3]),
+    }
+    my_items_bad_id = {
+        "grid_element": np.array(["node", "link"]),
+        "element_id": np.array([1, 300]),
+    }
+    my_items_bad_id2 = {
+        "grid_element": np.array(["node", "link"]),
+        "element_id": np.array([1, -300]),
+    }
+    my_items_bad_id3 = {
+        "grid_element": np.array(["node", "link"]),
+        "element_id": np.array([1, 2.0]),
+    }
+    my_items_bad_id4 = {
+        "grid_element": np.array(["node", "link"]),
+        "element_id": np.array([1, 2, 3]),
+    }
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_loc)
+    with pytest.raises(ValueError):
+        DataRecord(hmg, items=my_items_bad_loc)
+    with pytest.raises(ValueError):
+        DataRecord(radmg, items=my_items_bad_loc)
+    with pytest.raises(ValueError):
+        DataRecord(vdmg, items=my_items_bad_loc)
+    # should return ValueError(('One or more of the grid elements provided is/are'
+    #                             ' not permitted location for this grid type.'))
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_loc2)
+    # should return ValueError: Location provided: bad_loc is not a permitted
+    #  location for this grid type.
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_loc3)
+    # should return ValueError(('grid_element passed to DataRecord must be '
+    #  ' the same length as the number of items or 1.'))
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_id)
+    with pytest.raises(ValueError):
+        DataRecord(hmg, items=my_items_bad_id)
+    with pytest.raises(ValueError):
+        DataRecord(radmg, items=my_items_bad_id)
+    with pytest.raises(ValueError):
+        DataRecord(vdmg, items=my_items_bad_id)
+    # should return ValueError(('An item residing at ' + at + ' has an '
+    #  'element_id larger than the number of'+ at + 'on the grid.'))
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_id2)
+    #  should return ValueError(('An item residing at ' + at + ' has '
+    # 'an element id below zero. This is not permitted.'))
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_id3)
+    # should return ValueError(('You have passed a non-integer element_id to '
+    #                              'DataRecord, this is not permitted.'))
+    with pytest.raises(ValueError):
+        DataRecord(rmg, items=my_items_bad_id4)
+    # should return ValueError(('The number of grid_element passed '
+    #  ' to Datarecord must be 1 or equal  to the number of element_id '))
 
 
 # TIME ONLY


### PR DESCRIPTION
@nathanlyons @margauxmouchene

here is a proposed fix that approaches fixing #909. it removes DataRecord inheriting from xarray.Dataset and puts the dataset at self.dataset. 

It gets rid of inplace=True (and thus all those future warnings).

It also creates a feature needed by @pfeiffea in which items can live on a "phantom link". Later today/tomorrow I'll create a function "select_where" that wraps xarray select and where such and returns a DataRecord instance with a self.dataset that has been appropriately subsetted.

