### PR TITLE
Fix issue 953

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,19 +10,19 @@ environment:
   matrix:
     - TARGET_ARCH: x64
       CONDA_NPY: 111
-      CONDA_PY: 27
+      CONDA_PY: 2.7
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
       DISTUTILS_USE_SDK: 1
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
-      CONDA_PY: 37
+      CONDA_PY: 3.7
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
       CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-      CONDA_PY: 36
+      CONDA_PY: 3.6
 
 platform:
   - x64
@@ -40,8 +40,6 @@ install:
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
   - cmd: conda update conda
-  - cmd: conda install -q --force --no-deps psutil ruamel_yaml requests
-  - cmd: conda install -q numpy netcdf4
   - cmd: pip install twine pytest pytest-cov pytest-datadir
   - cmd: conda info
   - cmd: conda list
@@ -49,6 +47,7 @@ install:
 build: false
 
 test_script:
+  - "%WITH_COMPILER% pip install numpy"
   - "%WITH_COMPILER% pip install -e ."
   - pytest -vvv
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,8 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
+  - cmd: conda create -n test_env python=$CONDA_PY
+  - cmd: conda activate test_env
   - cmd: pip install twine pytest pytest-cov pytest-datadir
   - cmd: conda info
   - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,6 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda create -n test_env python=%CONDA_PY%
-  - cmd: conda activate test_env
   - cmd: pip install twine pytest pytest-cov pytest-datadir
   - cmd: conda info
   - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda create -n test_env python=$CONDA_PY
+  - cmd: conda create -n test_env python=%CONDA_PY%
   - cmd: conda activate test_env
   - cmd: pip install twine pytest pytest-cov pytest-datadir
   - cmd: conda info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,6 @@ install:
   - cmd: conda update --yes --quiet conda
   - cmd: set PYTHONUNBUFFERED=1
   - cmd: conda config --set always_yes yes
-  - cmd: conda update conda
   - cmd: pip install twine pytest pytest-cov pytest-datadir
   - cmd: conda info
   - cmd: conda list


### PR DESCRIPTION
This pull request fixes #953. The problem seemed to arise from running `conda update conda` multiple times, which, for some reason, caused *setuptools* to be removed. In any case, I've cleaned up the build process so that it looks more like what we do on Travis and things seem to now be building on AppVeyor.