### PR TITLE
fix: Treatment of porosity in ErosionDeposition and SPACE fixed

### DIFF
--- a/landlab/components/erosion_deposition/cfuncs.pyx
+++ b/landlab/components/erosion_deposition/cfuncs.pyx
@@ -20,8 +20,7 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] qs_in,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] Es,
                     DTYPE_FLOAT_t v_s,
-                    DTYPE_FLOAT_t F_f,
-                    DTYPE_FLOAT_t phi):
+                    DTYPE_FLOAT_t F_f):
 
     """Calculate and qs and qs_in."""
     # define internal variables
@@ -45,7 +44,7 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
         #
         if q[node_id] > 0:
             qs[node_id] = ((qs_in[node_id]
-                            + ((1.0 - F_f) * (1. - phi) * Es[node_id]) * cell_area_at_node[node_id])
+                            + ((1.0 - F_f) * Es[node_id]) * cell_area_at_node[node_id])
                            / (1.0 + (v_s * cell_area_at_node[node_id] / (q[node_id]))))
 
             # finally, add this nodes qs to recieiving nodes qs_in.

--- a/landlab/components/erosion_deposition/erosion_deposition.py
+++ b/landlab/components/erosion_deposition/erosion_deposition.py
@@ -88,11 +88,11 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
     def __init__(
         self,
         grid,
-        K=None,
-        phi=None,
-        v_s=None,
-        m_sp=None,
-        n_sp=None,
+        K=0.002,
+        phi=0.3,
+        v_s=1.0,
+        m_sp=0.5,
+        n_sp=1.0,
         sp_crit=0.0,
         F_f=0.0,
         discharge_field="surface_water__discharge",
@@ -287,7 +287,6 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
             self.erosion_term,
             self.v_s,
             self.F_f,
-            self.phi,
         )
 
         self.depo_rate[:] = 0.0
@@ -298,7 +297,7 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
         # topo elev is old elev + deposition - erosion
         cores = self.grid.core_nodes
         self.topographic__elevation[cores] += (
-            (self.depo_rate[cores] / (1 - self.phi)) - self.erosion_term[cores]
+            (self.depo_rate[cores] - self.erosion_term[cores]) / (1 - self.phi)
         ) * dt
 
     def run_with_adaptive_time_step_solver(self, dt=1.0, flooded_nodes=[], **kwds):
@@ -354,7 +353,6 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
                 self.erosion_term,
                 self.v_s,
                 self.F_f,
-                self.phi,
             )
 
             # Use Qs to calculate deposition rate at each node.
@@ -364,9 +362,9 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
             )
 
             # Rate of change of elevation at core nodes:
-            dzdt[cores] = (self.depo_rate[cores] / (1 - self.phi)) - self.erosion_term[
-                cores
-            ]
+            dzdt[cores] = (self.depo_rate[cores] - self.erosion_term[cores]) / (
+                1 - self.phi
+            )
 
             # Difference in elevation between each upstream-downstream pair
             zdif = z - z[r]
@@ -399,9 +397,7 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
 
             # From this, find the maximum stable time step. If it is smaller
             # than our tolerance, report and quit.
-            dt_max = np.amin(self.time_to_flat)
-            if dt_max < self.dt_min:
-                dt_max = self.dt_min
+            dt_max = max(np.amin(self.time_to_flat), self.dt_min)
 
             # Finally, apply dzdt to all nodes for a (sub)step of duration
             # dt_max

--- a/landlab/components/erosion_deposition/generalized_erosion_deposition.py
+++ b/landlab/components/erosion_deposition/generalized_erosion_deposition.py
@@ -52,11 +52,11 @@ class _GeneralizedErosionDeposition(Component):
     def __init__(
         self,
         grid,
-        m_sp=None,
-        n_sp=None,
-        phi=None,
-        F_f=None,
-        v_s=None,
+        m_sp,
+        n_sp,
+        phi,
+        F_f,
+        v_s,
         discharge_field="surface_water__discharge",
         dt_min=DEFAULT_MINIMUM_TIME_STEP,
     ):

--- a/landlab/components/erosion_deposition/tests/test_erodep.py
+++ b/landlab/components/erosion_deposition/tests/test_erodep.py
@@ -143,8 +143,14 @@ def test_steady_state_with_basic_solver_option():
     # compare numerical and analytical slope solutions
     num_slope = mg.at_node["topographic__steepest_slope"][mg.core_nodes]
     analytical_slope = np.power(
-        ((U * v_s) / (K * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp)))
-        + (U / (K * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))),
+        (
+            (U * v_s * (1 - phi))
+            / (K * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))
+        )
+        + (
+            (U * (1 - phi))
+            / (K * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))
+        ),
         1.0 / n_sp,
     )
 
@@ -209,3 +215,64 @@ def test_can_run_with_hex():
     s28 = sa_factor * (a28 ** -0.5)
     testing.assert_equal(np.round(s[18], 3), np.round(s18, 3))
     testing.assert_equal(np.round(s[28], 3), np.round(s28, 3))
+
+
+def test_phi_affects_transience():
+    """Test that different porosity values affect the transient case."""
+
+    # Set up one 5x5 grid with open boundaries and low initial elevations.
+    mg1 = HexModelGrid(7, 7)
+    z1 = mg1.add_zeros("node", "topographic__elevation")
+    z1[:] = 0.01 * mg1.x_of_node
+
+    # Create a D8 flow handler
+    fa1 = FlowAccumulator(mg1, flow_director="FlowDirectorSteepest")
+
+    # Parameter values for test 1
+    K1 = 0.001
+    vs1 = 0.0001
+    U1 = 0.001
+    dt1 = 10.0
+    phi1 = 0.1
+
+    # Create the ErosionDeposition component...
+    ed1 = ErosionDeposition(
+        mg1, K=K1, phi=phi1, v_s=vs1, m_sp=0.5, n_sp=1.0, solver="basic"
+    )
+
+    # ... and run it to steady state.
+    for i in range(200):
+        fa1.run_one_step()
+        ed1.run_one_step(dt=dt1)
+        z1[mg1.core_nodes] += U1 * dt1
+
+    # Set up a second 5x5 grid with open boundaries and low initial elevations.
+    mg2 = HexModelGrid(7, 7)
+    z2 = mg2.add_zeros("node", "topographic__elevation")
+    z2[:] = 0.01 * mg2.x_of_node
+
+    # Create a D8 flow handler
+    fa2 = FlowAccumulator(mg2, flow_director="FlowDirectorSteepest")
+
+    # Parameter values for test 1
+    K2 = 0.001
+    vs2 = 0.0001
+    U2 = 0.001
+    dt2 = 10.0
+    phi2 = 0.9
+
+    # Create the ErosionDeposition component...
+    ed2 = ErosionDeposition(
+        mg2, K=K2, phi=phi2, v_s=vs2, m_sp=0.5, n_sp=1.0, solver="basic"
+    )
+
+    # ... and run it to steady state.
+    for i in range(200):
+        fa2.run_one_step()
+        ed2.run_one_step(dt=dt2)
+        z2[mg2.core_nodes] += U2 * dt2
+
+    # Test the results: higher phi should be lower slope
+    s1 = mg1.at_node["topographic__steepest_slope"][mg1.core_nodes]
+    s2 = mg2.at_node["topographic__steepest_slope"][mg2.core_nodes]
+    testing.assert_array_less(s2, s1)

--- a/landlab/components/erosion_deposition/tests/test_erodep_steady_state.py
+++ b/landlab/components/erosion_deposition/tests/test_erodep_steady_state.py
@@ -210,7 +210,3 @@ def test_erodep_slope_area_with_threshold():
     s12 = sa_factor * (a12 ** -0.5)
     assert_equal(np.round(s[11], 2), np.round(s11, 2))
     assert_equal(np.round(s[12], 2), np.round(s12, 2))
-
-
-if __name__ == "__main__":
-    test_erodep_slope_area_shear_stress_scaling()

--- a/landlab/components/erosion_deposition/tests/test_general_erodep.py
+++ b/landlab/components/erosion_deposition/tests/test_general_erodep.py
@@ -6,7 +6,7 @@ from landlab import RasterModelGrid
 from landlab.components import ErosionDeposition, FlowAccumulator
 
 
-def test_Ff_bad_vals():
+def test_Ff_too_high_vals():
     """
     Test that instantiating ErosionDeposition with a F_f value > 1 throws a
     ValueError.
@@ -52,7 +52,53 @@ def test_Ff_bad_vals():
         )
 
 
-def test_phi_bad_vals():
+def test_Ff_too_low_vals():
+    """
+    Test that instantiating ErosionDeposition with a F_f value < 0 throws a
+    ValueError.
+    """
+
+    # set up a 5x5 grid with one open outlet node and low initial elevations.
+    nr = 5
+    nc = 5
+    mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
+
+    mg.add_zeros("node", "topographic__elevation")
+
+    mg["node"]["topographic__elevation"] += (
+        mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
+    )
+    mg.set_closed_boundaries_at_grid_edges(
+        bottom_is_closed=True,
+        left_is_closed=True,
+        right_is_closed=True,
+        top_is_closed=True,
+    )
+    mg.set_watershed_boundary_condition_outlet_id(
+        0, mg["node"]["topographic__elevation"], -9999.0
+    )
+
+    # Create a D8 flow handler
+    FlowAccumulator(
+        mg, flow_director="D8", depression_finder="DepressionFinderAndRouter"
+    )
+
+    # Instantiate the ErosionDeposition component...
+    with pytest.raises(ValueError):
+        ErosionDeposition(
+            mg,
+            K=0.01,
+            F_f=-0.5,
+            phi=0.5,
+            v_s=0.001,
+            m_sp=0.5,
+            n_sp=1.0,
+            sp_crit=0.0,
+            solver="basic",
+        )
+
+
+def test_phi_too_high_vals():
     """
     Test that instantiating ErosionDeposition with a phi value >= 1 throws a
     ValueError.
@@ -90,6 +136,52 @@ def test_phi_bad_vals():
             K=0.01,
             F_f=0.0,
             phi=2.0,
+            v_s=0.001,
+            m_sp=0.5,
+            n_sp=1.0,
+            sp_crit=0.0,
+            solver="basic",
+        )
+
+
+def test_phi_too_low_vals():
+    """
+    Test that instantiating ErosionDeposition with a phi value < 0 throws a
+    ValueError.
+    """
+
+    # set up a 5x5 grid with one open outlet node and low initial elevations.
+    nr = 5
+    nc = 5
+    mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
+
+    mg.add_zeros("node", "topographic__elevation")
+
+    mg["node"]["topographic__elevation"] += (
+        mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
+    )
+    mg.set_closed_boundaries_at_grid_edges(
+        bottom_is_closed=True,
+        left_is_closed=True,
+        right_is_closed=True,
+        top_is_closed=True,
+    )
+    mg.set_watershed_boundary_condition_outlet_id(
+        0, mg["node"]["topographic__elevation"], -9999.0
+    )
+
+    # Create a D8 flow handler
+    FlowAccumulator(
+        mg, flow_director="D8", depression_finder="DepressionFinderAndRouter"
+    )
+
+    # Instantiate the ErosionDeposition component...
+    with pytest.raises(ValueError):
+        ErosionDeposition(
+            mg,
+            K=0.01,
+            F_f=0.0,
+            phi=-0.5,
             v_s=0.001,
             m_sp=0.5,
             n_sp=1.0,

--- a/landlab/components/space/cfuncs.pyx
+++ b/landlab/components/space/cfuncs.pyx
@@ -21,8 +21,7 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] Es,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] Er,
                     DTYPE_FLOAT_t v_s,
-                    DTYPE_FLOAT_t F_f,
-                    DTYPE_FLOAT_t phi):
+                    DTYPE_FLOAT_t F_f):
     """Calculate and qs and qs_in."""
     # define internal variables
     cdef unsigned int n_nodes = stack_flip_ud.size
@@ -44,7 +43,7 @@ def calculate_qs_in(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud,
         # in an upstream to downstream loop, and cannot be vectorized.
 
         if q[node_id] > 0:
-            qs[node_id] = (qs_in[node_id] + (((1. - phi) * Es[node_id]) + ((1.0 - F_f) * (Er[node_id]))) * cell_area_at_node[node_id]) / \
+            qs[node_id] = (qs_in[node_id] + ((Es[node_id]) + ((1.0 - F_f) * (Er[node_id]))) * cell_area_at_node[node_id]) / \
                             (1.0 + (v_s * cell_area_at_node[node_id] / (q[node_id])))
 
             # finally, add this nodes qs to recieiving nodes qs_in.

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -134,15 +134,17 @@ class Space(_GeneralizedErosionDeposition):
     Now we test to see if soil depth and topography are right:
 
     >>> np.around(mg.at_node['soil__depth'], decimals=3) # doctest: +NORMALIZE_WHITESPACE
-    array([ 0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.495,  0.493,
-            0.492,  0.5  ,  0.5  ,  0.493,  0.493,  0.491,  0.5  ,  0.5  ,
-            0.492,  0.491,  0.486,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ])
+    array([ 0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.495,  0.492,
+            0.491,  0.5  ,  0.5  ,  0.492,  0.492,  0.49 ,  0.5  ,  0.5  ,
+            0.491,  0.49 ,  0.484,  0.5  ,  0.5  ,  0.5  ,  0.5  ,  0.5  ,
+            0.5  ])
 
     >>> np.around(mg.at_node['topographic__elevation'], decimals=3) # doctest: +NORMALIZE_WHITESPACE
-    array([ 0.423,  1.536,  2.573,  3.511,  4.561,  1.582,  0.424,  0.429,
-            0.438,  5.51 ,  2.54 ,  0.429,  0.429,  0.439,  6.526,  3.559,
-            0.438,  0.439,  0.451,  7.553,  4.559,  5.541,  6.57 ,  7.504,
+    array([ 0.423,  1.536,  2.573,  3.511,  4.561,  1.582,  0.424,  0.428,
+            0.438,  5.51 ,  2.54 ,  0.428,  0.428,  0.438,  6.526,  3.559,
+            0.438,  0.438,  0.45 ,  7.553,  4.559,  5.541,  6.57 ,  7.504,
             8.51 ])
+
     """
 
     _name = "Space"
@@ -202,16 +204,16 @@ class Space(_GeneralizedErosionDeposition):
     def __init__(
         self,
         grid,
-        K_sed=None,
-        K_br=None,
-        F_f=None,
-        phi=None,
-        H_star=None,
-        v_s=None,
-        m_sp=None,
-        n_sp=None,
-        sp_crit_sed=None,
-        sp_crit_br=None,
+        K_sed=0.02,
+        K_br=0.02,
+        F_f=0.0,
+        phi=0.3,
+        H_star=0.1,
+        v_s=1.0,
+        m_sp=0.5,
+        n_sp=1.0,
+        sp_crit_sed=0.0,
+        sp_crit_br=0.0,
         discharge_field="surface_water__discharge",
         solver="basic",
         dt_min=DEFAULT_MINIMUM_TIME_STEP,
@@ -343,7 +345,6 @@ class Space(_GeneralizedErosionDeposition):
             self.Er,
             self.v_s,
             self.F_f,
-            self.phi,
         )
 
         self.depo_rate[self.q > 0] = self.qs[self.q > 0] * (
@@ -363,7 +364,7 @@ class Space(_GeneralizedErosionDeposition):
         # positive slopes, not flooded
         pos_not_flood = (self.q > 0) & (blowup) & (self.slope > 0) & (~flooded)
         self.soil__depth[pos_not_flood] = self.H_star * np.log(
-            (self.sed_erosion_term[pos_not_flood] / self.H_star) * dt
+            ((self.sed_erosion_term[pos_not_flood] / (1 - self.phi)) / self.H_star) * dt
             + np.exp(self.soil__depth[pos_not_flood] / self.H_star)
         )
         # positive slopes, flooded
@@ -384,7 +385,7 @@ class Space(_GeneralizedErosionDeposition):
                 1
                 / (
                     (self.depo_rate[pos_not_flood] / (1 - self.phi))
-                    / (self.sed_erosion_term[pos_not_flood])
+                    / (self.sed_erosion_term[pos_not_flood] / (1 - self.phi))
                     - 1
                 )
             )
@@ -392,7 +393,7 @@ class Space(_GeneralizedErosionDeposition):
                 np.exp(
                     (
                         self.depo_rate[pos_not_flood] / (1 - self.phi)
-                        - (self.sed_erosion_term[pos_not_flood])
+                        - (self.sed_erosion_term[pos_not_flood] / (1 - self.phi))
                     )
                     * (dt / self.H_star)
                 )
@@ -401,7 +402,7 @@ class Space(_GeneralizedErosionDeposition):
                         (
                             self.depo_rate[pos_not_flood]
                             / (1 - self.phi)
-                            / (self.sed_erosion_term[pos_not_flood])
+                            / (self.sed_erosion_term[pos_not_flood] / (1 - self.phi))
                         )
                         - 1
                     )
@@ -531,7 +532,6 @@ class Space(_GeneralizedErosionDeposition):
                 self.Er,
                 self.v_s,
                 self.F_f,
-                self.phi,
             )
 
             self.depo_rate[self.q > 0] = self.qs[self.q > 0] * (
@@ -558,7 +558,7 @@ class Space(_GeneralizedErosionDeposition):
 
             # Next we consider time to exhaust regolith
             time_to_zero_alluv[:] = remaining_time
-            dHdt = self.porosity_factor * (self.depo_rate) - self.Es
+            dHdt = self.porosity_factor * (self.depo_rate - self.Es)
             decreasing_H = np.where(dHdt < 0.0)[0]
             time_to_zero_alluv[decreasing_H] = -(
                 TIME_STEP_FACTOR * H[decreasing_H] / dHdt[decreasing_H]
@@ -568,9 +568,7 @@ class Space(_GeneralizedErosionDeposition):
             dt_max2 = np.amin(time_to_zero_alluv)
 
             # Take the smaller of the limits
-            dt_max = min(dt_max1, dt_max2)
-            if dt_max < self.dt_min:
-                dt_max = self.dt_min
+            dt_max = max(self.dt_min, min(dt_max1, dt_max2))
 
             # Now a vector operation: apply dzdt and dhdt to all nodes
             br[cores] -= self.Er[cores] * dt_max

--- a/landlab/components/space/tests/test_space.py
+++ b/landlab/components/space/tests/test_space.py
@@ -352,10 +352,13 @@ def test_matches_transport_solution():
     num_slope = mg.at_node["topographic__steepest_slope"][mg.core_nodes]
     analytical_slope = np.power(
         (
-            (U * v_s)
+            (U * v_s * (1 - phi))
             / (K_sed * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))
         )
-        + (U / (K_sed * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))),
+        + (
+            (U * (1 - phi))
+            / (K_sed * np.power(mg.at_node["drainage_area"][mg.core_nodes], m_sp))
+        ),
         1.0 / n_sp,
     )
 


### PR DESCRIPTION
* remove porosity from qs calculation

* finish deleting porosity from qs calc

* fix porosity in bed change equations in space

* fix porosity in bed change term in ed

* give defaults for space and ED, make positional arguments for generalized ED

* fixing analytical solutions in tests

* fix additional analytical solution bugs in tests

* fix TL analytical soln for erodep tests

* fix lint errors

* get rid of if in dt_max [skip ci]

* get rid of if in dt_min in erodep [skip ci]

* test negative ff and phi errors [skip ci]

* test to force timestep subdividing

* fix minimum calc

* temporarily deleting large dt test

* fix min/max error

* use python max instead of numpy

* fix mistake in space dt calc

* make dt calc cleaner

* fix lint errors [skip ci]

* add test to force timestep subdividing

* fix lint error

* set runtime for big dt test

* fix first_iteration syntax

* undo test for full coverage of dynamic solver

* test for porosity effect on transient erodep [skip ci]

* delete print statements

* formatting