### PR TITLE
fix: change datarecord to not inherit from Xarray Dataset

### DIFF
--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -195,7 +195,9 @@ class ChiFinder(Component):
         self._set_up_reference_area(reference_area)
 
         self.use_true_dx = use_true_dx
-        self.chi = self._grid.add_zeros("node", "channel__chi_index", noclobber=noclobber)
+        self.chi = self._grid.add_zeros(
+            "node", "channel__chi_index", noclobber=noclobber
+        )
         self._mask = self.grid.ones("node", dtype=bool)
         # this one needs modifying if smooth_elev
         self._elev = self.grid.at_node["topographic__elevation"]

--- a/landlab/components/groundwater/__init__.py
+++ b/landlab/components/groundwater/__init__.py
@@ -7,6 +7,4 @@
 
 from .dupuit_percolator import GroundwaterDupuitPercolator
 
-__all__ = [
-    "GroundwaterDupuitPercolator",
-]
+__all__ = ["GroundwaterDupuitPercolator"]

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -6,10 +6,10 @@ GroundwaterDupuitPercolator Component
 """
 
 import numpy as np
-from landlab import Component
-from landlab.utils import return_array_at_node, return_array_at_link
-from landlab.grid.mappers import map_mean_of_link_nodes_to_link
 
+from landlab import Component
+from landlab.grid.mappers import map_mean_of_link_nodes_to_link
+from landlab.utils import return_array_at_link, return_array_at_node
 
 ACTIVE_LINK = 0
 
@@ -46,12 +46,16 @@ class GroundwaterDupuitPercolator(Component):
 
     _name = "GroundwaterDupuitPercolator"
 
-    _input_var_names = set(("topographic__elevation",
-                            "aquifer_base__elevation"))
+    _input_var_names = set(("topographic__elevation", "aquifer_base__elevation"))
 
     _output_var_names = set(
-        ("aquifer__thickness", "water_table__elevation", "hydraulic__gradient",
-         "groundwater__specific_discharge", "groundwater__velocity")
+        (
+            "aquifer__thickness",
+            "water_table__elevation",
+            "hydraulic__gradient",
+            "groundwater__specific_discharge",
+            "groundwater__velocity",
+        )
     )
 
     _var_units = {
@@ -61,7 +65,7 @@ class GroundwaterDupuitPercolator(Component):
         "water_table__elevation": "m",
         "hydraulic__gradient": "m/m",
         "groundwater__specific_discharge": "m2/s",
-        "groundwater__velocity": "m/s"
+        "groundwater__velocity": "m/s",
     }
 
     _var_mapping = {
@@ -84,8 +88,7 @@ class GroundwaterDupuitPercolator(Component):
         "groundwater__velocity": "velocity of groundwater in link direction",
     }
 
-    def __init__(self, grid, hydraulic_conductivity=0.01,
-                 recharge_rate=1.0e-8):
+    def __init__(self, grid, hydraulic_conductivity=0.01, recharge_rate=1.0e-8):
         """Initialize the GroundwaterDupuitPercolator.
 
         Parameters
@@ -141,8 +144,7 @@ class GroundwaterDupuitPercolator(Component):
         if "groundwater__specific_discharge" in self._grid.at_link:
             self._q = self._grid.at_link["groundwater__specific_discharge"]
         else:
-            self._q = self._grid.add_zeros("link",
-                                           "groundwater__specific_discharge")
+            self._q = self._grid.add_zeros("link", "groundwater__specific_discharge")
 
         if "groundwater__velocity" in self._grid.at_link:
             self._vel = self._grid.at_link["groundwater__velocity"]
@@ -168,8 +170,7 @@ class GroundwaterDupuitPercolator(Component):
         self._vel[self._grid.status_at_link != 0] = 0.0
 
         # Aquifer thickness at links
-        hlink = map_mean_of_link_nodes_to_link(self._grid,
-                                               'aquifer__thickness')
+        hlink = map_mean_of_link_nodes_to_link(self._grid, "aquifer__thickness")
 
         # Calculate specific discharge
         self._q[:] = hlink * self._vel
@@ -182,5 +183,6 @@ class GroundwaterDupuitPercolator(Component):
         self._thickness[self._grid.core_nodes] += dhdt[self._cores] * dt
 
         # Recalculate water surface height
-        self._wtable[self._grid.core_nodes] = (self._base[self._cores]
-                                               + self._thickness[self._cores])
+        self._wtable[self._grid.core_nodes] = (
+            self._base[self._cores] + self._thickness[self._cores]
+        )

--- a/landlab/components/groundwater/tests/test_dupuit_percolator.py
+++ b/landlab/components/groundwater/tests/test_dupuit_percolator.py
@@ -6,10 +6,11 @@ Created on Tue Jun  4 16:26:31 2019
 @author: gtucker
 """
 
-from landlab.components import GroundwaterDupuitPercolator
-from landlab import RasterModelGrid
-from numpy.testing import assert_equal
 import numpy as np
+from numpy.testing import assert_equal
+
+from landlab import RasterModelGrid
+from landlab.components import GroundwaterDupuitPercolator
 
 
 def test_simple_water_table():
@@ -33,12 +34,11 @@ def test_simple_water_table():
 
         H ~ 0.00141 m.
     """
-    boundaries = {'top': 'closed',
-                  'left': 'closed',
-                  'bottom': 'closed'}
+    boundaries = {"top": "closed", "left": "closed", "bottom": "closed"}
     rg = RasterModelGrid((3, 3), bc=boundaries)
-    gdp = GroundwaterDupuitPercolator(rg, recharge_rate=1.0e-8,
-                                      hydraulic_conductivity=0.01)
+    gdp = GroundwaterDupuitPercolator(
+        rg, recharge_rate=1.0e-8, hydraulic_conductivity=0.01
+    )
     for i in range(12):
         gdp.run_one_step(5.0e4)
 

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -41,15 +41,7 @@ class DataRecord(object):
 
     _name = "DataRecord"
 
-    def __init__(
-        self,
-        grid,
-        time=None,
-        items=None,
-        data_vars=None,
-        attrs=None,
-        compat="broadcast_equals",
-    ):
+    def __init__(self, grid, time=None, items=None, data_vars=None, attrs=None):
         """
         Parameters
         ----------
@@ -87,15 +79,6 @@ class DataRecord(object):
         attrs : dict (optional)
             Dictionary of global attributes on the DataRecord (metadata).
             Example: {'time_units' : 'y'}
-        compat: str (optional)
-            String indicating how to compare variables of the same name
-            for potential conflicts:
-                - 'broadcast_equals': all values must be equal when variables
-                are broadcast against each other to ensure common dimensions.
-                - 'equals': all values and dimensions must be the same.
-                - 'identical': all values, dimensions and attributes must be
-                the same.
-            The default is 'broadcast_equals'.
 
         Examples
         --------
@@ -285,9 +268,7 @@ class DataRecord(object):
                 )
 
         # create an xarray Dataset:
-        self.dataset = Dataset(
-            data_vars=data_vars_dict, coords=coords, attrs=attrs, compat=compat
-        )
+        self.dataset = Dataset(data_vars=data_vars_dict, coords=coords, attrs=attrs)
 
     def _check_grid_element_and_id(self, grid_element, element_id, flag=None):
         """Check the location and size of grid_element and element_id."""

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -536,7 +536,7 @@ class DataRecord(object):
         # create dataset of new record
         ds_to_add = Dataset(data_vars=_new_data_vars, coords=coords_to_add)
         # merge new record and original dataset
-        self.dataset.merge(ds_to_add, inplace="True", compat="no_conflicts")
+        self.dataset = self.dataset.merge(ds_to_add, compat="no_conflicts")
 
     def add_item(self, time=None, new_item=None, new_item_spec=None):
         """Add new item(s) to the current DataRecord.
@@ -701,7 +701,7 @@ class DataRecord(object):
         ds_to_add = Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
         # Merge new record and original dataset:
-        self.dataset.merge(ds_to_add, inplace="True", compat="no_conflicts")
+        self.dataset = self.dataset.merge(ds_to_add, compat="no_conflicts")
 
     def get_data(self, time=None, item_id=None, data_variable=None):
         """Get the value of a variable at a model time and/or for an item.

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -12,7 +12,7 @@ class DataRecord(object):
     This class uses a xarray Dataset to store variables. This datastructure is
     located at the property ``dataset``. The DataRecord improves on an xarray
     Dataset by providing additional attributes and functions, including the
-    ability to aggregate values on Landlab grid elements. 
+    ability to aggregate values on Landlab grid elements.
 
     Data variables can vary along one or both of the following dimensions:
         - time (model time)
@@ -155,7 +155,7 @@ class DataRecord(object):
         self._grid = grid
 
         # depending on the grid type, permitted locations for items vary
-        self.permitted_locations = self._grid.groups
+        self._permitted_locations = self._grid.groups
 
         # set initial time coordinates, if any
         if isinstance(time, (list, np.ndarray)):
@@ -276,7 +276,7 @@ class DataRecord(object):
         """Check the location and size of grid_element and element_id."""
         if isinstance(grid_element, string_types):
             # all items are on same type of grid_element
-            if grid_element in self.permitted_locations:
+            if grid_element in self._permitted_locations:
                 pass
             else:
                 raise ValueError(
@@ -306,7 +306,7 @@ class DataRecord(object):
                 if isinstance(loc, np.ndarray):
                     # depending on dims
                     loc = loc[0]
-                if loc in self.permitted_locations:
+                if loc in self._permitted_locations:
                     pass
                 else:
                     raise ValueError(
@@ -319,7 +319,7 @@ class DataRecord(object):
 
     def _check_element_id_values(self, grid_element, element_id):
         """Check that element_id values are valid."""
-        for at in self.permitted_locations:
+        for at in self._permitted_locations:
             max_size = self._grid[at].size
             selected_elements_ind = [
                 i for i in range(len(grid_element)) if grid_element[i] == at

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -208,7 +208,7 @@ class DataRecord(object):
             self._check_element_id_values(_grid_elements, _element_ids)
 
             # create coordinates for the dimension 'item_id':
-            self.item_ids = np.array(range(self._number_of_items))
+            self._item_ids = np.array(range(self._number_of_items))
 
             # create initial dictionaries of variables:
             if time is not None:
@@ -216,14 +216,14 @@ class DataRecord(object):
                     "grid_element": (["item_id", "time"], _grid_elements),
                     "element_id": (["item_id", "time"], _element_ids),
                 }
-                coords = {"time": self._times, "item_id": self.item_ids}
+                coords = {"time": self._times, "item_id": self._item_ids}
             else:
                 # no time
                 data_vars_dict = {
                     "grid_element": (["item_id"], _grid_elements),
                     "element_id": (["item_id"], _element_ids),
                 }
-                coords = {"item_id": self.item_ids}
+                coords = {"item_id": self._item_ids}
 
         else:
             # no items, initial dictionary of variables is empty:

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -6,7 +6,7 @@ from six import string_types
 from xarray import Dataset
 
 
-class DataRecord(Dataset):
+class DataRecord(object):
     """Data structure to store variables in time and/or space dimensions.
 
     This is a base class to contain the majority of core DataRecord
@@ -118,21 +118,21 @@ class DataRecord(Dataset):
         Coordinates are one dimensional arrays used for label-based indexing.
         DataRecord inherits all the methods and attributes from xarray.Dataset.
 
-        >>> dr1.to_dataframe()
+        >>> dr1.dataset.to_dataframe()
               mean_elevation
         time
         0.0              100
 
-        >>> dr1.time.values
+        >>> dr1.dataset.time.values
         array([ 0.])
 
         >>> dr1.variable_names
         ['mean_elevation']
 
-        >>> dr1['mean_elevation'].values
+        >>> dr1.dataset['mean_elevation'].values
         array([100])
 
-        >>> dr1.attrs
+        >>> dr1.dataset.attrs
         OrderedDict([('time_units', 'y')])
 
         Example of a DataRecord with item_id as the only dimension:
@@ -144,7 +144,7 @@ class DataRecord(Dataset):
         Note that both arrays (grid_element and element_id) have 1 dimension
         as they only vary along the dimension 'item_id'.
 
-        >>> dr2.to_dataframe()[['grid_element', 'element_id']]
+        >>> dr2.dataset.to_dataframe()[['grid_element', 'element_id']]
                 grid_element  element_id
         item_id
         0               node           1
@@ -160,7 +160,7 @@ class DataRecord(Dataset):
         Note that both arrays have 2 dimensions as they vary along dimensions
         'time' and 'item_id'.
 
-        >>> dr3.to_dataframe()[['grid_element', 'element_id']]
+        >>> dr3.dataset.to_dataframe()[['grid_element', 'element_id']]
                      grid_element  element_id
         item_id time
         0       0.0          node           1
@@ -284,8 +284,8 @@ class DataRecord(Dataset):
                     "Attributes (attrs) passed to DataRecord" "must be a dictionary"
                 )
 
-        # initialize the xarray Dataset:
-        super(DataRecord, self).__init__(
+        # create an xarray Dataset:
+        self.dataset = Dataset(
             data_vars=data_vars_dict, coords=coords, attrs=attrs, compat=compat
         )
 
@@ -414,7 +414,7 @@ class DataRecord(Dataset):
         ...                             'element_id' : np.array([[6]])},
         ...                new_record={'item_size':(
         ...                           ['item_id', 'time'], np.array([[0.2]]))})
-        >>> dr3['element_id'].values
+        >>> dr3.dataset['element_id'].values
         array([[  1.,   6.],
                [  3.,  nan]])
         >>> dr3.get_data([2.0],[0],'item_size')
@@ -424,7 +424,7 @@ class DataRecord(Dataset):
         record:
         >>> dr3.add_record(time=[50.0],
         ...                new_record={'mean_elev': (['time'], [110])})
-        >>> dr3['mean_elev'].to_dataframe()
+        >>> dr3.dataset['mean_elev'].to_dataframe()
               mean_elev
         time
         0.0         NaN
@@ -434,7 +434,7 @@ class DataRecord(Dataset):
         if time is not None:
             try:
                 # check that time is a dim of the DataRecord
-                self["time"]
+                self.dataset["time"]
             except KeyError:
                 raise KeyError("This DataRecord does not record time")
 
@@ -448,7 +448,7 @@ class DataRecord(Dataset):
                 if item_id is not None:
                     try:
                         # check that DataRecord holds items
-                        self["item_id"]
+                        self.dataset["item_id"]
                     except KeyError:
                         raise KeyError("This DataRecord does not hold items")
                     try:
@@ -456,7 +456,7 @@ class DataRecord(Dataset):
                         len(item_id)
                     except TypeError:
                         raise TypeError("item_id must be a list or a 1D array")
-                    if not all(i in self["item_id"].values for i in item_id):
+                    if not all(i in self.dataset["item_id"].values for i in item_id):
                         # check that item_id already exist
                         raise ValueError(
                             "One or more of the value(s) you "
@@ -504,7 +504,7 @@ class DataRecord(Dataset):
         else:
             # no time
             if item_id is not None:
-                if not all(i in self["item_id"].values for i in item_id):
+                if not all(i in self.dataset["item_id"].values for i in item_id):
                     # check that item_id already exist
                     raise ValueError(
                         "One or more of the value(s) you "
@@ -536,7 +536,7 @@ class DataRecord(Dataset):
         # create dataset of new record
         ds_to_add = Dataset(data_vars=_new_data_vars, coords=coords_to_add)
         # merge new record and original dataset
-        self.merge(ds_to_add, inplace="True", compat="no_conflicts")
+        self.dataset.merge(ds_to_add, inplace="True", compat="no_conflicts")
 
     def add_item(self, time=None, new_item=None, new_item_spec=None):
         """Add new item(s) to the current DataRecord.
@@ -605,14 +605,14 @@ class DataRecord(Dataset):
         If a data variable is also added with the new items ('size' in this
         example), the values for this variable are filled with 'nan' for the
         pre-existing items:
-        >>> dr3['size'][:,1].values
+        >>> dr3.dataset['size'][:,1].values
         array([ nan,  nan,  10.,   5.])
 
         The previous line calls the values of the variable 'size', for all
         items, at time=1; the first two items don't have a value for the
         variable 'size'.
         """
-        if time is None and "time" in self["grid_element"].coords:
+        if time is None and "time" in self.dataset["grid_element"].coords:
             raise ValueError(
                 "The items previously defined in this DataRecord"
                 ' have dimensions "time" and "item_id", '
@@ -641,14 +641,14 @@ class DataRecord(Dataset):
 
         number_of_new_items = len(new_item["element_id"])
         # first id of new item = last item in existing datarecord+1
-        new_first_item_id = self["item_id"][-1].values + 1
+        new_first_item_id = self.dataset["item_id"][-1].values + 1
         new_item_ids = np.array(
             range(new_first_item_id, new_first_item_id + number_of_new_items)
         )
 
         if time is not None:
             try:
-                self["time"]
+                self.dataset["time"]
             except KeyError:
                 raise KeyError("This DataRecord does not record time")
             if not isinstance(time, (list, np.ndarray)):
@@ -701,7 +701,7 @@ class DataRecord(Dataset):
         ds_to_add = Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
         # Merge new record and original dataset:
-        self.merge(ds_to_add, inplace="True", compat="no_conflicts")
+        self.dataset.merge(ds_to_add, inplace="True", compat="no_conflicts")
 
     def get_data(self, time=None, item_id=None, data_variable=None):
         """Get the value of a variable at a model time and/or for an item.
@@ -749,17 +749,17 @@ class DataRecord(Dataset):
                ['node']], dtype=object)
         """
         try:
-            self[data_variable]
+            self.dataset[data_variable]
         except KeyError:
             raise KeyError(
                 "the variable '{}' is not in the " "DataRecord".format(data_variable)
             )
         if time is None:
             if item_id is None:
-                return self[data_variable].values
+                return self.dataset[data_variable].values
             else:
                 try:
-                    self["item_id"]
+                    self.dataset["item_id"]
                 except KeyError:
                     raise KeyError("This DataRecord does not hold items")
                 try:
@@ -767,17 +767,17 @@ class DataRecord(Dataset):
                 except TypeError:
                     raise TypeError("item_id must be a list or a 1-D array")
                 try:
-                    self["item_id"].values[item_id]
+                    self.dataset["item_id"].values[item_id]
                 except IndexError:
                     raise IndexError(
                         "The item_id you passed does not exist " "in this DataRecord"
                     )
 
-                return self.isel(item_id=item_id)[data_variable].values
+                return self.dataset.isel(item_id=item_id)[data_variable].values
 
         else:  # time is not None
             try:
-                self["time"]
+                self.dataset["time"]
             except KeyError:
                 raise KeyError("This DataRecord does not record time")
             try:
@@ -794,10 +794,10 @@ class DataRecord(Dataset):
                     " coordinate using the add_record method"
                 )
             if item_id is None:
-                return self.isel(time=time_index)[data_variable].values
+                return self.dataset.isel(time=time_index)[data_variable].values
             else:
                 try:
-                    self["item_id"]
+                    self.dataset["item_id"]
                 except KeyError:
                     raise KeyError("This DataRecord does not hold items")
                 try:
@@ -805,12 +805,12 @@ class DataRecord(Dataset):
                 except TypeError:
                     raise TypeError("item_id must be a list or a 1-D array")
                 try:
-                    self["item_id"].values[item_id]
+                    self.dataset["item_id"].values[item_id]
                 except IndexError:
                     raise IndexError(
                         "The item_id you passed does not exist " "in this DataRecord"
                     )
-                return self.isel(time=time_index, item_id=item_id)[data_variable].values
+                return self.dataset.isel(time=time_index, item_id=item_id)[data_variable].values
 
     def set_data(self, time=None, item_id=None, data_variable=None, new_value=np.nan):
         """Set a variable value at a model time and/or an item to a new value.
@@ -852,13 +852,13 @@ class DataRecord(Dataset):
         ...                  time=[50.],
         ...                  items=my_items4,
         ...                  data_vars=my_data4)
-        >>> dr4['item_size'].values
+        >>> dr4.dataset['item_size'].values
         array([[ 0.3],
                [ 0.4],
                [ 0.8],
                [ 0.4]])
         >>> dr4.set_data([50.],[2],'item_size', [0.5])
-        >>> dr4['item_size'].values
+        >>> dr4.dataset['item_size'].values
         array([[ 0.3],
                [ 0.4],
                [ 0.5],
@@ -904,7 +904,7 @@ class DataRecord(Dataset):
                 )
 
         if time is None:
-            self[data_variable].values[item_id] = new_value
+            self.dataset[data_variable].values[item_id] = new_value
         else:
             try:
                 len(time)
@@ -912,7 +912,7 @@ class DataRecord(Dataset):
                 raise TypeError("time must be a list or a 1-d array")
             try:
                 # check that time coordinate already exists
-                time_index = np.where(self.time.values == time)[0][0]
+                time_index = np.where(self.dataset.time.values == time)[0][0]
             except IndexError:
                 raise IndexError(
                     "The time you passed is not currently"
@@ -922,15 +922,15 @@ class DataRecord(Dataset):
                 )
 
             if item_id is None:
-                self[data_variable].values[time_index] = new_value
+                self.dataset[data_variable].values[time_index] = new_value
             else:
                 try:
                     len(item_id)
                 except TypeError:
                     raise TypeError("item_id must be a list or a 1-d array")
                 try:
-                    self["item_id"]
-                    self[data_variable].values[item_id, time_index] = new_value
+                    self.dataset["item_id"]
+                    self.dataset[data_variable].values[item_id, time_index] = new_value
                 except KeyError:
                     raise KeyError("This DataRecord does not hold items")
 
@@ -993,7 +993,7 @@ class DataRecord(Dataset):
 
         For example, if we wanted to aggregate volume for items with an age
         greater than 10 we would to the following:
-        >>> f = dr['ages'] > 10.
+        >>> f = dr.dataset['ages'] > 10.
         >>> v_f = dr.calc_aggregate_value(func=np.sum,
         ...                               data_variable='volumes',
         ...                               filter_array=f)
@@ -1012,7 +1012,7 @@ class DataRecord(Dataset):
         #        >>> print(s)
         #        [ 10.75  14.    15.    16.     8.    10.      nan    nan    nan]
 
-        filter_at = self["grid_element"] == at
+        filter_at = self.dataset["grid_element"] == at
 
         if filter_array is None:
             my_filter = filter_at
@@ -1020,7 +1020,7 @@ class DataRecord(Dataset):
             my_filter = filter_at & filter_array
 
         # Filter DataRecord with my_filter and groupby element_id:
-        filtered = self.where(my_filter).groupby("element_id")
+        filtered = self.dataset.where(my_filter).groupby("element_id")
 
         vals = filtered.apply(func, *args, **kwargs)  # .reduce
         #        vals = xr.apply_ufunc(func,
@@ -1071,20 +1071,20 @@ class DataRecord(Dataset):
         grid_element and element_id of the items has been filled with 'nan'
         for these time coordinates.
 
-        >>> dr3['grid_element'].values
+        >>> dr3.dataset['grid_element'].values
         array([['node', nan, nan],
                ['link', nan, nan]], dtype=object)
-        >>> dr3['element_id'].values
+        >>> dr3.dataset['element_id'].values
         array([[  1.,  nan,  nan],
                [  3.,  nan,  nan]])
 
         To fill these values with the last valid value, use the method
         ffill_grid_element_and_id:
         >>> dr3.ffill_grid_element_and_id()
-        >>> dr3['grid_element'].values
+        >>> dr3.dataset['grid_element'].values
         array([['node', 'node', 'node'],
                ['link', 'link', 'link']], dtype=object)
-        >>> dr3['element_id'].values
+        >>> dr3.dataset['element_id'].values
         array([[ 1.,  1.,  1.],
                [ 3.,  3.,  3.]])
 
@@ -1092,31 +1092,31 @@ class DataRecord(Dataset):
 
         # Forward fill element_id:
         fill_value = []
-        ei = self["element_id"].values
+        ei = self.dataset["element_id"].values
         for i in range(ei.shape[0]):
             for j in range(ei.shape[1]):
                 if np.isnan(ei[i, j]):
                     ei[i, j] = fill_value
                 else:
                     fill_value = ei[i, j]
-        self["element_id"] = (["item_id", "time"], ei)
+        self.dataset["element_id"] = (["item_id", "time"], ei)
         # Can't do ffill to grid_element because str/nan, so:
         fill_value = ""
-        ge = self["grid_element"].values
+        ge = self.dataset["grid_element"].values
         for i in range(ge.shape[0]):
             for j in range(ge.shape[1]):
                 if isinstance(ge[i, j], str):
                     fill_value = ge[i, j]
                 else:
                     ge[i, j] = fill_value
-        self["grid_element"] = (["item_id", "time"], ge)
+        self.dataset["grid_element"] = (["item_id", "time"], ge)
 
     @property
     def variable_names(self):
         """Return the name(s) of the data variable(s) in the record as a list.
         """
         _keys = []
-        for key in self.to_dataframe().keys():
+        for key in self.dataset.to_dataframe().keys():
             _keys.append(key)
         return _keys
 
@@ -1124,37 +1124,37 @@ class DataRecord(Dataset):
     def number_of_items(self):
         """Return the number of items in the DataRecord.
         """
-        return len(self.item_id)
+        return len(self.dataset.item_id)
 
     @property
     def item_coordinates(self):
         """Return a list of the item_id coordinates in the DataRecord.
         """
-        return self.item_id.values.tolist()
+        return self.dataset.item_id.values.tolist()
 
     @property
     def number_of_timesteps(self):
         """Return the number of time steps in the DataRecord.
         """
-        return len(self.time)
+        return len(self.dataset.time)
 
     @property
     def time_coordinates(self):
         """Return a list of the time coordinates in the DataRecord.
         """
-        return self.time.values.tolist()
+        return self.dataset.time.values.tolist()
 
     @property
     def earliest_time(self):
         """Return the earliest time coordinate in the DataRecord.
         """
-        return min(self.time.values)
+        return min(self.dataset.time.values)
 
     @property
     def latest_time(self):
         """Return the latest time coordinate in the DataRecord.
         """
-        return max(self.time.values)
+        return max(self.dataset.time.values)
 
     @property
     def prior_time(self):

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -791,7 +791,9 @@ class DataRecord(object):
                     raise IndexError(
                         "The item_id you passed does not exist " "in this DataRecord"
                     )
-                return self.dataset.isel(time=time_index, item_id=item_id)[data_variable].values
+                return self.dataset.isel(time=time_index, item_id=item_id)[
+                    data_variable
+                ].values
 
     def set_data(self, time=None, item_id=None, data_variable=None, new_value=np.nan):
         """Set a variable value at a model time and/or an item to a new value.
@@ -982,17 +984,6 @@ class DataRecord(object):
         array([  8.,   3.,   4.,   5.,  nan,  nan,  nan,  nan,  nan])
 
         """
-
-        #    (From ItemCollection:)
-        #        To add to Example, when I can make it work:
-        #        You can even pass functions that require additional positional
-        #        arguments or keyword arguments. For example, in order to get the 25th
-        #        percentile, we we do the following.
-        #
-        #        >>> s = ic.calc_aggregate_value(np.percentile, 'ages', q=25)
-        #        >>> print(s)
-        #        [ 10.75  14.    15.    16.     8.    10.      nan    nan    nan]
-
         filter_at = self.dataset["grid_element"] == at
 
         if filter_array is None:
@@ -1004,10 +995,6 @@ class DataRecord(object):
         filtered = self.dataset.where(my_filter).groupby("element_id")
 
         vals = filtered.apply(func, *args, **kwargs)  # .reduce
-        #        vals = xr.apply_ufunc(func,
-        #                            filtered,
-        #                            #input_core_dims=[['item_id']],
-        #                            **kwargs)
 
         # create a nan array that we will fill with the results of the sum
         # this should be the size of the number of elements, even if there are
@@ -1070,7 +1057,6 @@ class DataRecord(object):
                [ 3.,  3.,  3.]])
 
         """
-
         # Forward fill element_id:
         fill_value = []
         ei = self.dataset["element_id"].values

--- a/landlab/data_record/tests/test_data_record_2dim.py
+++ b/landlab/data_record/tests/test_data_record_2dim.py
@@ -34,8 +34,8 @@ def test_grid_shape(dr_2dim):
     assert dr_2dim._grid.number_of_node_columns == shape[1]
 
 
-def test_permitted_locations(dr_2dim):
-    assert dr_2dim.permitted_locations == grid.groups
+def test__permitted_locations(dr_2dim):
+    assert dr_2dim._permitted_locations == grid.groups
 
 
 def test_coordinates(dr_2dim):

--- a/landlab/data_record/tests/test_data_record_2dim.py
+++ b/landlab/data_record/tests/test_data_record_2dim.py
@@ -126,4 +126,6 @@ def test_ffill_grid_element_and_id(dr_2dim):
     assert dr_2dim.dataset["grid_element"].values[0, 0] == (
         dr_2dim.dataset["grid_element"].values[0, 1]
     )
-    assert dr_2dim.dataset["element_id"].values[0, 0] == (dr_2dim.dataset["element_id"].values[0, 1])
+    assert dr_2dim.dataset["element_id"].values[0, 0] == (
+        dr_2dim.dataset["element_id"].values[0, 1]
+    )

--- a/landlab/data_record/tests/test_data_record_2dim.py
+++ b/landlab/data_record/tests/test_data_record_2dim.py
@@ -39,10 +39,10 @@ def test_permitted_locations(dr_2dim):
 
 
 def test_coordinates(dr_2dim):
-    assert len(dr_2dim.dims) == 2
-    assert list(dr_2dim.time.values) == time
+    assert len(dr_2dim.dataset.dims) == 2
+    assert list(dr_2dim.dataset.time.values) == time
     assert list(dr_2dim.time_coordinates) == time
-    assert list(dr_2dim.item_id.values) == [0, 1]
+    assert list(dr_2dim.dataset.item_id.values) == [0, 1]
     assert list(dr_2dim.item_coordinates) == [0, 1]
     # properties:
     assert dr_2dim.number_of_timesteps == 1
@@ -73,16 +73,16 @@ def test_add_record(dr_2dim):
         time=[20.0], new_record={"mean_elevation": (["time"], np.array([130.0]))}
     )
     assert (
-        dr_2dim["grid_element"].values[1, 1],
-        dr_2dim["mean_elevation"].values[2],
+        dr_2dim.dataset["grid_element"].values[1, 1],
+        dr_2dim.dataset["mean_elevation"].values[2],
     ) == ("cell", 130.0)
-    assert np.isnan(dr_2dim["element_id"].values[1, 2])
+    assert np.isnan(dr_2dim.dataset["element_id"].values[1, 2])
     dr_2dim.add_record(
         time=[10.0],
         item_id=[1],
         new_record={"size": (["item_id", "time"], np.array([[0.3]]))},
     )
-    assert np.isnan(dr_2dim["size"].values[0, 0])
+    assert np.isnan(dr_2dim.dataset["size"].values[0, 0])
 
 
 def test_add_item(dr_2dim):
@@ -95,9 +95,9 @@ def test_add_item(dr_2dim):
         new_item_spec={"size": (["item_id"], [10, 5])},
     )
     assert (
-        dr_2dim["grid_element"].values[3, 1],
-        dr_2dim["element_id"].values[2, 1],
-        dr_2dim["size"].values[3],
+        dr_2dim.dataset["grid_element"].values[3, 1],
+        dr_2dim.dataset["element_id"].values[2, 1],
+        dr_2dim.dataset["size"].values[3],
     ) == ("cell", 2.0, 5.0)
 
 
@@ -114,8 +114,8 @@ def test_set_data(dr_2dim):
         time=[0.0], item_id=[1], data_variable="grid_element", new_value="node"
     )
     dr_2dim.set_data(time=[0.0], data_variable="mean_elevation", new_value=150.0)
-    assert all(dr_2dim["grid_element"].values == "node")
-    assert dr_2dim["mean_elevation"].values[0] == 150.0
+    assert all(dr_2dim.dataset["grid_element"].values == "node")
+    assert dr_2dim.dataset["mean_elevation"].values[0] == 150.0
 
 
 def test_ffill_grid_element_and_id(dr_2dim):
@@ -123,7 +123,7 @@ def test_ffill_grid_element_and_id(dr_2dim):
         time=[20.0], new_record={"mean_elevation": (["time"], np.array([130.0]))}
     )
     dr_2dim.ffill_grid_element_and_id()
-    assert dr_2dim["grid_element"].values[0, 0] == (
-        dr_2dim["grid_element"].values[0, 1]
+    assert dr_2dim.dataset["grid_element"].values[0, 0] == (
+        dr_2dim.dataset["grid_element"].values[0, 1]
     )
-    assert dr_2dim["element_id"].values[0, 0] == (dr_2dim["element_id"].values[0, 1])
+    assert dr_2dim.dataset["element_id"].values[0, 0] == (dr_2dim.dataset["element_id"].values[0, 1])

--- a/landlab/data_record/tests/test_data_record_item.py
+++ b/landlab/data_record/tests/test_data_record_item.py
@@ -34,12 +34,12 @@ def test_permitted_locations(dr_item):
 
 
 def test_coordinates(dr_item):
-    assert len(dr_item.dims) == 1
-    assert list(dr_item.item_id.values) == [0, 1]
+    assert len(dr_item.dataset.dims) == 1
+    assert list(dr_item.dataset.item_id.values) == [0, 1]
     assert list(dr_item.item_coordinates) == [0, 1]
     assert dr_item.number_of_items == len(my_items2["element_id"])
     with pytest.raises(AttributeError):
-        dr_item.time
+        dr_item.dataset.time
     with pytest.raises(AttributeError):
         dr_item.time_coordinates
     with pytest.raises(AttributeError):
@@ -65,9 +65,9 @@ def test_add_item(dr_item):
         new_item_spec={"size": (["item_id"], [10, 5])},
     )
     assert (
-        dr_item["grid_element"].values[3],
-        dr_item["element_id"].values[3],
-        dr_item["size"].values[3],
+        dr_item.dataset["grid_element"].values[3],
+        dr_item.dataset["element_id"].values[3],
+        dr_item.dataset["size"].values[3],
     ) == ("node", 4.0, 5.0)
 
 
@@ -78,4 +78,4 @@ def test_get_data(dr_item):
 
 def test_set_data(dr_item):
     dr_item.set_data(item_id=[1], data_variable="element_id", new_value=2)
-    assert dr_item["element_id"].values[1] == 2
+    assert dr_item.dataset["element_id"].values[1] == 2

--- a/landlab/data_record/tests/test_data_record_item.py
+++ b/landlab/data_record/tests/test_data_record_item.py
@@ -29,8 +29,8 @@ def test_grid_shape(dr_item):
     assert dr_item._grid.number_of_node_columns == shape[1]
 
 
-def test_permitted_locations(dr_item):
-    assert dr_item.permitted_locations == grid.groups
+def test__permitted_locations(dr_item):
+    assert dr_item._permitted_locations == grid.groups
 
 
 def test_coordinates(dr_item):

--- a/landlab/data_record/tests/test_data_record_time.py
+++ b/landlab/data_record/tests/test_data_record_time.py
@@ -28,8 +28,8 @@ def test_grid_shape(dr_time):
     assert dr_time._grid.number_of_node_columns == shape[1]
 
 
-def test_permitted_locations(dr_time):
-    assert dr_time.permitted_locations == grid.groups
+def test__permitted_locations(dr_time):
+    assert dr_time._permitted_locations == grid.groups
 
 
 def test_coordinates(dr_time):

--- a/landlab/data_record/tests/test_data_record_time.py
+++ b/landlab/data_record/tests/test_data_record_time.py
@@ -33,8 +33,8 @@ def test_permitted_locations(dr_time):
 
 
 def test_coordinates(dr_time):
-    assert len(dr_time.dims) == 1
-    assert list(dr_time.time.values) == list(np.array(time))
+    assert len(dr_time.dataset.dims) == 1
+    assert list(dr_time.dataset.time.values) == list(np.array(time))
     assert list(dr_time.time_coordinates) == list(np.array(time))
     # properties:
     assert dr_time.number_of_timesteps == 1
@@ -61,7 +61,7 @@ def test_add_record(dr_time):
     dr_time.add_record(
         time=[100.0], new_record={"new_variable": (["time"], ["new_data"])}
     )
-    assert np.isnan(dr_time["mean_elevation"].values[2])
+    assert np.isnan(dr_time.dataset["mean_elevation"].values[2])
 
 
 def test_get_data(dr_time):
@@ -71,4 +71,4 @@ def test_get_data(dr_time):
 
 def test_set_data(dr_time):
     dr_time.set_data(time=[0.0], data_variable="mean_elevation", new_value=105.0)
-    assert dr_time["mean_elevation"].values[0] == 105.0
+    assert dr_time.dataset["mean_elevation"].values[0] == 105.0

--- a/landlab/grid/tests/test_hex_grid/test_shape_dep_warning.py
+++ b/landlab/grid/tests/test_hex_grid/test_shape_dep_warning.py
@@ -17,7 +17,7 @@ def test_shape_dep_warning():
         # Trigger the deprecation warning.
         HexModelGrid(3, 2, shape="rect")
         # Verify some things
-        catmsg = ''
+        catmsg = ""
         for warn in w:
             catmsg += str(warn.message)
-        assert 'node_layout' in catmsg
+        assert "node_layout" in catmsg

--- a/landlab/grid/tests/test_raster_funcs/test_line_to_grid_coords.py
+++ b/landlab/grid/tests/test_raster_funcs/test_line_to_grid_coords.py
@@ -6,8 +6,9 @@ Created on Fri Jul 26 13:59:55 2019
 @author: gtucker
 """
 
-from landlab.grid.raster_funcs import line_to_grid_coords
 from numpy.testing import assert_array_equal
+
+from landlab.grid.raster_funcs import line_to_grid_coords
 
 
 def test_line_to_grid_coords():


### PR DESCRIPTION
As part of the discussion regarding #909, and other needs of @pfeiffea and I with regard to the network sediment transporter, I'm replacing the now closed #948 with two PRs. This is the first of them. 

It changes DataRecord to not inherit from an Xarray Dataset. 

@margauxmouchene what do you think? 

I believe this will minimally impact ClastTracker, but please correct me if I am mistaken. 
