### PR TITLE
fix: relax scipy version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         "netcdf4",
         "pyyaml",
         "pyshp",
-        "scipy<1.3",
+        "scipy",
         "six",
         "statsmodels",
         "xarray",


### PR DESCRIPTION
#932 identified that there was an issue between statsmodels and scipy. In response to that @mcflugen added the requirement [on this commit](https://github.com/landlab/landlab/commit/28ad18bd624608b905b0419e04136c4da10ff237). 

If this passes, CI then we can relax this requirement. 