### PR TITLE
Add tutorials stage to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,11 @@ jobs:
     - conda activate landlab_dev
     - pip install -e .
     script:
+    - pushd ../..
     - git clone https://github.com/landlab/tutorials.git landlab/tutorials
+    - pushd landlab/tutorials
     - git fetch origin release
     - git checkout -qf release
-    - pushd landlab/tutorials
     - pip install pytest
     - travis_wait 50 pytest -vvv
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,21 @@ env:
 sudo: false
 jobs:
   include:
+  - stage: tutorials
+    if: branch = release
+    os: linux
+    install:
+    - conda env create --file environment-dev.yml
+    - conda activate landlab_dev
+    - pip install -e .
+    script:
+    - git clone https://github.com/landlab/tutorials.git landlab/tutorials
+    - git fetch origin release
+    - git checkout -qf release
+    - pushd landlab/tutorials
+    - pip install pytest
+    - travis_wait 50 pytest -vvv
+
   - stage: lint
     os: linux
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ jobs:
     - pushd landlab/tutorials
     - git fetch origin release
     - git checkout -qf release
-    - pip install pytest
+    - conda install --file=requirements.txt
+    - conda install nbformat
     - travis_wait 50 pytest -vvv
 
   - stage: lint

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -117,14 +117,16 @@ class DataRecord(object):
         >>> dr1.dataset['mean_elevation'].values
         array([100])
 
-        >>> dr1.dataset.attrs
-        OrderedDict([('time_units', 'y')])
+        >>> list(dr1.dataset.attrs.items())
+        [('time_units', 'y')]
 
         Example of a DataRecord with item_id as the only dimension:
-        >>> my_items2 = {'grid_element': np.array(('node', 'link'), dtype=str),
-        ...              'element_id': np.array([1, 3])}
-        >>> dr2 = DataRecord(grid,
-        ...                  items=my_items2)
+
+        >>> my_items2 = {
+        ...     'grid_element': np.array(('node', 'link'), dtype=str),
+        ...     'element_id': np.array([1, 3]),
+        ... }
+        >>> dr2 = DataRecord(grid, items=my_items2)
 
         Note that both arrays (grid_element and element_id) have 1 dimension
         as they only vary along the dimension 'item_id'.
@@ -138,9 +140,7 @@ class DataRecord(object):
         Example of a DataRecord with dimensions time and item_id:
         >>> my_items3 = {'grid_element':np.array([['node'], ['link']]),
         ...              'element_id': np.array([[1], [3]])}
-        >>> dr3 = DataRecord(grid,
-        ...                  time=[0.],
-        ...                  items=my_items3)
+        >>> dr3 = DataRecord(grid, time=[0.], items=my_items3)
 
         Note that both arrays have 2 dimensions as they vary along dimensions
         'time' and 'item_id'.


### PR DESCRIPTION
As discussed in the call this afternoon, we presently don't verify that code that will go into a release version of landlab works against the release version of the tutorials repo. 

This PR (which aims to pull into `release` intentionally) is to fix that. 

The travis script will probably need some fixing... but its probably pretty close to right. 

As written it makes a tutorials stage on the **continuous-integration/travis-ci/pr** CI builds. 
