### PR TITLE
Change noclobber keyword to clobber

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,7 @@ build: false
 
 test_script:
   - "%WITH_COMPILER% pip install numpy"
+  - "%WITH_COMPILER% pip install netcdf4==1.5.2"
   - "%WITH_COMPILER% pip install -e ."
   - pytest -vvv
 

--- a/docs/source/user_guide/grid.rst
+++ b/docs/source/user_guide/grid.rst
@@ -196,13 +196,18 @@ There are currently no data values (fields) assigned to the links, as shown by t
 It is also possible, and indeed, often quite useful, to initialize a field from an
 existing NumPy array of data. You can do this with the
 :py:func:`add_field <landlab.field.grouped.ModelDataFields.add_field>` method.
-This method allows slightly more granular control over how the field gets created. In addition to the grid element and field name, this method takes an array of values to assign to the field. Optional arguments include: ``units=`` to assign a unit of measurement (as a string) to the value, ``copy=`` a boolean to determine whether to make a copy of the data, and ``noclobber=`` a boolean that prevents accidentally overwriting an existing field.
+This method allows slightly more granular control over how the field gets
+created. In addition to the grid element and field name, this method takes an
+array of values to assign to the field. Optional arguments include: ``units=``
+to assign a unit of measurement (as a string) to the value, ``copy=`` a boolean
+to determine whether to make a copy of the data, and ``clobber=`` a boolean
+that prevents accidentally overwriting an existing field.
 
 .. code-block:: python
 
     import numpy as np
     elevs_in = np.random.rand(mg.number_of_nodes)
-    mg.add_field('node', 'elevation', elevs_in, units='m', copy=True, noclobber=True)
+    mg.add_field('node', 'elevation', elevs_in, units='m', copy=True, clobber=False)
 
 Fields can store data at nodes, cells, links, faces, patches, junctions, and corners (though the
 latter two or three are very rarely, if ever, used). The grid element you select is
@@ -273,9 +278,9 @@ The following gives an overview of the commands you can use to interact with the
 Field initialization
 ^^^^^^^^^^^^^^^^^^^^
 
-* ``grid.add_empty(group, name, units='-')``
-* ``grid.add_ones(group, name, units='-')``
-* ``grid.add_zeros(group, name, units='-')``
+* ``grid.add_empty(name, at="group", units='-')``
+* ``grid.add_ones(name, at="group", units='-')``
+* ``grid.add_zeros(name, at="group", units='-')``
 
 "group" is one of 'node', 'link', 'cell', 'face', 'corner', 'junction', 'patch'
 
@@ -287,7 +292,7 @@ Field initialization
 Field creation from existing data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* ``grid.add_field(group, name, value_array, units='-', copy=False, noclobber=False)``
+* ``grid.add_field(name, value_array, at="group", units='-', copy=False, clobber=True)``
 
 Arguments as above, plus:
 
@@ -295,7 +300,7 @@ Arguments as above, plus:
 
 "copy" (optional) if True adds a *copy* of value_array to the field; if False, creates a reference to value_array.
 
-"noclobber" (optional) if True, raises an exception if a field called name already exists.
+"clobber" (optional) if `False`, raises an exception if a field called name already exists.
 
 
 Field access

--- a/docs/source/user_guide/landlab_one_to_two.rst
+++ b/docs/source/user_guide/landlab_one_to_two.rst
@@ -32,6 +32,19 @@ Deprecation of some grid methods
 
 TODO List of these, including replacements if any.
 
+Changes to field creation
+-------------------------
+- no more `noclobber`, instead we have `clobber`
+
+Changes to Boundary Condition Flags
+-----------------------------------
+- no more use of unbound flags (e.g., `from landlab import CLOSED_NODE`)
+  now we use `Grid.BC_NODE_IS_CLOSED`.
+
+Changes to Field initialization
+-------------------------------
+- PUT HERE IF THIS HAPPENS
+
 Standardization and deprecation within the component library
 ------------------------------------------------------------
 
@@ -42,7 +55,6 @@ Standardization and deprecation within the component library
   erosion).
 - Removal of old deprecated methods such as (``erode``, ``diffuse``...)
 - Main method now either take ``dt`` or nothing.
-
 
 Some other functions/methods have been removed
 ----------------------------------------------

--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -78,7 +78,7 @@ class ChiFinder(Component):
     ...     use_true_dx=True,
     ...     reference_concavity=0.5,
     ...     reference_area=mg2.at_node['drainage_area'].max(),
-    ...     noclobber=False)
+    ...     clobber=True)
     >>> cf3.calculate_chi()
     >>> cf3.chi_indices.reshape(mg2.shape)  # doctest: +NORMALIZE_WHITESPACE
     array([[   0. ,   0.        ,   0.        ,   0. ,   0. ],
@@ -162,7 +162,7 @@ class ChiFinder(Component):
         min_drainage_area=1.0e6,
         reference_area=1.0,
         use_true_dx=False,
-        noclobber=True,
+        clobber=False,
     ):
         """
         Parameters
@@ -182,7 +182,7 @@ class ChiFinder(Component):
             spacing along the channel (which can lead to a quantization effect,
             and is not preferred by Taylor & Royden). If False, the mean value of
             node spacing along the all channels is assumed everywhere.
-        noclobber : bool (default True)
+        clobber : bool (default False)
             Raise an exception if adding an already existing field.
 
         """
@@ -210,7 +210,7 @@ class ChiFinder(Component):
 
         self._use_true_dx = use_true_dx
         self._chi = self._grid.add_zeros(
-            "node", "channel__chi_index", noclobber=noclobber
+            "node", "channel__chi_index", clobber=clobber
         )
         self._mask = self._grid.ones("node", dtype=bool)
         self._elev = self._grid.at_node["topographic__elevation"]

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -244,10 +244,10 @@ class DepressionFinderAndRouter(Component):
         # Note that we initialize depression
         # outlet ID to LOCAL_BAD_INDEX_VALUE (which is a major clue!)
         self._depression_depth = self._grid.add_zeros(
-            "node", "depression__depth", noclobber=False
+            "node", "depression__depth", clobber=True
         )
         self._depression_outlet_map = self._grid.add_zeros(
-            "node", "depression__outlet_node", dtype=int, noclobber=False
+            "node", "depression__outlet_node", dtype=int, clobber=True
         )
         self._depression_outlet_map += LOCAL_BAD_INDEX_VALUE
 
@@ -261,10 +261,10 @@ class DepressionFinderAndRouter(Component):
         # ^note this is nlakes-long
 
         self._is_pit = self._grid.add_ones(
-            "node", "is_pit", dtype=bool, noclobber=False
+            "node", "is_pit", dtype=bool, clobber=True
         )
         self._flood_status = self._grid.add_zeros(
-            "node", "flood_status_code", dtype=int, noclobber=False
+            "node", "flood_status_code", dtype=int, clobber=True
         )
         self._lake_map = np.empty(self._grid.number_of_nodes, dtype=int)
         self._lake_map.fill(LOCAL_BAD_INDEX_VALUE)

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -236,14 +236,14 @@ class LinearDiffuser(Component):
             qs = self._grid.zeros(at="link")
             try:
                 self._g = self._grid.add_field(
-                    "link", "topographic__gradient", g, noclobber=True
+                    "topographic__gradient", g, at="link", clobber=False
                 )
                 # ^note this will object if this exists already
             except FieldError:  # keep a ref
                 self._g = self._grid.at_link["topographic__gradient"]
             try:
                 self._qs = self._grid.add_field(
-                    "link", "hillslope_sediment__unit_volume_flux", qs, noclobber=True
+                    "hillslope_sediment__unit_volume_flux", qs, at="link", clobber=False
                 )
             except FieldError:
                 self._qs = self._grid.at_link["hillslope_sediment__unit_volume_flux"]

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -238,7 +238,7 @@ class FlowAccumulator(Component):
     ...        'node',
     ...        'water__unit_flux_in',
     ...        runoff_rate,
-    ...        noclobber=False
+    ...        clobber=True,
     ... )
     >>> fa.run_one_step()
     >>> mg.at_node['surface_water__discharge'] # doctest: +NORMALIZE_WHITESPACE

--- a/landlab/components/flow_accum/lossy_flow_accumulator.py
+++ b/landlab/components/flow_accum/lossy_flow_accumulator.py
@@ -351,7 +351,7 @@ class LossyFlowAccumulator(FlowAccumulator):
         # add the new loss discharge field if necessary:
         if "surface_water__discharge_loss" not in grid.at_node:
             grid.add_zeros(
-                "node", "surface_water__discharge_loss", dtype=float, noclobber=False
+                "node", "surface_water__discharge_loss", dtype=float, clobber=True
             )
 
         super(LossyFlowAccumulator, self).__init__(

--- a/landlab/components/flow_director/flow_director.py
+++ b/landlab/components/flow_director/flow_director.py
@@ -93,7 +93,7 @@ class _FlowDirector(Component):
         self._surface = surface
         self._surface_values = return_array_at_node(grid, surface)
 
-        grid.add_zeros("flow__sink_flag", at="node", dtype=bool, noclobber=False)
+        grid.add_zeros("flow__sink_flag", at="node", dtype=bool, clobber=True)
 
     @property
     def surface_values(self):

--- a/landlab/components/gflex/flexure.py
+++ b/landlab/components/gflex/flexure.py
@@ -232,7 +232,7 @@ class gFlex(Component):
             "lithosphere_surface__elevation_increment",
             at="node",
             dtype=float,
-            noclobber=False,
+            clobber=True,
         )
 
     def flex_lithosphere(self):

--- a/landlab/components/lateral_erosion/lateral_erosion.py
+++ b/landlab/components/lateral_erosion/lateral_erosion.py
@@ -347,7 +347,7 @@ class LateralEroder(Component):
         self._Klr = float(Kl_ratio)  # default ratio of Kv/Kl is 1. Can be overwritten
 
         self._dzdt = grid.add_zeros(
-            "dzdt", at="node", noclobber=False
+            "dzdt", at="node", clobber=True
         )  # elevation change rate (M/Y)
         # optional inputs
         self._inlet_on = inlet_on
@@ -359,7 +359,7 @@ class LateralEroder(Component):
             # Change the runoff at the inlet node to node area + inlet node
             runoffinlet[inlet_node] += inlet_area
             grid.add_field(
-                "water__unit_flux_in", runoffinlet, at="node", noclobber=False
+                "water__unit_flux_in", runoffinlet, at="node", clobber=True
             )
             # set qsinlet at inlet node. This doesn't have to be provided, defaults
             # to 0.
@@ -398,8 +398,8 @@ class LateralEroder(Component):
         Kl = Kv * Klr
         z = grid.at_node["topographic__elevation"]
         # clear qsin for next loop
-        qs_in = grid.add_zeros("node", "sediment__flux", noclobber=False)
-        qs = grid.add_zeros("node", "qs", noclobber=False)
+        qs_in = grid.add_zeros("node", "sediment__flux", clobber=True)
+        qs = grid.add_zeros("node", "qs", clobber=True)
         lat_nodes = np.zeros(grid.number_of_nodes, dtype=int)
         dzver = np.zeros(grid.number_of_nodes)
         vol_lat_dt = np.zeros(grid.number_of_nodes)
@@ -519,8 +519,8 @@ class LateralEroder(Component):
         Kl = Kv * Klr
         z = grid.at_node["topographic__elevation"]
         # clear qsin for next loop
-        qs_in = grid.add_zeros("node", "sediment__flux", noclobber=False)
-        qs = grid.add_zeros("node", "qs", noclobber=False)
+        qs_in = grid.add_zeros("node", "sediment__flux", clobber=True)
+        qs = grid.add_zeros("node", "qs", clobber=True)
         lat_nodes = np.zeros(grid.number_of_nodes, dtype=int)
         dzver = np.zeros(grid.number_of_nodes)
         vol_lat_dt = np.zeros(grid.number_of_nodes)

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -147,7 +147,7 @@ class SinkFiller(Component):
 
         # create the only new output field:
         self._sed_fill_depth = self._grid.add_zeros(
-            "node", "sediment_fill__depth", noclobber=False
+            "node", "sediment_fill__depth", clobber=True
         )
 
         self._lf = DepressionFinderAndRouter(

--- a/landlab/components/sink_fill/sink_fill_barnes.py
+++ b/landlab/components/sink_fill/sink_fill_barnes.py
@@ -112,7 +112,7 @@ class SinkFillerBarnes(LakeMapperBarnes):
         self._supplied_surface = return_array_at_node(grid, surface).copy()
         # create the only new output field:
         self._sed_fill_depth = self._grid.add_zeros(
-            "node", "sediment_fill__depth", noclobber=False
+            "node", "sediment_fill__depth", clobber=True
         )
 
     def run_one_step(self):

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -168,7 +168,7 @@ class SteepnessFinder(Component):
         self._elev_step = elev_step
         self._discretization = discretization_length
         self._ksn = self._grid.add_zeros(
-            "node", "channel__steepness_index", noclobber=False
+            "node", "channel__steepness_index", clobber=True
         )
         self._mask = self._grid.ones("node", dtype=bool)
         # this one needs modifying if smooth_elev

--- a/landlab/field/graph_field.py
+++ b/landlab/field/graph_field.py
@@ -959,7 +959,7 @@ class GraphFields(object):
 
     def add_field(self, *args, **kwds):
         """add_field(name, value_array, at='node', units='-', copy=False,
-        noclobber=True)
+        clobber=False)
 
         Add an array of values to the field.
 
@@ -984,7 +984,7 @@ class GraphFields(object):
         copy : boolean, optional
             If True, add a *copy* of the array to the field. Otherwise save add
             a reference to the array.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -1017,16 +1017,18 @@ class GraphFields(object):
 
         If you want to save a copy of the array, use the *copy* keyword. In
         addition, adding values to an existing field will remove the reference
-        to the previously saved array. The *noclobber* keyword changes this
+        to the previously saved array. The *clobber=False* keyword changes this
         behavior to raise an exception in such a case.
 
-        >>> field.add_field('node', 'topographic__elevation', values,
-        ...     copy=True, noclobber=False)
+        >>> field.add_field(
+        ...     "topographic__elevation", values, at="node", copy=True, clobber=True
+        ... )
         array([1, 1, 1, 1])
         >>> field.at_node['topographic__elevation'] is values
         False
-        >>> field.add_field('node', 'topographic__elevation', values,
-        ...     noclobber=True) # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> field.add_field(
+        ...     "topographic__elevation", values, at="node", clobber=False
+        ... ) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         FieldError: topographic__elevation
 
@@ -1041,7 +1043,7 @@ class GraphFields(object):
 
         units = kwds.get("units", "?")
         copy = kwds.get("copy", False)
-        noclobber = kwds.get("noclobber", True)
+        clobber = kwds.get("clobber", False)
         value_array = np.asarray(value_array)
 
         at = at or self.default_group
@@ -1056,7 +1058,7 @@ class GraphFields(object):
 
         ds = getattr(self, "at_" + at)
 
-        if noclobber and name in ds:
+        if not clobber and name in ds:
             raise FieldError("{name}@{at}".format(name=name, at=at))
 
         dims = (at,)
@@ -1091,7 +1093,7 @@ class GraphFields(object):
         ds._ds = ds._ds.drop(name)
 
     def add_empty(self, *args, **kwds):
-        """add_empty(name, at='node', units='-', noclobber=True)
+        """add_empty(name, at='node', units='-', clobber=False)
 
         Create and add an uninitialized array of values to the field.
 
@@ -1111,7 +1113,7 @@ class GraphFields(object):
             assumed to be on `node`.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -1137,18 +1139,18 @@ class GraphFields(object):
             raise ValueError("number of arguments must be 1 or 2")
         units = kwds.pop("units", "?")
         copy = kwds.pop("copy", False)
-        noclobber = kwds.pop("noclobber", True)
+        clobber = kwds.pop("clobber", False)
         return self.add_field(
             name,
             self.empty(at=loc, **kwds),
             at=loc,
             units=units,
             copy=copy,
-            noclobber=noclobber,
+            clobber=clobber,
         )
 
     def add_ones(self, *args, **kwds):
-        """add_ones(name, at='node', units='-', noclobber=True)
+        """add_ones(name, at='node', units='-', clobber=False)
 
         Create and add an array of values, initialized to 1, to the field.
 
@@ -1168,7 +1170,7 @@ class GraphFields(object):
             assumed to be on `node`.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -1207,7 +1209,7 @@ class GraphFields(object):
         return data
 
     def add_zeros(self, *args, **kwds):
-        """add_zeros(name, at='node', units='-', noclobber=True)
+        """add_zeros(name, at='node', units='-', clobber=False)
 
         Create and add an array of values, initialized to 0, to the field.
 
@@ -1225,7 +1227,7 @@ class GraphFields(object):
             assumed to be on `node`.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -1264,7 +1266,7 @@ class GraphFields(object):
         copy : boolean, optional
             If True, add a *copy* of the array to the field. Otherwise save add
             a reference to the array.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -134,12 +134,12 @@ class ModelDataFields(object):
         >>> fields = ModelDataFields()
         >>> fields.new_field_location('node', 12)
 
-        >>> fields.add_field('z', [1.] * 12)
+        >>> fields.add_field("z", [1.] * 12)
         ...     # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ValueError: missing group name
         >>> fields.set_default_group('node')
-        >>> _ = fields.add_field('z', [1.] * 12)
+        >>> _ = fields.add_field("z", [1.] * 12)
         >>> 'z' in fields.at_node
         True
         """
@@ -634,7 +634,7 @@ class ModelDataFields(object):
         return self[group].zeros(**kwds)
 
     def add_empty(self, *args, **kwds):
-        """add_empty(group, name, units='-', noclobber=True)
+        """add_empty(group, name, units='-', clobber=False)
 
         Create and add an uninitialized array of values to the field.
 
@@ -653,7 +653,7 @@ class ModelDataFields(object):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -686,12 +686,12 @@ class ModelDataFields(object):
             )
 
         numpy_kwds = kwds.copy()
-        numpy_kwds.pop("units", 0.0)
-        numpy_kwds.pop("noclobber", 0.0)
+        numpy_kwds.pop("units", None)
+        numpy_kwds.pop("clobber", None)
         return self.add_field(group, name, self.empty(group, **numpy_kwds), **kwds)
 
     def add_ones(self, *args, **kwds):
-        """add_ones(group, name, units='-', noclobber=True)
+        """add_ones(group, name, units='-', clobber=False)
 
         Create and add an array of values, initialized to 1, to the field.
 
@@ -710,7 +710,7 @@ class ModelDataFields(object):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -759,12 +759,12 @@ class ModelDataFields(object):
             )
 
         numpy_kwds = kwds.copy()
-        numpy_kwds.pop("units", 0.0)
-        numpy_kwds.pop("noclobber", 0.0)
+        numpy_kwds.pop("units", None)
+        numpy_kwds.pop("clobber", None)
         return self.add_field(group, name, self.ones(group, **numpy_kwds), **kwds)
 
     def add_zeros(self, *args, **kwds):
-        """add_zeros(group, name, units='-', noclobber=True)
+        """add_zeros(group, name, units='-', clobber=False)
 
         Create and add an array of values, initialized to 0, to the field.
 
@@ -781,7 +781,7 @@ class ModelDataFields(object):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -814,13 +814,12 @@ class ModelDataFields(object):
             )
 
         numpy_kwds = kwds.copy()
-        numpy_kwds.pop("units", 0.0)
-        numpy_kwds.pop("noclobber", 0.0)
+        numpy_kwds.pop("units", None)
+        numpy_kwds.pop("clobber", None)
         return self.add_field(group, name, self.zeros(group, **numpy_kwds), **kwds)
 
     def add_field(self, *args, **kwds):
-        """add_field(group, name, value_array, units='-', copy=False,
-        noclobber=True)
+        """add_field(group, name, value_array, units='-', copy=False, clobber=False)
 
         Add an array of values to the field.
 
@@ -844,7 +843,7 @@ class ModelDataFields(object):
         copy : boolean, optional
             If True, add a *copy* of the array to the field. Otherwise save add
             a reference to the array.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -866,7 +865,7 @@ class ModelDataFields(object):
         >>> field = ModelDataFields()
         >>> field.new_field_location('node', 4)
         >>> values = np.ones(4, dtype=int)
-        >>> field.add_field('node', 'topographic__elevation', values)
+        >>> field.add_field("topographic__elevation", values, at="node")
         array([1, 1, 1, 1])
 
         A new field is added to the collection of fields. The saved value
@@ -877,16 +876,18 @@ class ModelDataFields(object):
 
         If you want to save a copy of the array, use the *copy* keyword. In
         addition, adding values to an existing field will remove the reference
-        to the previously saved array. The *noclobber* keyword changes this
+        to the previously saved array. The *clobber=False* keyword changes this
         behavior to raise an exception in such a case.
 
-        >>> field.add_field('node', 'topographic__elevation', values,
-        ...     copy=True, noclobber=False)
+        >>> field.add_field(
+        ...     "topographic__elevation", values, at="node", copy=True, clobber=True
+        ... )
         array([1, 1, 1, 1])
         >>> field.at_node['topographic__elevation'] is values
         False
-        >>> field.add_field('node', 'topographic__elevation', values,
-        ...     noclobber=True) # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> field.add_field(
+        ...     "topographic__elevation", values, at="node", clobber=False
+        ... ) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         FieldError: topographic__elevation
 

--- a/landlab/field/scalar_data_fields.py
+++ b/landlab/field/scalar_data_fields.py
@@ -258,7 +258,7 @@ class ScalarDataFields(dict):
         """
         return np.zeros(self.size, **kwds)
 
-    def add_empty(self, name, units=_UNKNOWN_UNITS, noclobber=True, **kwds):
+    def add_empty(self, name, units=_UNKNOWN_UNITS, clobber=False, **kwds):
         """Create and add an uninitialized array of values to the field.
 
         Create a new array of the data field size, without initializing
@@ -272,7 +272,7 @@ class ScalarDataFields(dict):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -291,10 +291,10 @@ class ScalarDataFields(dict):
         LLCATS: FIELDCR
         """
         return self.add_field(
-            name, self.empty(**kwds), units=units, noclobber=noclobber
+            name, self.empty(**kwds), units=units, clobber=clobber
         )
 
-    def add_ones(self, name, units=_UNKNOWN_UNITS, noclobber=True, **kwds):
+    def add_ones(self, name, units=_UNKNOWN_UNITS, clobber=False, **kwds):
         """Create and add an array of values, initialized to 1, to the field.
 
         Create a new array of the data field size, filled with ones, and
@@ -308,7 +308,7 @@ class ScalarDataFields(dict):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -339,9 +339,9 @@ class ScalarDataFields(dict):
 
         LLCATS: FIELDCR
         """
-        return self.add_field(name, self.ones(**kwds), units=units, noclobber=noclobber)
+        return self.add_field(name, self.ones(**kwds), units=units, clobber=clobber)
 
-    def add_zeros(self, name, units=_UNKNOWN_UNITS, noclobber=True, **kwds):
+    def add_zeros(self, name, units=_UNKNOWN_UNITS, clobber=False, **kwds):
         """Create and add an array of values, initialized to 0, to the field.
 
         Create a new array of the data field size, filled with zeros, and
@@ -355,7 +355,7 @@ class ScalarDataFields(dict):
             Name of the new field to add.
         units : str, optional
             Optionally specify the units of the field.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -374,7 +374,7 @@ class ScalarDataFields(dict):
         LLCATS: FIELDCR
         """
         return self.add_field(
-            name, self.zeros(**kwds), units=units, noclobber=noclobber
+            name, self.zeros(**kwds), units=units, clobber=clobber
         )
 
     def add_field(
@@ -383,7 +383,7 @@ class ScalarDataFields(dict):
         value_array,
         units=_UNKNOWN_UNITS,
         copy=False,
-        noclobber=True,
+        clobber=False,
         **kwds
     ):
         """Add an array of values to the field.
@@ -403,7 +403,7 @@ class ScalarDataFields(dict):
         copy : boolean, optional
             If True, add a *copy* of the array to the field. Otherwise save add
             a reference to the array.
-        noclobber : boolean, optional
+        clobber : boolean, optional
             Raise an exception if adding to an already existing field.
 
         Returns
@@ -435,22 +435,23 @@ class ScalarDataFields(dict):
 
         If you want to save a copy of the array, use the *copy* keyword. In
         addition, adding values to an existing field will remove the reference
-        to the previously saved array. The *noclobber* keyword changes this
+        to the previously saved array. The *clobber=False* keyword changes this
         behavior to raise an exception in such a case.
 
-        >>> field.add_field('topographic__elevation', values, copy=True,
-        ...                 noclobber=False)
+        >>> field.add_field(
+        ...     "topographic__elevation", values, copy=True, clobber=True
+        ... )
         array([1, 1, 1, 1])
         >>> field['topographic__elevation'] is values
         False
-        >>> field.add_field('topographic__elevation', values, noclobber=True)
+        >>> field.add_field('topographic__elevation', values, clobber=False)
         ...     # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         FieldError: topographic__elevation already exists
 
         LLCATS: FIELDCR
         """
-        if noclobber and name in self:
+        if not clobber and name in self:
             raise FieldError("{name}: already exists".format(name=name))
 
         value_array = np.asarray(value_array)

--- a/landlab/grid/divergence.py
+++ b/landlab/grid/divergence.py
@@ -200,7 +200,7 @@ def calc_net_flux_at_node(grid, unit_flux_at_links, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> lg = hg.calc_grad_at_link(z)  # there are ? links
@@ -275,7 +275,7 @@ def _calc_net_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> lg = hg.calc_grad_at_link(z)
@@ -391,7 +391,7 @@ def _calc_net_active_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> fg = hg.calc_grad_at_link(z)[hg.link_at_face]  # there are 11 faces
@@ -515,7 +515,7 @@ def _calc_net_active_link_flux_at_node(grid, unit_flux_at_links, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> lg = hg.calc_grad_at_link(z)  # there are ? links
@@ -645,7 +645,7 @@ def _calc_net_face_flux_at_node(grid, unit_flux_at_faces, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> fg = hg.calc_grad_at_link(z)[hg.link_at_face]  # there are 11 faces
@@ -713,7 +713,7 @@ def _calc_net_active_face_flux_at_node(grid, unit_flux_at_faces, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> fg = hg.calc_grad_at_link(z)[hg.link_at_face]  # there are 11 faces

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -53,7 +53,7 @@ def calc_grad_at_link(grid, node_values, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> calc_grad_at_link(hg, z)  # there are 11 faces
@@ -167,7 +167,7 @@ def calculate_gradients_at_faces(grid, node_values, out=None):
 
     >>> from landlab import HexModelGrid
     >>> hg = HexModelGrid((3, 3), spacing=10.0)
-    >>> z = hg.add_zeros('node', 'topographic__elevation', noclobber=False)
+    >>> z = hg.add_zeros("topographic__elevation", at="node", clobber=True)
     >>> z[4] = 50.0
     >>> z[5] = 36.0
     >>> calculate_gradients_at_faces(hg, z)  # there are 11 faces

--- a/landlab/io/netcdf/read.py
+++ b/landlab/io/netcdf/read.py
@@ -399,7 +399,7 @@ def read_netcdf(
                 add_field = False
 
             if add_field:
-                grid.add_field(field_name, values, at="node", noclobber=False)
+                grid.add_field(field_name, values, at="node", clobber=True)
 
         if (name is not None) and (name not in grid.at_node):
             raise ValueError(

--- a/landlab/utils/distance_to_divide.py
+++ b/landlab/utils/distance_to_divide.py
@@ -6,7 +6,7 @@ from landlab import BAD_INDEX_VALUE, FieldError, RasterModelGrid
 
 
 def calculate_distance_to_divide(
-    grid, longest_path=True, add_to_grid=False, noclobber=True
+    grid, longest_path=True, add_to_grid=False, clobber=False
 ):
     """Calculate the along flow distance from drainage divide to point.
 
@@ -23,9 +23,9 @@ def calculate_distance_to_divide(
     add_to_grid : boolean, optional
         Flag to indicate if the stream length field should be added to the
         grid. Default is False. The field name used is ``distance_to_divide``.
-    noclobber : boolean, optional
+    clobber : boolean, optional
         Flag to indicate if adding the field to the grid should not clobber an
-        existing field with the same name. Default is True.
+        existing field with the same name. Default is False.
 
     Returns
     -------
@@ -57,7 +57,8 @@ def calculate_distance_to_divide(
     >>> distance_to_divide = calculate_distance_to_divide(
     ...     mg,
     ...     add_to_grid=True,
-    ...     noclobber=False)
+    ...     clobber=True,
+    ... )
     >>> mg.at_node['distance_to_divide']
     array([ 0.,  3.,  3.,  0.,
             0.,  2.,  2.,  0.,
@@ -89,7 +90,8 @@ def calculate_distance_to_divide(
     >>> distance_to_divide = calculate_distance_to_divide(
     ...     mg,
     ...     add_to_grid=True,
-    ...     noclobber=False)
+    ...     clobber=True,
+    ... )
     >>> mg.at_node['distance_to_divide']
     array([ 0.,  3.,  3.,  0.,
             0.,  2.,  2.,  0.,
@@ -117,7 +119,8 @@ def calculate_distance_to_divide(
     >>> distance_to_divide = calculate_distance_to_divide(
     ...     hmg,
     ...     add_to_grid=True,
-    ...     noclobber=False)
+    ...     clobber=True,
+    ... )
     >>> hmg.at_node['distance_to_divide']
     array([ 3.,  0.,  0.,
          0.,  2.,  1.,  0.,
@@ -227,7 +230,7 @@ def calculate_distance_to_divide(
     # store on the grid
     if add_to_grid:
         grid.add_field(
-            "node", "distance_to_divide", distance_to_divide, noclobber=noclobber
+            "distance_to_divide", distance_to_divide, at="node", clobber=clobber
         )
 
     return distance_to_divide

--- a/landlab/utils/flow__distance.py
+++ b/landlab/utils/flow__distance.py
@@ -5,7 +5,7 @@ import numpy as np
 from landlab import BAD_INDEX_VALUE, FieldError, RasterModelGrid
 
 
-def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
+def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
     """Calculate the along flow distance from node to outlet.
 
     This utility calculates the along flow distance based on the results of
@@ -18,9 +18,9 @@ def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
     add_to_grid : boolean, optional
         Flag to indicate if the stream length field should be added to the
         grid. Default is False. The field name used is ``flow__distance``.
-    noclobber : boolean, optional
+    clobber : boolean, optional
         Flag to indicate if adding the field to the grid should not clobber an
-        existing field with the same name. Default is True.
+        existing field with the same name. Default is False.
 
     Returns
     -------
@@ -46,7 +46,7 @@ def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
     ...                                        top_is_closed=True)
     >>> fr = FlowAccumulator(mg, flow_director = 'D8')
     >>> fr.run_one_step()
-    >>> flow__distance = calculate_flow__distance(mg, add_to_grid=True, noclobber=False)
+    >>> flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
     >>> mg.at_node['flow__distance']
     array([ 0.        ,  0.        ,  0.        ,  0.        ,
             0.        ,  1.        ,  0.        ,  0.        ,
@@ -73,8 +73,7 @@ def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
     ...                                        top_is_closed=True)
     >>> fr = FlowAccumulator(mg, flow_director = 'D4')
     >>> fr.run_one_step()
-    >>> flow__distance = calculate_flow__distance(mg, add_to_grid=True,
-    ...                                          noclobber=False)
+    >>> flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
     >>> mg.at_node['flow__distance']
     array([ 0.,  0.,  0.,  0.,
             0.,  1.,  0.,  0.,
@@ -98,9 +97,7 @@ def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
     >>> hmg.status_at_node[0] = hmg.BC_NODE_IS_FIXED_VALUE
     >>> fr = FlowAccumulator(hmg, flow_director = 'D4')
     >>> fr.run_one_step()
-    >>> flow__distance = calculate_flow__distance(hmg,
-    ...                                           add_to_grid=True,
-    ...                                           noclobber=False)
+    >>> flow__distance = calculate_flow__distance(hmg, add_to_grid=True, clobber=True)
     >>> hmg.at_node['flow__distance']
     array([ 0.,  0.,  0.,
             0.,  1.,  2.,  0.,
@@ -216,6 +213,6 @@ def calculate_flow__distance(grid, add_to_grid=False, noclobber=True):
 
     # store on the grid
     if add_to_grid:
-        grid.add_field("node", "flow__distance", flow__distance, noclobber=noclobber)
+        grid.add_field("flow__distance", flow__distance, at="node", clobber=clobber)
 
     return flow__distance

--- a/tests/field/test_graph_fields.py
+++ b/tests/field/test_graph_fields.py
@@ -93,32 +93,32 @@ def test_add_existing_field_default():
         fields.add_zeros("z", at="node")
 
 
-def test_add_existing_field_with_noclobber():
-    """Test noclobber raises an error with an existing field."""
+def test_add_existing_field_with_clobber_off():
+    """Test clobber raises an error with an existing field."""
     fields = ModelDataFields()
     fields.new_field_location("node", 12)
     fields.add_empty("z", at="node")
 
     with pytest.raises(FieldError):
-        fields.add_empty("z", at="node", noclobber=True)
+        fields.add_empty("z", at="node", clobber=False)
     with pytest.raises(FieldError):
-        fields.add_ones("z", at="node", noclobber=True)
+        fields.add_ones("z", at="node", clobber=False)
     with pytest.raises(FieldError):
-        fields.add_zeros("z", at="node", noclobber=True)
+        fields.add_zeros("z", at="node", clobber=False)
 
 
-def test_add_field_with_noclobber():
-    """Test noclobber does not raise an error with an new field."""
+def test_add_field_with_clobber_off():
+    """Test clobber does not raise an error with an new field."""
     fields = ModelDataFields()
     fields.new_field_location("node", 12)
 
-    fields.add_empty("a", at="node", noclobber=True)
+    fields.add_empty("a", at="node", clobber=False)
     assert "a" in fields["node"]
 
-    fields.add_ones("b", at="node", noclobber=True)
+    fields.add_ones("b", at="node", clobber=False)
     assert "b" in fields["node"]
 
-    fields.add_zeros("c", at="node", noclobber=True)
+    fields.add_zeros("c", at="node", clobber=False)
     assert "c" in fields["node"]
 
 
@@ -128,13 +128,13 @@ def test_add_field_with_clobber():
     fields.new_field_location("node", 12)
 
     assert fields.add_empty("a", at="node") is not fields.add_empty(
-        "a", at="node", noclobber=False
+        "a", at="node", clobber=True
     )
     assert fields.add_ones("b", at="node") is not fields.add_ones(
-        "b", at="node", noclobber=False
+        "b", at="node", clobber=True
     )
     assert fields.add_zeros("c", at="node") is not fields.add_zeros(
-        "c", at="node", noclobber=False
+        "c", at="node", clobber=True
     )
 
 

--- a/tests/field/test_grouped_fields.py
+++ b/tests/field/test_grouped_fields.py
@@ -89,32 +89,32 @@ def test_add_existing_field_default():
         fields.add_zeros("z", at="node")
 
 
-def test_add_existing_field_with_noclobber():
-    """Test noclobber raises an error with an existing field."""
+def test_add_existing_field_with_clobber_off():
+    """Test clobber raises an error with an existing field."""
     fields = ModelDataFields()
     fields.new_field_location("node", 12)
     fields.add_empty("z", at="node")
 
     with pytest.raises(FieldError):
-        fields.add_empty("z", at="node", noclobber=True)
+        fields.add_empty("z", at="node", clobber=False)
     with pytest.raises(FieldError):
-        fields.add_ones("z", at="node", noclobber=True)
+        fields.add_ones("z", at="node", clobber=False)
     with pytest.raises(FieldError):
-        fields.add_zeros("z", at="node", noclobber=True)
+        fields.add_zeros("z", at="node", clobber=False)
 
 
-def test_add_field_with_noclobber():
-    """Test noclobber does not raise an error with an new field."""
+def test_add_field_with_clobber_off():
+    """Test clobber does not raise an error with an new field."""
     fields = ModelDataFields()
     fields.new_field_location("node", 12)
 
-    fields.add_empty("a", at="node", noclobber=True)
+    fields.add_empty("a", at="node", clobber=False)
     assert "a" in fields["node"]
 
-    fields.add_ones("b", at="node", noclobber=True)
+    fields.add_ones("b", at="node", clobber=False)
     assert "b" in fields["node"]
 
-    fields.add_zeros("c", at="node", noclobber=True)
+    fields.add_zeros("c", at="node", clobber=False)
     assert "c" in fields["node"]
 
 
@@ -124,13 +124,13 @@ def test_add_field_with_clobber():
     fields.new_field_location("node", 12)
 
     assert fields.add_empty("a", at="node") is not fields.add_empty(
-        "a", at="node", noclobber=False
+        "a", at="node", clobber=True
     )
     assert fields.add_ones("b", at="node") is not fields.add_ones(
-        "b", at="node", noclobber=False
+        "b", at="node", clobber=True
     )
     assert fields.add_zeros("c", at="node") is not fields.add_zeros(
-        "c", at="node", noclobber=False
+        "c", at="node", clobber=True
     )
 
 

--- a/tests/utils/test_flow__distance.py
+++ b/tests/utils/test_flow__distance.py
@@ -97,7 +97,7 @@ def test_flow__distance_regular_grid_d8():
 
     # calculating flow distance map
 
-    flow__distance = calculate_flow__distance(mg, add_to_grid=True, noclobber=False)
+    flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
     flow__distance = np.reshape(
         flow__distance, mg.number_of_node_rows * mg.number_of_node_columns
     )
@@ -153,7 +153,7 @@ def test_flow__distance_regular_grid_d4():
 
     # calculating flow distance map
 
-    flow__distance = calculate_flow__distance(mg, add_to_grid=True, noclobber=False)
+    flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
     flow__distance = np.reshape(
         flow__distance, mg.number_of_node_rows * mg.number_of_node_columns
     )
@@ -214,7 +214,7 @@ def test_flow__distance_irregular_grid_d4():
 
     # calculating flow distance map
 
-    flow__distance = calculate_flow__distance(hmg, add_to_grid=True, noclobber=False)
+    flow__distance = calculate_flow__distance(hmg, add_to_grid=True, clobber=True)
 
     # test that the flow__distance utility works as expected
 
@@ -274,7 +274,7 @@ def test_flow__distance_raster_MFD_diagonals_true():
 
     # calculating flow distance map
 
-    flow__distance = calculate_flow__distance(mg, add_to_grid=True, noclobber=False)
+    flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
 
     # test that the flow__distance utility works as expected
 
@@ -328,7 +328,7 @@ def test_flow__distance_raster_MFD_diagonals_false():
 
     # calculating flow distance map
 
-    flow__distance = calculate_flow__distance(mg, add_to_grid=True, noclobber=False)
+    flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
 
     # test that the flow__distance utility works as expected
 
@@ -378,7 +378,7 @@ def test_flow__distance_raster_D_infinity():
     # calculating flow distance map
 
     flow__distance = calculate_flow__distance(
-        mg, add_to_grid=True, noclobber=False
+        mg, add_to_grid=True, clobber=True
     ).reshape(mg.shape)
 
     # test that the flow__distance utility works as expected


### PR DESCRIPTION
This pull request fixes #979 by changing the `noclobber` keyword to `clobber` for methods that add fields to a grid. The `noclobber` keyword was confusing when using the double negative,`noclobber=False`.