### PR TITLE
Fix bug in GroundwaterDupuitPercolator, add symmetry test

### DIFF
--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -83,7 +83,7 @@ class GroundwaterDupuitPercolator(Component):
 
     Initialize the grid and component
 
-    >>> grid = RasterModelGrid((10, 10), spacing=10.0)
+    >>> grid = RasterModelGrid((10, 10), xy_spacing=10.0)
     >>> elev = grid.add_zeros('node', 'topographic__elevation')
     >>> elev[:] = 5.0
     >>> gdp = GroundwaterDupuitPercolator(grid)
@@ -308,8 +308,13 @@ class GroundwaterDupuitPercolator(Component):
 
     @property
     def K(self):
-        """hydraulic conductivity (m/s)"""
+        """hydraulic conductivity at link (m/s)"""
         return self._K
+
+    @K.setter
+    def K(self,new_val):
+        """set hydraulic conductivity at link (m/s)"""
+        self._K = new_val
 
     @property
     def recharge(self):
@@ -318,6 +323,7 @@ class GroundwaterDupuitPercolator(Component):
 
     @recharge.setter
     def recharge(self, new_val):
+        """set recharge rate (m/s)"""
         self._recharge = new_val
 
     @property

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -8,12 +8,12 @@ GroundwaterDupuitPercolator Component
 import numpy as np
 
 from landlab import Component
+from landlab.grid.base import INACTIVE_LINK
 from landlab.grid.mappers import (
     map_max_of_node_links_to_node,
     map_mean_of_link_nodes_to_link,
     map_value_at_max_node_to_link,
 )
-from landlab.grid.base import INACTIVE_LINK
 from landlab.utils import return_array_at_link, return_array_at_node
 
 
@@ -471,14 +471,18 @@ class GroundwaterDupuitPercolator(Component):
         dqdx = self._grid.calc_flux_div_at_node(self._q)
 
         # Determine the relative aquifer thickness, 1 if permeable thickness is 0.
-        soil_present = self._elev-self._base > 0.0
+        soil_present = self._elev - self._base > 0.0
         rel_thickness = np.ones_like(self._elev)
-        rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )
+        rel_thickness[soil_present] = np.minimum(
+            1,
+            self._thickness[soil_present]
+            / (self._elev[soil_present] - self._base[soil_present]),
+        )
 
         # Calculate surface discharge at nodes
-        self._qs[:] = _regularize_G(
-            rel_thickness, self._r
-        ) * _regularize_R(self._recharge - dqdx)
+        self._qs[:] = _regularize_G(rel_thickness, self._r) * _regularize_R(
+            self._recharge - dqdx
+        )
 
         # Mass balance
         self._dhdt[:] = (1 / self._n) * (self._recharge - dqdx - self._qs)
@@ -540,14 +544,18 @@ class GroundwaterDupuitPercolator(Component):
             dqdx = self._grid.calc_flux_div_at_node(self._q)
 
             # Determine the relative aquifer thickness, 1 if permeable thickness is 0.
-            soil_present = self._elev-self._base > 0.0
+            soil_present = self._elev - self._base > 0.0
             rel_thickness = np.ones_like(self._elev)
-            rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )
+            rel_thickness[soil_present] = np.minimum(
+                1,
+                self._thickness[soil_present]
+                / (self._elev[soil_present] - self._base[soil_present]),
+            )
 
             # Calculate surface discharge at nodes
-            self._qs[:] = _regularize_G(
-                rel_thickness, self._r
-            ) * _regularize_R(self._recharge - dqdx)
+            self._qs[:] = _regularize_G(rel_thickness, self._r) * _regularize_R(
+                self._recharge - dqdx
+            )
 
             # Mass balance
             self._dhdt[:] = (1 / self._n) * (self._recharge - dqdx - self._qs)

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -469,9 +469,13 @@ class GroundwaterDupuitPercolator(Component):
         # Groundwater flux divergence
         dqdx = self._grid.calc_flux_div_at_node(self._q)
 
+        soil_present = self._elev-self._base > 0.0
+        rel_thickness = np.ones_like(self._elev)
+        rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )
+
         # Calculate surface discharge at nodes
         self._qs[:] = _regularize_G(
-            self._thickness / (self._elev - self._base), self._r
+            rel_thickness, self._r
         ) * _regularize_R(self._recharge - dqdx)
 
         # Mass balance

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -13,6 +13,7 @@ from landlab.grid.mappers import (
     map_mean_of_link_nodes_to_link,
     map_value_at_max_node_to_link,
 )
+from landlab.grid.base import INACTIVE_LINK
 from landlab.utils import return_array_at_link, return_array_at_node
 
 
@@ -454,9 +455,9 @@ class GroundwaterDupuitPercolator(Component):
         # Calculate groundwater velocity
         self._vel[:] = -self._K * (
             self._hydr_grad * np.cos(np.arctan(abs(self._base_grad)))
-            + np.sin(np.arctan(abs(self._base_grad)))
+            + np.sin(np.arctan(self._base_grad))
         )
-        self._vel[self._grid.status_at_link == 4] = 0.0
+        self._vel[self._grid.status_at_link == INACTIVE_LINK] = 0.0
 
         # Aquifer thickness at links (upwind)
         hlink = map_value_at_max_node_to_link(
@@ -469,6 +470,7 @@ class GroundwaterDupuitPercolator(Component):
         # Groundwater flux divergence
         dqdx = self._grid.calc_flux_div_at_node(self._q)
 
+        # Determine the relative aquifer thickness, 1 if permeable thickness is 0.
         soil_present = self._elev-self._base > 0.0
         rel_thickness = np.ones_like(self._elev)
         rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )
@@ -522,9 +524,9 @@ class GroundwaterDupuitPercolator(Component):
             # Calculate groundwater velocity
             self._vel[:] = -self._K * (
                 self._hydr_grad * np.cos(np.arctan(abs(self._base_grad)))
-                + np.sin(np.arctan(abs(self._base_grad)))
+                + np.sin(np.arctan(self._base_grad))
             )
-            self._vel[self._grid.status_at_link == 4] = 0.0
+            self._vel[self._grid.status_at_link == INACTIVE_LINK] = 0.0
 
             # Aquifer thickness at links (upwind)
             hlink = map_value_at_max_node_to_link(
@@ -537,6 +539,7 @@ class GroundwaterDupuitPercolator(Component):
             # Groundwater flux divergence
             dqdx = self._grid.calc_flux_div_at_node(self._q)
 
+            # Determine the relative aquifer thickness, 1 if permeable thickness is 0.
             soil_present = self._elev-self._base > 0.0
             rel_thickness = np.ones_like(self._elev)
             rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -537,9 +537,13 @@ class GroundwaterDupuitPercolator(Component):
             # Groundwater flux divergence
             dqdx = self._grid.calc_flux_div_at_node(self._q)
 
+            soil_present = self._elev-self._base > 0.0
+            rel_thickness = np.ones_like(self._elev)
+            rel_thickness[soil_present] = np.minimum(1, self._thickness[soil_present] / (self._elev[soil_present] - self._base[soil_present]) )
+
             # Calculate surface discharge at nodes
             self._qs[:] = _regularize_G(
-                self._thickness / (self._elev - self._base), self._r
+                rel_thickness, self._r
             ) * _regularize_R(self._recharge - dqdx)
 
             # Mass balance

--- a/landlab/components/groundwater/tests/test_dupuit_percolator.py
+++ b/landlab/components/groundwater/tests/test_dupuit_percolator.py
@@ -3,13 +3,13 @@
 """
 Created on Tue Jun  4 16:26:31 2019
 
-@author: gtucker
+@author: G Tucker, D Litwin
 """
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from landlab import RasterModelGrid
+from landlab import RasterModelGrid, HexModelGrid
 from landlab.components import FlowAccumulator, GroundwaterDupuitPercolator
 
 
@@ -123,7 +123,6 @@ def test_conservation_of_mass_adaptive_dt():
     recharge_flux = 0
     gw_flux = 0
     sw_flux = 0
-    storage = 0
     storage_0 = gdp.calc_total_storage()
 
     dt = 1e4
@@ -139,3 +138,34 @@ def test_conservation_of_mass_adaptive_dt():
     assert_almost_equal(
         (gw_flux + sw_flux + storage - storage_0) / recharge_flux, 1.0, decimal=3
     )
+
+def test_symmetry_of_solution():
+    """ test that water table is symmetric under constant recharge
+
+    Notes:
+    ----
+    Under constant recharge with radially symmetric aquifer base elevation,
+    the model should produce a water table that is radially symmetric. This test
+    demonstrates this is the case where topographic elevation and aquifer
+    base elevation are radially symmetric parabolas on a hexagonal grid.
+
+    """
+    hmg = HexModelGrid(shape=(7, 4), dx=10.0)
+    x = hmg.x_of_node
+    y = hmg.y_of_node
+    elev = hmg.add_zeros('node', 'topographic__elevation')
+    elev[:] = 1E-3*( x*(max(x)-x) + y*(max(y)-y) ) + 2
+    base = hmg.add_zeros('node', 'aquifer_base__elevation')
+    base[:] = elev - 2
+    wt = hmg.add_zeros('node', 'water_table__elevation')
+    wt[:] = elev
+    wt[hmg.open_boundary_nodes] = 0.0
+
+    gdp = GroundwaterDupuitPercolator(hmg,recharge_rate=1e-7,hydraulic_conductivity=1e-4)
+    for i in range(1000):
+        gdp.run_one_step(1e3)
+
+    tc = hmg.at_node['aquifer__thickness']
+    assert_almost_equal(tc[5],tc[31]) #SW-NE
+    assert_almost_equal(tc[29],tc[7]) #NW-SE
+    assert_almost_equal(tc[16],tc[20]) #W-E

--- a/landlab/components/groundwater/tests/test_dupuit_percolator.py
+++ b/landlab/components/groundwater/tests/test_dupuit_percolator.py
@@ -106,7 +106,7 @@ def test_conservation_of_mass_adaptive_dt():
     this case is only to ~3 significant digits.
     """
 
-    grid = RasterModelGrid((3, 10), spacing=10.0)
+    grid = RasterModelGrid((3, 10), xy_spacing=10.0)
     grid.set_closed_boundaries_at_grid_edges(True, True, False, True)
     elev = grid.add_zeros("node", "topographic__elevation")
     elev[:] = grid.x_of_node / 100 + 1

--- a/landlab/components/groundwater/tests/test_dupuit_percolator.py
+++ b/landlab/components/groundwater/tests/test_dupuit_percolator.py
@@ -9,7 +9,7 @@ Created on Tue Jun  4 16:26:31 2019
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from landlab import RasterModelGrid, HexModelGrid
+from landlab import HexModelGrid, RasterModelGrid
 from landlab.components import FlowAccumulator, GroundwaterDupuitPercolator
 
 
@@ -139,6 +139,7 @@ def test_conservation_of_mass_adaptive_dt():
         (gw_flux + sw_flux + storage - storage_0) / recharge_flux, 1.0, decimal=3
     )
 
+
 def test_symmetry_of_solution():
     """ test that water table is symmetric under constant recharge
 
@@ -153,19 +154,21 @@ def test_symmetry_of_solution():
     hmg = HexModelGrid(shape=(7, 4), dx=10.0)
     x = hmg.x_of_node
     y = hmg.y_of_node
-    elev = hmg.add_zeros('node', 'topographic__elevation')
-    elev[:] = 1E-3*( x*(max(x)-x) + y*(max(y)-y) ) + 2
-    base = hmg.add_zeros('node', 'aquifer_base__elevation')
+    elev = hmg.add_zeros("node", "topographic__elevation")
+    elev[:] = 1e-3 * (x * (max(x) - x) + y * (max(y) - y)) + 2
+    base = hmg.add_zeros("node", "aquifer_base__elevation")
     base[:] = elev - 2
-    wt = hmg.add_zeros('node', 'water_table__elevation')
+    wt = hmg.add_zeros("node", "water_table__elevation")
     wt[:] = elev
     wt[hmg.open_boundary_nodes] = 0.0
 
-    gdp = GroundwaterDupuitPercolator(hmg,recharge_rate=1e-7,hydraulic_conductivity=1e-4)
+    gdp = GroundwaterDupuitPercolator(
+        hmg, recharge_rate=1e-7, hydraulic_conductivity=1e-4
+    )
     for i in range(1000):
         gdp.run_one_step(1e3)
 
-    tc = hmg.at_node['aquifer__thickness']
-    assert_almost_equal(tc[5],tc[31]) #SW-NE
-    assert_almost_equal(tc[29],tc[7]) #NW-SE
-    assert_almost_equal(tc[16],tc[20]) #W-E
+    tc = hmg.at_node["aquifer__thickness"]
+    assert_almost_equal(tc[5], tc[31])  # SW-NE
+    assert_almost_equal(tc[29], tc[7])  # NW-SE
+    assert_almost_equal(tc[16], tc[20])  # W-E


### PR DESCRIPTION
Fixes a missing sign in the gw velocity equations, adds support for locations where regolith thickness goes to zero, and ensures that the model produces a radially symmetric water table when aquifer base is radially symmetric and recharge is uniform over the domain.