### PR TITLE
Fix #1049

### DIFF
--- a/landlab/field/graph_field.py
+++ b/landlab/field/graph_field.py
@@ -263,7 +263,7 @@ class FieldDataset(dict):
         return self._ds
 
     def keys(self):
-        return self._ds.variables
+        return list(self._ds.variables)
 
     def set_value(self, name, value_array, attrs=None):
         attrs = attrs or {}
@@ -1066,7 +1066,8 @@ class GraphFields(object):
             dims += (name + "_per_" + at,)
             value_array = value_array.reshape((value_array.shape[0], -1))
 
-        ds[name] = value_array
+        ds.set_value(name, value_array, attrs=attrs)
+        # ds[name] = value_array
         return ds[name]
 
     def delete_field(self, loc, name):
@@ -1277,12 +1278,13 @@ class GraphFields(object):
         LLCATS: FIELDCR
         """
         if len(args) == 3:
-            fill_value = args[2]
+            at, name, fill_value = args
         elif len(args) == 2:
-            fill_value = args[1]
+            at = kwds.pop("at", "node")
+            name, fill_value = args
         else:
             raise ValueError("number of arguments must be 2 or 3")
 
-        data = self.add_empty(*args, **kwds)
+        data = self.add_empty(name, at=at, **kwds)
         data.fill(fill_value)
         return data

--- a/tests/grid/test_raster_grid/conftest.py
+++ b/tests/grid/test_raster_grid/conftest.py
@@ -1,0 +1,3 @@
+def pytest_generate_tests(metafunc):
+    if "at" in metafunc.fixturenames:
+        metafunc.parametrize("at", ("node", "link", "patch", "corner", "face", "cell"))

--- a/tests/grid/test_raster_grid/test_fields.py
+++ b/tests/grid/test_raster_grid/test_fields.py
@@ -5,6 +5,31 @@ from numpy.testing import assert_array_equal
 from landlab import RasterModelGrid
 
 
+def test_add_full(at):
+    grid = RasterModelGrid((4, 5))
+    grid.add_full("temperature", 3, at=at)
+    assert_array_equal(
+        getattr(grid, "at_{0}".format(at))["temperature"],
+        np.full(grid.number_of_elements(at), 3),
+    )
+
+
+def test_add_field_with_units(at):
+    grid = RasterModelGrid((4, 5))
+    grid.add_empty("temperature", at=at, units="C")
+    assert getattr(grid, "at_{0}".format(at)).units["temperature"] == "C"
+
+
+def test_field_keys_is_list(at):
+    grid = RasterModelGrid((4, 5))
+    expected = []
+    assert getattr(grid, "at_{0}".format(at)).keys() == expected
+    for name in ["temperature", "elevation"]:
+        grid.add_empty(name, at=at)
+        expected.append(name)
+        assert sorted(getattr(grid, "at_{0}".format(at)).keys()) == sorted(expected)
+
+
 def test_add_field_at_node():
     """Add field at nodes."""
     grid = RasterModelGrid((4, 5))


### PR DESCRIPTION
This pull request addresses the issues found by @kbarnhart and described in #1049.

I've made only a couple small changes:
* `grid.at_node.keys()` now returns a list of field names at grid element. I believe this was caused by a change in *xarray.variables*
* when creating new fields, the *units* keyword is now passed all the way through so that it is saved in the field

With these changes, we now get:
```python
>>> from landlab import RasterModelGrid
>>> grid.add_full("temperature", 2, at="node", units="m")
>>> grid.at_node.keys()
['temperature']
>>> grid.at_node.units["temperature"]
'm'
```