### PR TITLE
Change grid add_* methods to use new-style signature

### DIFF
--- a/landlab/_registry.py
+++ b/landlab/_registry.py
@@ -34,8 +34,8 @@ Examples
 >>> from landlab.components import Flexure
 
 >>> grid = RasterModelGrid((4, 5))
->>> _ = grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
->>> _ = grid.add_zeros("node", "lithosphere_surface__elevation_increment")
+>>> _ = grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
+>>> _ = grid.add_zeros("lithosphere_surface__elevation_increment", at="node")
 >>> flexure = Flexure(grid)
 >>> print(registry.format_citations())
 # Citations

--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -32,7 +32,7 @@ class ChiFinder(Component):
     >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
     ...               mg.nodes_at_top_edge):
     ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-    >>> _ = mg.add_field('node', 'topographic__elevation', mg.node_x)
+    >>> _ = mg.add_field("topographic__elevation", mg.node_x, at="node")
     >>> fr = FlowAccumulator(mg, flow_director='D8')
     >>> cf = ChiFinder(mg,
     ...     min_drainage_area=1.,
@@ -294,7 +294,7 @@ class ChiFinder(Component):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
         >>> z = mg.node_x.copy()
         >>> z[[5, 13]] = z[6]  # guard nodes
-        >>> _ = mg.add_field('node', 'topographic__elevation', z)
+        >>> _ = mg.add_field("topographic__elevation", z, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> cf = ChiFinder(mg)
         >>> fr.run_one_step()
@@ -347,7 +347,7 @@ class ChiFinder(Component):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
         >>> z = mg.node_x.copy()
         >>> z[[5, 13]] = z[6]  # guard nodes
-        >>> _ = mg.add_field('node', 'topographic__elevation', z)
+        >>> _ = mg.add_field("topographic__elevation", z, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> cf = ChiFinder(mg)
         >>> fr.run_one_step()
@@ -435,7 +435,7 @@ class ChiFinder(Component):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
         >>> z = mg.node_x.copy()
         >>> z[[5, 13]] = z[6]  # guard nodes
-        >>> _ = mg.add_field('node', 'topographic__elevation', z)
+        >>> _ = mg.add_field("topographic__elevation", z, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> cf = ChiFinder(mg)
         >>> fr.run_one_step()
@@ -488,8 +488,7 @@ class ChiFinder(Component):
         >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_field('node', 'topographic__elevation',
-        ...                  mg.node_x.copy())
+        >>> z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
         >>> z[4:8] = np.array([0.5, 1., 2., 0.])
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> cf = ChiFinder(
@@ -530,8 +529,7 @@ class ChiFinder(Component):
         >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_field('node', 'topographic__elevation',
-        ...                  mg.node_x.copy())
+        >>> z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
         >>> z[4:8] = np.array([0.5, 1., 2., 0.])
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> fr.run_one_step()

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -59,7 +59,7 @@ class DepressionFinderAndRouter(Component):
     >>> from landlab import RasterModelGrid
     >>> from landlab.components import FlowAccumulator, DepressionFinderAndRouter
     >>> mg = RasterModelGrid((7, 7), xy_spacing=0.5)
-    >>> z = mg.add_field('node', 'topographic__elevation', mg.node_x.copy())
+    >>> z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
     >>> z += 0.01 * mg.node_y
     >>> mg.at_node['topographic__elevation'].reshape(mg.shape)[2:5, 2:5] *= 0.1
     >>> fr = FlowAccumulator(mg, flow_director='D8')

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -244,10 +244,10 @@ class DepressionFinderAndRouter(Component):
         # Note that we initialize depression
         # outlet ID to LOCAL_BAD_INDEX_VALUE (which is a major clue!)
         self._depression_depth = self._grid.add_zeros(
-            "node", "depression__depth", clobber=True
+            "depression__depth", at="node", clobber=True
         )
         self._depression_outlet_map = self._grid.add_zeros(
-            "node", "depression__outlet_node", dtype=int, clobber=True
+            "depression__outlet_node", at="node", dtype=int, clobber=True
         )
         self._depression_outlet_map += LOCAL_BAD_INDEX_VALUE
 
@@ -260,9 +260,9 @@ class DepressionFinderAndRouter(Component):
         self._lake_outlets = []  # a list of each unique lake outlet
         # ^note this is nlakes-long
 
-        self._is_pit = self._grid.add_ones("node", "is_pit", dtype=bool, clobber=True)
+        self._is_pit = self._grid.add_ones("is_pit", at="node", dtype=bool, clobber=True)
         self._flood_status = self._grid.add_zeros(
-            "node", "flood_status_code", dtype=int, clobber=True
+            "flood_status_code", at="node", dtype=int, clobber=True
         )
         self._lake_map = np.empty(self._grid.number_of_nodes, dtype=int)
         self._lake_map.fill(LOCAL_BAD_INDEX_VALUE)
@@ -487,7 +487,7 @@ class DepressionFinderAndRouter(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import DepressionFinderAndRouter
         >>> rg = RasterModelGrid((3, 3))
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
         >>> z[4] = 2.0
         >>> df = DepressionFinderAndRouter(rg, routing='D4')
         >>> (links, nbrs, dnbrs) = df._links_and_nbrs_at_node(4)
@@ -528,7 +528,7 @@ class DepressionFinderAndRouter(Component):
         >>> from landlab import RasterModelGrid
         >>> rg = RasterModelGrid((7, 7))
         >>> rg.status_at_node[rg.nodes_at_right_edge] = rg.BC_NODE_IS_CLOSED
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
         >>> z[:] = rg.x_of_node + 0.01 * rg.y_of_node
         >>> lake_nodes = np.array([10, 16, 17, 18, 24, 32, 33, 38, 40])
         >>> z[lake_nodes] *= 0.1
@@ -885,7 +885,7 @@ class DepressionFinderAndRouter(Component):
         ...     DepressionFinderAndRouter)
 
         >>> rg = RasterModelGrid((5, 5))
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
         >>> z[:] = np.array([100., 100.,  95., 100., 100.,
         ...                  100., 101.,  92.,   1., 100.,
         ...                  100., 101.,   2., 101., 100.,
@@ -959,7 +959,7 @@ class DepressionFinderAndRouter(Component):
         >>> from landlab.components import DepressionFinderAndRouter
         >>> from landlab import RasterModelGrid
         >>> rg = RasterModelGrid((7, 8))
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
         >>> df = DepressionFinderAndRouter(rg)
         >>> rcvr = np.arange(56)
         >>> rcvr[13] = -1
@@ -985,7 +985,7 @@ class DepressionFinderAndRouter(Component):
         >>> from landlab.components import DepressionFinderAndRouter
         >>> from landlab import RasterModelGrid
         >>> rg = RasterModelGrid((7, 8))
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
         >>> df = DepressionFinderAndRouter(rg)
         >>> rcvr = np.arange(56)
         >>> rcvr[13] = -1
@@ -1015,8 +1015,8 @@ class DepressionFinderAndRouter(Component):
         >>> import numpy as np
         >>> from landlab.components import DepressionFinderAndRouter
         >>> rg = RasterModelGrid((7, 8))
-        >>> z = rg.add_zeros('node', 'topographic__elevation')
-        >>> rcvr = rg.add_zeros('node', 'flow__receiver_node', dtype=int)
+        >>> z = rg.add_zeros("topographic__elevation", at="node")
+        >>> rcvr = rg.add_zeros("flow__receiver_node", at="node", dtype=int)
         >>> rcvr[:] = np.arange(rg.number_of_nodes)
         >>> lake_nodes = np.array([10, 12, 13, 19, 20, 21, 25, 26, 27, 28, 29, 30, 33, 34, 35, 36, 37, 38, 44, 45, 46])
         >>> rcvr[9] = 1

--- a/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
+++ b/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
@@ -42,9 +42,9 @@ class DepthDependentDiffuser(Component):
     >>> from landlab.components import ExponentialWeatherer
     >>> from landlab.components import DepthDependentDiffuser
     >>> mg = RasterModelGrid((5, 5))
-    >>> soilTh = mg.add_zeros('node', 'soil__depth')
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
-    >>> BRz = mg.add_zeros('node', 'bedrock__elevation')
+    >>> soilTh = mg.add_zeros("soil__depth", at="node")
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
+    >>> BRz = mg.add_zeros("bedrock__elevation", at="node")
     >>> expweath = ExponentialWeatherer(mg)
     >>> DDdiff = DepthDependentDiffuser(mg)
     >>> expweath.calc_soil_prod_rate()
@@ -61,9 +61,9 @@ class DepthDependentDiffuser(Component):
     Now with a slope:
 
     >>> mg = RasterModelGrid((3, 5))
-    >>> soilTh = mg.add_zeros('node', 'soil__depth')
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
-    >>> BRz = mg.add_zeros('node', 'bedrock__elevation')
+    >>> soilTh = mg.add_zeros("soil__depth", at="node")
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
+    >>> BRz = mg.add_zeros("bedrock__elevation", at="node")
     >>> z += mg.node_x.copy()
     >>> BRz += mg.node_x/2.
     >>> soilTh[:] = z - BRz
@@ -88,9 +88,9 @@ class DepthDependentDiffuser(Component):
     Now, we'll test that changing the transport decay depth behaves as expected.
 
     >>> mg = RasterModelGrid((3, 5))
-    >>> soilTh = mg.add_zeros('node', 'soil__depth')
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
-    >>> BRz = mg.add_zeros('node', 'bedrock__elevation')
+    >>> soilTh = mg.add_zeros("soil__depth", at="node")
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
+    >>> BRz = mg.add_zeros("bedrock__elevation", at="node")
     >>> z += mg.node_x.copy()**0.5
     >>> BRz = z.copy() - 1.0
     >>> soilTh[:] = z - BRz
@@ -180,19 +180,19 @@ class DepthDependentDiffuser(Component):
         if "topographic__slope" in self._grid.at_link:
             self._slope = self._grid.at_link["topographic__slope"]
         else:
-            self._slope = self._grid.add_zeros("link", "topographic__slope")
+            self._slope = self._grid.add_zeros("topographic__slope", at="link")
 
         # soil flux
         if "soil__flux" in self._grid.at_link:
             self._flux = self._grid.at_link["soil__flux"]
         else:
-            self._flux = self._grid.add_zeros("link", "soil__flux")
+            self._flux = self._grid.add_zeros("soil__flux", at="link")
 
         # bedrock elevation
         if "bedrock__elevation" in self._grid.at_node:
             self._bedrock = self._grid.at_node["bedrock__elevation"]
         else:
-            self._bedrock = self._grid.add_zeros("node", "bedrock__elevation")
+            self._bedrock = self._grid.add_zeros("bedrock__elevation", at="node")
 
     def soilflux(self, dt):
         """Calculate soil flux for a time period 'dt'.

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -47,7 +47,7 @@ class LinearDiffuser(Component):
     >>> from landlab import RasterModelGrid
     >>> import numpy as np
     >>> mg = RasterModelGrid((9, 9))
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
     >>> z.reshape((9, 9))[4, 4] = 1.
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
     >>> ld = LinearDiffuser(mg, linear_diffusivity=1.)
@@ -56,7 +56,7 @@ class LinearDiffuser(Component):
     >>> np.isclose(z[mg.core_nodes].sum(), 1.)
     True
     >>> mg2 = RasterModelGrid((5, 30))
-    >>> z2 = mg2.add_zeros('node', 'topographic__elevation')
+    >>> z2 = mg2.add_zeros("topographic__elevation", at="node")
     >>> z2.reshape((5, 30))[2, 8] = 1.
     >>> z2.reshape((5, 30))[2, 22] = 1.
     >>> mg2.set_closed_boundaries_at_grid_edges(True, True, True, True)
@@ -73,11 +73,11 @@ class LinearDiffuser(Component):
 
     >>> mg1 = RasterModelGrid((10, 10), xy_spacing=100.)
     >>> mg2 = RasterModelGrid((10, 10), xy_spacing=100.)
-    >>> z1 = mg1.add_zeros('node', 'topographic__elevation')
-    >>> z2 = mg2.add_zeros('node', 'topographic__elevation')
+    >>> z1 = mg1.add_zeros("topographic__elevation", at="node")
+    >>> z2 = mg2.add_zeros("topographic__elevation", at="node")
     >>> dt = 1.
     >>> nt = 10
-    >>> kappa_links = mg2.add_ones('link', 'surface_water__discharge')
+    >>> kappa_links = mg2.add_ones("surface_water__discharge", at="link")
     >>> kappa_links *= 10000.
     >>> dfn1 = LinearDiffuser(mg1, linear_diffusivity=10000.)
     >>> dfn2 = LinearDiffuser(mg2, linear_diffusivity='surface_water__discharge')
@@ -332,7 +332,7 @@ class LinearDiffuser(Component):
         >>> from landlab import RasterModelGrid
         >>> import numpy as np
         >>> mg = RasterModelGrid((4, 5))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> z[mg.core_nodes] = 1.
         >>> ld = LinearDiffuser(mg, linear_diffusivity=1.)
         >>> ld.fixed_grad_nodes.size == 0

--- a/landlab/components/discharge_diffuser/diffuse_by_discharge.py
+++ b/landlab/components/discharge_diffuser/diffuse_by_discharge.py
@@ -295,9 +295,9 @@ class DischargeDiffuser(Component):
         >>> import numpy as np
         >>> from landlab import RasterModelGrid
         >>> mg = RasterModelGrid((3, 4), xy_spacing=(1., 0.5))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
-        >>> z = mg.add_zeros('node', 'water__discharge_in')
-        >>> z = mg.add_zeros('node', 'sediment__discharge_in')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
+        >>> z = mg.add_zeros("water__discharge_in", at="node")
+        >>> z = mg.add_zeros("sediment__discharge_in", at="node")
         >>> z[:] = np.array([[1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6]])
         >>> zpad = np.pad(z.reshape((3, 4)), ((1, 1), (1, 1)), 'edge')
         >>> dd = DischargeDiffuser(mg, 0.25)
@@ -382,9 +382,9 @@ if __name__ == "__main__":
 
     S_crit = 0.25
     mg = RasterModelGrid((20, 20), 0.5)
-    mg.add_zeros("node", "topographic__elevation")
-    Qw_in = mg.add_zeros("node", "water__discharge_in")
-    Qs_in = mg.add_zeros("node", "sediment__discharge_in")
+    mg.add_zeros("topographic__elevation", at="node")
+    Qw_in = mg.add_zeros("water__discharge_in", at="node")
+    Qs_in = mg.add_zeros("sediment__discharge_in", at="node")
     Qw_in[0] = 0.5 * np.pi
     Qs_in[0] = (1.0 - S_crit) * 0.5 * np.pi
     dd = DischargeDiffuser(mg, S_crit)

--- a/landlab/components/flexure/flexure.py
+++ b/landlab/components/flexure/flexure.py
@@ -12,9 +12,7 @@ Create a grid on which we will run the flexure calculations.
 >>> from landlab import RasterModelGrid
 >>> from landlab.components.flexure import Flexure
 >>> grid = RasterModelGrid((5, 4), xy_spacing=(1.e4, 1.e4))
->>> lith_press = grid.add_zeros(
-...     "node",
-...     "lithosphere__overlying_pressure_increment")
+>>> lith_press = grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
 
 Check the fields that are used as input to the flexure component.
 
@@ -80,8 +78,8 @@ class Flexure(Component):
     >>> from landlab.components.flexure import Flexure
     >>> grid = RasterModelGrid((5, 4), xy_spacing=(1.e4, 1.e4))
     >>> lith_press = grid.add_zeros(
-    ...     "node",
-    ...     "lithosphere__overlying_pressure_increment")
+    ...     "lithosphere__overlying_pressure_increment", at="node"
+    ... )
 
     >>> flex = Flexure(grid)
     >>> flex.name

--- a/landlab/components/flow_accum/flow_accum_bw.py
+++ b/landlab/components/flow_accum/flow_accum_bw.py
@@ -368,7 +368,7 @@ def find_drainage_area_and_discharge_lossy(
     >>> np.isclose(mg.at_node['surface_water__discharge_loss'][4], 0.)
     True
 
-    >>> lossfield = mg.add_ones('node', 'loss_field', dtype=float)
+    >>> lossfield = mg.add_ones("loss_field", at="node", dtype=float)
     >>> lossfield *= 0.5
     >>> def lossfunc2(Qw, nodeID, dummyl, grid):
     ...     return grid.at_node['loss_field'][nodeID] * Qw

--- a/landlab/components/flow_accum/flow_accum_to_n.py
+++ b/landlab/components/flow_accum/flow_accum_to_n.py
@@ -608,7 +608,7 @@ def find_drainage_area_and_discharge_to_n_lossy(
 
     >>> mg = RasterModelGrid((3, 3))
     >>> _ = mg.add_zeros('node', 'surface_water__discharge_loss', dtype=float)
-    >>> lossy = mg.add_ones('link', 'lossy', dtype=float)
+    >>> lossy = mg.add_ones("lossy", at="link", dtype=float)
     >>> lossy *= 0.5
     >>> def lossfunc(Qw, dummyn, linkID, grid):
     ...     return grid.at_link['lossy'][linkID] * Qw

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -609,7 +609,7 @@ class FlowAccumulator(Component):
     >>> x_of_node = (0, 0, -1, 1)
     >>> nodes_at_link = ((1, 0), (2, 1), (3, 1))
     >>> nmg = NetworkModelGrid((y_of_node, x_of_node), nodes_at_link)
-    >>> area = nmg.add_ones('node', 'cell_area_at_node')
+    >>> area = nmg.add_ones("cell_area_at_node", at="node")
     >>> z = nmg.add_field(
     ...     'topographic__elevation',
     ...     nmg.x_of_node + nmg.y_of_node,
@@ -862,7 +862,7 @@ class FlowAccumulator(Component):
             if runoff_rate is None:
                 # assume that if runoff rate is not supplied, that the value
                 # should be set to one everywhere.
-                grid.add_ones("node", "water__unit_flux_in", dtype=float)
+                grid.add_ones("water__unit_flux_in", at="node", dtype=float)
             else:
                 runoff_rate = return_array_at_node(grid, runoff_rate)
                 grid.at_node["water__unit_flux_in"] = runoff_rate

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -123,9 +123,11 @@ class FlowAccumulator(Component):
     >>> from landlab.components import FlowAccumulator
     >>> mg = RasterModelGrid((3,3))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
-    >>> _ = mg.add_field('topographic__elevation',
-    ...                  mg.node_x + mg.node_y,
-    ...                  at = 'node')
+    >>> _ = mg.add_field(
+    ...     "topographic__elevation",
+    ...     mg.node_x + mg.node_y,
+    ...     at="node",
+    ... )
 
     The FlowAccumulator component accumulates flow and calculates drainage using
     all of the different methods for directing flow in Landlab. These include
@@ -191,11 +193,7 @@ class FlowAccumulator(Component):
     ...                                    0., 31., 20., 0.,
     ...                                    0., 32., 30., 0.,
     ...                                    0.,  0.,  0., 0.])
-    >>> _ = mg.add_field(
-    ...     'node',
-    ...     'topographic__elevation',
-    ...     topographic__elevation
-    ... )
+    >>> _ = mg.add_field("topographic__elevation", topographic__elevation, at="node")
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> fa = FlowAccumulator(
     ...      mg,
@@ -222,11 +220,7 @@ class FlowAccumulator(Component):
 
     Put the data back into the new grid.
 
-    >>> _ = mg.add_field(
-    ...     'node',
-    ...     'topographic__elevation',
-    ...     topographic__elevation
-    ... )
+    >>> _ = mg.add_field("topographic__elevation", topographic__elevation, at="node")
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> fa = FlowAccumulator(
     ...      mg,
@@ -234,12 +228,7 @@ class FlowAccumulator(Component):
     ...      flow_director=FlowDirectorSteepest
     ...      )
     >>> runoff_rate = np.arange(mg.number_of_nodes, dtype=float)
-    >>> rnff = mg.add_field(
-    ...        'node',
-    ...        'water__unit_flux_in',
-    ...        runoff_rate,
-    ...        clobber=True,
-    ... )
+    >>> rnff = mg.add_field("water__unit_flux_in", runoff_rate, at="node", clobber=True)
     >>> fa.run_one_step()
     >>> mg.at_node['surface_water__discharge'] # doctest: +NORMALIZE_WHITESPACE
     array([    0.,   500.,  5200.,     0.,
@@ -284,10 +273,10 @@ class FlowAccumulator(Component):
     >>> from landlab import HexModelGrid
     >>> hmg = HexModelGrid((5, 3), xy_of_lower_left=(-1., 0.))
     >>> _ = hmg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     hmg.node_x + np.round(hmg.node_y),
-    ...     at = 'node'
-    ...     )
+    ...     at="node",
+    ... )
     >>> fa = FlowAccumulator(
     ...      hmg,
     ...      'topographic__elevation',
@@ -309,11 +298,7 @@ class FlowAccumulator(Component):
 
     >>> mg = RasterModelGrid((5, 5))
     >>> topographic__elevation = mg.node_y+mg.node_x
-    >>> _ = mg.add_field(
-    ...     'node',
-    ...     'topographic__elevation',
-    ...     topographic__elevation
-    ... )
+    >>> _ = mg.add_field("topographic__elevation", topographic__elevation, at="node")
     >>> fa = FlowAccumulator(
     ...      mg,
     ...      'topographic__elevation',
@@ -374,9 +359,9 @@ class FlowAccumulator(Component):
     >>> dx=(2./(3.**0.5))**0.5
     >>> hmg = HexModelGrid((5, 3), spacing=dx, xy_of_lower_left=(-1.0745, 0.))
     >>> _ = hmg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     hmg.node_x**2 + np.round(hmg.node_y)**2,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fa = FlowAccumulator(
     ...      hmg,
@@ -404,9 +389,9 @@ class FlowAccumulator(Component):
     Put the data back into the new grid.
 
     >>> _ = hmg.add_field(
-    ...     'topographic__elevation',
-    ...     hmg.node_x**2 + np.round(hmg.node_y)**2,
-    ...     at = 'node'
+    ...     "topographic__elevation",
+    ...     hmg.node_x ** 2 + np.round(hmg.node_y) ** 2,
+    ...     at="node",
     ... )
     >>> fa = FlowAccumulator(
     ...      hmg,
@@ -424,7 +409,7 @@ class FlowAccumulator(Component):
     Next, let's see what happens to a raster grid when there is a depression.
 
     >>> mg = RasterModelGrid((7, 7), xy_spacing=0.5)
-    >>> z = mg.add_field('node', 'topographic__elevation', mg.node_x.copy())
+    >>> z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
     >>> z += 0.01 * mg.node_y
     >>> mg.at_node['topographic__elevation'].reshape(mg.shape)[2:5, 2:5] *= 0.1
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, False, True)
@@ -528,7 +513,7 @@ class FlowAccumulator(Component):
     class DepressionFinderAndRouter to the parameter `depression_finder`.
 
     >>> mg = RasterModelGrid((7, 7), xy_spacing=0.5)
-    >>> z = mg.add_field('node', 'topographic__elevation', mg.node_x.copy())
+    >>> z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
     >>> z += 0.01 * mg.node_y
     >>> mg.at_node['topographic__elevation'].reshape(mg.shape)[2:5, 2:5] *= 0.1
     >>> fa = FlowAccumulator(
@@ -611,9 +596,10 @@ class FlowAccumulator(Component):
     >>> nmg = NetworkModelGrid((y_of_node, x_of_node), nodes_at_link)
     >>> area = nmg.add_ones("cell_area_at_node", at="node")
     >>> z = nmg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     nmg.x_of_node + nmg.y_of_node,
-    ...     at = 'node')
+    ...     at="node",
+    ... )
     >>> fa = FlowAccumulator(nmg)
     >>> fa.run_one_step()
     >>> nmg.at_node['flow__receiver_node']
@@ -797,10 +783,10 @@ class FlowAccumulator(Component):
         >>> mg = RasterModelGrid((5, 5))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
-        ...     )
+        ...     at="node",
+        ... )
         >>> fa = FlowAccumulator(mg, 'topographic__elevation')
         >>> fa.run_one_step()
         >>> fa.link_order_upstream()
@@ -811,9 +797,9 @@ class FlowAccumulator(Component):
         >>> mg = RasterModelGrid((5, 5))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fa = FlowAccumulator(mg,
         ...      'topographic__elevation',
@@ -841,9 +827,9 @@ class FlowAccumulator(Component):
         >>> mg = RasterModelGrid((5, 5))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fa = FlowAccumulator(mg, 'topographic__elevation')
         >>> fa.run_one_step()

--- a/landlab/components/flow_accum/lossy_flow_accumulator.py
+++ b/landlab/components/flow_accum/lossy_flow_accumulator.py
@@ -138,9 +138,7 @@ class LossyFlowAccumulator(FlowAccumulator):
 
     >>> mg = RasterModelGrid((3, 5), xy_spacing=(2, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, False, True)
-    >>> z = mg.add_field('topographic__elevation',
-    ...                  mg.node_x + mg.node_y,
-    ...                  at='node')
+    >>> z = mg.add_field("topographic__elevation", mg.node_x + mg.node_y, at="node")
 
     >>> def mylossfunction(qw):
     ...     return 0.5 * qw
@@ -168,9 +166,11 @@ class LossyFlowAccumulator(FlowAccumulator):
 
     >>> dx=(2./(3.**0.5))**0.5  # area to be 100.
     >>> hmg = HexModelGrid((5, 3), spacing=dx, xy_of_lower_left=(-1.0745, 0.))
-    >>> z = hmg.add_field('topographic__elevation',
-    ...                   hmg.node_x**2 + np.round(hmg.node_y)**2,
-    ...                   at = 'node')
+    >>> z = hmg.add_field(
+    ...     "topographic__elevation",
+    ...     hmg.node_x**2 + np.round(hmg.node_y)**2,
+    ...     at="node",
+    ... )
     >>> z[9] = -10.  # poke a hole
     >>> lossy = hmg.add_zeros('node', 'mylossterm', dtype=float)
     >>> lossy[14] = 1.  # suppress all flow from node 14
@@ -236,7 +236,7 @@ class LossyFlowAccumulator(FlowAccumulator):
     >>> from landlab.components import FlowDirectorMFD
     >>> mg = RasterModelGrid((4, 6), xy_spacing=(1, 2))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, False, True)
-    >>> z = mg.add_field('node', 'topographic__elevation', 2.*mg.node_x)
+    >>> z = mg.add_field("topographic__elevation", 2.0 * mg.node_x, at="node")
     >>> z[9] = 8.
     >>> z[16] = 6.5  # force the first node sideways
 

--- a/landlab/components/flow_director/flow_direction_dinf.py
+++ b/landlab/components/flow_director/flow_direction_dinf.py
@@ -78,9 +78,11 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     triangular facets around a central raster node.
 
     >>> grid = RasterModelGrid((3,3), xy_spacing=(1, 1))
-    >>> _ = grid.add_field('topographic__elevation',
-    ...                     2.*grid.node_x+grid.node_y,
-    ...                     at = 'node')
+    >>> _ = grid.add_field(
+    ...     "topographic__elevation",
+    ...     2.*grid.node_x+grid.node_y,
+    ...     at="node",
+    ... )
     >>> (receivers, proportions, slopes,
     ... steepest_slope, steepest_receiver,
     ... sink, receiver_links, steepest_link) = flow_directions_dinf(grid)

--- a/landlab/components/flow_director/flow_direction_mfd.py
+++ b/landlab/components/flow_director/flow_direction_mfd.py
@@ -91,7 +91,11 @@ def flow_directions_mfd(
     >>> from landlab.components.flow_director.flow_direction_mfd import(
     ...                                           flow_directions_mfd)
     >>> grid = RasterModelGrid((3,3), xy_spacing=(1, 1))
-    >>> elev = grid.add_field('topographic__elevation', grid.node_x+grid.node_y, at = 'node')
+    >>> elev = grid.add_field(
+    ...     "topographic__elevation",
+    ...     grid.node_x + grid.node_y,
+    ...     at="node",
+    ... )
 
     For the first example, we will not pass any diagonal elements to the flow
     direction algorithm.

--- a/landlab/components/flow_director/flow_director.py
+++ b/landlab/components/flow_director/flow_director.py
@@ -42,10 +42,10 @@ class _FlowDirector(Component):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
-    ...     )
+    ...     at="node",
+    ... )
     >>> fd = _FlowDirector(mg, 'topographic__elevation')
     >>> fd.surface_values
     array([ 0.,  1.,  2.,  1.,  2.,  3.,  2.,  3.,  4.])

--- a/landlab/components/flow_director/flow_director_d8.py
+++ b/landlab/components/flow_director/flow_director_d8.py
@@ -52,9 +52,9 @@ class FlowDirectorD8(_FlowDirectorToOne):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = FlowDirectorD8(mg, 'topographic__elevation')
     >>> fd.surface_values
@@ -76,9 +76,9 @@ class FlowDirectorD8(_FlowDirectorToOne):
     ...                                    0., 32., 30., 0.,
     ...                                    0.,  0.,  0., 0.])
     >>> _ = mg_2.add_field(
-    ...     'node',
-    ...     'topographic__elevation',
-    ...     topographic__elevation
+    ...     "topographic__elevation",
+    ...     topographic__elevation,
+    ...     at="node",
     ... )
     >>> mg_2.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> fd_2 = FlowDirectorD8(mg_2)

--- a/landlab/components/flow_director/flow_director_dinf.py
+++ b/landlab/components/flow_director/flow_director_dinf.py
@@ -56,9 +56,9 @@ class FlowDirectorDINF(_FlowDirectorToMany):
     >>> mg = RasterModelGrid((4,4), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x**2 + mg.node_y**2,
-    ...     at = 'node'
+    ...     at="node",
     ... )
 
     The DINF flow director can be uses for raster grids only.

--- a/landlab/components/flow_director/flow_director_mfd.py
+++ b/landlab/components/flow_director/flow_director_mfd.py
@@ -60,9 +60,9 @@ class FlowDirectorMFD(_FlowDirectorToMany):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
 
     The MFD flow director can be uses for raster and irregular grids. For
@@ -153,9 +153,9 @@ class FlowDirectorMFD(_FlowDirectorToMany):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = FlowDirectorMFD(mg, 'topographic__elevation')
     >>> fd.run_one_step()
@@ -197,9 +197,9 @@ class FlowDirectorMFD(_FlowDirectorToMany):
     >>> from landlab import HexModelGrid
     >>> mg = HexModelGrid((5, 3))
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + numpy.round(mg.node_y),
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = FlowDirectorMFD(
     ...      mg,

--- a/landlab/components/flow_director/flow_director_steepest.py
+++ b/landlab/components/flow_director/flow_director_steepest.py
@@ -57,9 +57,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
     >>> fd.surface_values
@@ -80,9 +80,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
     ...                                    0., 32., 30., 0.,
     ...                                    0.,  0.,  0., 0.])
     >>> _ = mg_2.add_field(
-    ...     'node',
-    ...     'topographic__elevation',
-    ...     topographic__elevation
+    ...     "topographic__elevation",
+    ...     topographic__elevation,
+    ...     at="node",
     ... )
     >>> mg_2.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> fd_2 = FlowDirectorSteepest(mg_2)
@@ -206,9 +206,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
     >>> from landlab import HexModelGrid
     >>> mg = HexModelGrid((5, 3))
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + np.round(mg.node_y),
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
     >>> fd.surface_values
@@ -463,9 +463,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()
@@ -487,9 +487,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> from landlab.components import FlowAccumulator
         >>> mg1 = RasterModelGrid((5, 5))
         >>> z1 = mg1.add_field(
-        ...      'node',
-        ...      'topographic__elevation',
-        ...      mg1.x_of_node+2 * mg1.y_of_node
+        ...     "topographic__elevation",
+        ...     mg1.x_of_node+2 * mg1.y_of_node,
+        ...     at="node",
         ... )
         >>> z1[12] -= 5
         >>> mg1.set_closed_boundaries_at_grid_edges(True, True, True, False)
@@ -532,9 +532,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
 
         >>> mg2 = RasterModelGrid((5, 5))
         >>> z2 = mg2.add_field(
-        ...      'node',
-        ...      'topographic__elevation',
-        ...      mg2.x_of_node+2 * mg2.y_of_node
+        ...     "topographic__elevation",
+        ...     mg2.x_of_node+2 * mg2.y_of_node,
+        ...     at="node",
         ... )
         >>> z2[12] -= 5
         >>> mg2.set_closed_boundaries_at_grid_edges(True, True, True, False)
@@ -602,9 +602,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()
@@ -654,9 +654,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()
@@ -677,9 +677,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()
@@ -707,9 +707,9 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()

--- a/landlab/components/flow_director/flow_director_to_many.py
+++ b/landlab/components/flow_director/flow_director_to_many.py
@@ -44,9 +44,9 @@ class _FlowDirectorToMany(_FlowDirector):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = _FlowDirectorToMany(mg, 'topographic__elevation')
     >>> fd.surface_values

--- a/landlab/components/flow_director/flow_director_to_one.py
+++ b/landlab/components/flow_director/flow_director_to_one.py
@@ -55,9 +55,9 @@ class _FlowDirectorToOne(_FlowDirector):
     >>> mg = RasterModelGrid((3,3), xy_spacing=(1, 1))
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
     >>> _ = mg.add_field(
-    ...     'topographic__elevation',
+    ...     "topographic__elevation",
     ...     mg.node_x + mg.node_y,
-    ...     at = 'node'
+    ...     at="node",
     ... )
     >>> fd = _FlowDirectorToOne(mg, 'topographic__elevation')
     >>> fd.surface_values
@@ -157,9 +157,9 @@ class _FlowDirectorToOne(_FlowDirector):
         >>> mg = RasterModelGrid((3,3))
         >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
         >>> _ = mg.add_field(
-        ...     'topographic__elevation',
+        ...     "topographic__elevation",
         ...     mg.node_x + mg.node_y,
-        ...     at = 'node'
+        ...     at="node",
         ... )
         >>> fd = FlowDirectorSteepest(mg, 'topographic__elevation')
         >>> fd.run_one_step()

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -66,8 +66,8 @@ class GroundwaterDupuitPercolator(Component):
     Initialize the grid and component
 
     >>> grid = RasterModelGrid((10, 10), xy_spacing=10.0)
-    >>> elev = grid.add_zeros('node', 'topographic__elevation')
-    >>> abe = grid.add_zeros('node', 'aquifer_base__elevation')
+    >>> elev = grid.add_zeros("topographic__elevation", at="node")
+    >>> abe = grid.add_zeros("aquifer_base__elevation", at="node")
     >>> elev[:] = 5.0
     >>> gdp = GroundwaterDupuitPercolator(grid)
 
@@ -90,11 +90,11 @@ class GroundwaterDupuitPercolator(Component):
 
     Make a sloping, 3 m thick aquifer, initially fully saturated
 
-    >>> elev = grid.add_zeros('node', 'topographic__elevation')
+    >>> elev = grid.add_zeros("topographic__elevation", at="node")
     >>> elev[:] = grid.x_of_node/100+3
-    >>> base = grid.add_zeros('node', 'aquifer_base__elevation')
+    >>> base = grid.add_zeros("aquifer_base__elevation", at="node")
     >>> base[:] = grid.x_of_node/100
-    >>> wt = grid.add_zeros('node', 'water_table__elevation')
+    >>> wt = grid.add_zeros("water_table__elevation", at="node")
     >>> wt[:] = grid.x_of_node/100 + 3
 
     Initialize components

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -471,7 +471,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[2, 1:-1] = [2., 1., 0.5, 1.5]
         >>> z.reshape(mg.shape)[1, 1:-1] = [2.1, 1.1, 0.6, 1.6]
         >>> z.reshape(mg.shape)[3, 1:-1] = [2.2, 1.2, 0.7, 1.7]
@@ -531,7 +531,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((3, 7))
         >>> for edge in ('top', 'right', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[1, 1:-1] = [1., 0.2, 0.1,
         ...                                 1.0000000000000004, 1.5]
         >>> z_init = z.copy()
@@ -649,7 +649,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -759,7 +759,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[2, 1:-1] = [2., 1., 0.5, 1.5]
         >>> z.reshape(mg.shape)[1, 1:-1] = [2.1, 1.1, 0.6, 1.6]
         >>> z.reshape(mg.shape)[3, 1:-1] = [2.2, 1.2, 0.7, 1.7]
@@ -846,7 +846,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((3, 7))
         >>> for edge in ('top', 'right', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[1, 1:-1] = [1., 0.2, 0.1,
         ...                                 1.0000000000000004, 1.5]
         >>> z_init = z.copy()
@@ -952,8 +952,8 @@ class LakeMapperBarnes(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import LakeMapperBarnes, FlowAccumulator
         >>> mg = RasterModelGrid((5, 6), xy_spacing=2.)
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
-        >>> z_new = mg.add_zeros('node', 'topographic__fill', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
+        >>> z_new = mg.add_zeros("topographic__fill", at="node", dtype=float)
         >>> fa = FlowAccumulator(mg)
         >>> lmb = LakeMapperBarnes(mg, method='D8',
         ...                        surface='topographic__elevation',
@@ -1000,7 +1000,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6), xy_spacing=2.)
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[23] = 1.3
         >>> z[15] = -2.  # this deep pit causes the outlet to first drain *in*
@@ -1260,7 +1260,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6), xy_spacing=2.)
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[2, 1:-1] = [2., 1., 0.5, 1.5]
         >>> z.reshape(mg.shape)[1, 1:-1] = [2.1, 1.1, 0.6, 1.6]
         >>> z.reshape(mg.shape)[3, 1:-1] = [2.2, 1.2, 0.7, 1.7]
@@ -1432,7 +1432,7 @@ class LakeMapperBarnes(Component):
 
         >>> from landlab import HexModelGrid, FieldError
         >>> hmg = HexModelGrid((5, 4), spacing=2.)
-        >>> z_hex = hmg.add_zeros('node', 'topographic__elevation')
+        >>> z_hex = hmg.add_zeros("topographic__elevation", at="node")
         >>> z_hex[:] = hmg.node_x
         >>> z_hex[11] = -3.
         >>> z_hex[12] = -1.
@@ -1458,7 +1458,7 @@ class LakeMapperBarnes(Component):
         True
 
         >>> hmg = HexModelGrid((5, 4), spacing=2.0)
-        >>> z_hex = hmg.add_zeros('node', 'topographic__elevation')
+        >>> z_hex = hmg.add_zeros("topographic__elevation", at="node")
         >>> z_hex[:] = z_hex_init
         >>> try:
         ...     lmb = LakeMapperBarnes(hmg, method='Steepest',
@@ -1508,14 +1508,12 @@ class LakeMapperBarnes(Component):
         elevation though, since the LakeMapper will need it. We start them
         equal (i.e., topo starts dry).
 
-        >>> z_water = mg.add_zeros(
-        ...     'node', 'topographic__elevation', dtype=float)
+        >>> z_water = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z_water[:] = mg.node_x
         >>> z_water[11] = 1.5
         >>> z_water[19] = 0.5
         >>> z_water[34] = 1.1
-        >>> z_bed = mg.add_zeros(
-        ...     'node', 'bedrock__elevation', dtype=float)
+        >>> z_bed = mg.add_zeros("bedrock__elevation", at="node", dtype=float)
         >>> z_bed[:] = z_water  # topo starts dry
 
         Let's just take a look:
@@ -1714,7 +1712,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[2, 1:-1] = [2., 1., 0.5, 1.5]
         >>> z.reshape(mg.shape)[1, 1:-1] = [2.1, 1.1, 0.6, 1.6]
         >>> z.reshape(mg.shape)[3, 1:-1] = [2.2, 1.2, 0.7, 1.7]
@@ -1756,7 +1754,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[2, 1:-1] = [2., 1., 0.5, 1.5]
         >>> z.reshape(mg.shape)[1, 1:-1] = [2.1, 1.1, 0.6, 1.6]
         >>> z.reshape(mg.shape)[3, 1:-1] = [2.2, 1.2, 0.7, 1.7]
@@ -1799,7 +1797,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -1848,7 +1846,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -1923,7 +1921,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -1962,7 +1960,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -2022,7 +2020,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -2077,7 +2075,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((5, 6))
         >>> for edge in ('left', 'top', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z[:] = mg.node_x.max() - mg.node_x
         >>> z[[10, 23]] = 1.1  # raise "guard" exit nodes
         >>> z[7] = 2.  # is a lake on its own
@@ -2129,7 +2127,7 @@ class LakeMapperBarnes(Component):
         >>> mg = RasterModelGrid((3, 7))
         >>> for edge in ('top', 'right', 'bottom'):
         ...     mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-        >>> z = mg.add_zeros('node', 'topographic__elevation', dtype=float)
+        >>> z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
         >>> z.reshape(mg.shape)[1, 1:-1] = [1., 0.2, 0.1,
         ...                                 1.0000000000000004, 1.5]
         >>> z_init = z.copy()

--- a/landlab/components/lateral_erosion/lateral_erosion.py
+++ b/landlab/components/lateral_erosion/lateral_erosion.py
@@ -396,8 +396,8 @@ class LateralEroder(Component):
         Kl = Kv * Klr
         z = grid.at_node["topographic__elevation"]
         # clear qsin for next loop
-        qs_in = grid.add_zeros("node", "sediment__flux", clobber=True)
-        qs = grid.add_zeros("node", "qs", clobber=True)
+        qs_in = grid.add_zeros("sediment__flux", at="node", clobber=True)
+        qs = grid.add_zeros("qs", at="node", clobber=True)
         lat_nodes = np.zeros(grid.number_of_nodes, dtype=int)
         dzver = np.zeros(grid.number_of_nodes)
         vol_lat_dt = np.zeros(grid.number_of_nodes)
@@ -517,8 +517,8 @@ class LateralEroder(Component):
         Kl = Kv * Klr
         z = grid.at_node["topographic__elevation"]
         # clear qsin for next loop
-        qs_in = grid.add_zeros("node", "sediment__flux", clobber=True)
-        qs = grid.add_zeros("node", "qs", clobber=True)
+        qs_in = grid.add_zeros("sediment__flux", at="node", clobber=True)
+        qs = grid.add_zeros("qs", at="node", clobber=True)
         lat_nodes = np.zeros(grid.number_of_nodes, dtype=int)
         dzver = np.zeros(grid.number_of_nodes)
         vol_lat_dt = np.zeros(grid.number_of_nodes)

--- a/landlab/components/lithology/lithology.py
+++ b/landlab/components/lithology/lithology.py
@@ -112,7 +112,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
 
         Create a Lithology with uniform thicknesses that alternates between
         layers of type 1 and type 2 rock.
@@ -347,7 +347,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -368,7 +368,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -388,7 +388,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -411,7 +411,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -437,7 +437,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -464,7 +464,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -520,7 +520,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
 
@@ -611,7 +611,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -672,7 +672,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -736,7 +736,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -855,7 +855,7 @@ class Lithology(Component):
         >>> from landlab import RasterModelGrid
         >>> from landlab.components import Lithology
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_ones('node', 'topographic__elevation')
+        >>> z = mg.add_ones("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,
@@ -916,7 +916,7 @@ class Lithology(Component):
         use to store the layer information.
 
         >>> mg = RasterModelGrid((3, 3))
-        >>> z = mg.add_ones('node', 'topographic__elevation')
+        >>> z = mg.add_ones("topographic__elevation", at="node")
         >>> thicknesses = [1, 2, 4, 1]
         >>> ids = [1, 2, 1, 2]
         >>> attrs = {'K_sp': {1: 0.001,

--- a/landlab/components/lithology/lithology.py
+++ b/landlab/components/lithology/lithology.py
@@ -252,11 +252,11 @@ class Lithology(Component):
         # assert that attrs are pointing to fields (or create them)
         for at in self._properties:
             if at not in grid.at_node:
-                self._grid.add_empty("node", at)
+                self._grid.add_empty(at, at="node")
 
         # add a field for the rock type id
         if self._rock_id_name not in self._grid.at_node:
-            self._grid.add_empty("node", self._rock_id_name)
+            self._grid.add_empty(self._rock_id_name, at="node")
 
         # verify that all IDs have attributes.
         self._check_property_dictionary()
@@ -652,7 +652,7 @@ class Lithology(Component):
 
         for at in attrs:
             if at not in self._grid.at_node:
-                self._grid.add_empty("node", at)
+                self._grid.add_empty(at, at="node")
             self._attrs[at] = attrs[at]
             self._properties.append(at)
 

--- a/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
+++ b/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
@@ -34,7 +34,7 @@ class PerronNLDiffuse(Component):
     >>> from landlab import RasterModelGrid
     >>> import numpy as np
     >>> mg = RasterModelGrid((5, 5))
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
     >>> nl = PerronNLDiffuse(mg, nonlinear_diffusivity=1.)
     >>> dt = 100.
     >>> nt = 20

--- a/landlab/components/normal_fault/normal_fault.py
+++ b/landlab/components/normal_fault/normal_fault.py
@@ -123,7 +123,7 @@ class NormalFault(Component):
 
         Add an elevation field.
 
-        >>> z = grid.add_zeros('node', 'topographic__elevation')
+        >>> z = grid.add_zeros("topographic__elevation", at="node")
 
         Set the parameter values for the NormalFault component.
 
@@ -185,7 +185,7 @@ class NormalFault(Component):
 
         >>> from landlab.components import FastscapeEroder, FlowAccumulator
         >>> grid = RasterModelGrid((6, 6), xy_spacing=10)
-        >>> z = grid.add_zeros('node', 'topographic__elevation')
+        >>> z = grid.add_zeros("topographic__elevation", at="node")
         >>> param_dict = {'faulted_surface': 'topographic__elevation',
         ...               'fault_dip_angle': 90.0,
         ...               'fault_throw_rate_through_time': {'time': [0, 900, 1000],
@@ -224,7 +224,7 @@ class NormalFault(Component):
         timestep (or some more seismogenically reasonable set of times).
 
         >>> grid = RasterModelGrid((6, 6), xy_spacing=10)
-        >>> z = grid.add_zeros('node', 'topographic__elevation')
+        >>> z = grid.add_zeros("topographic__elevation", at="node")
         >>> nf = NormalFault(grid, **param_dict)
         >>> fr = FlowAccumulator(grid)
         >>> fs = FastscapeEroder(grid, K_sp=0.01)

--- a/landlab/components/overland_flow/generate_overland_flow_Bates.py
+++ b/landlab/components/overland_flow/generate_overland_flow_Bates.py
@@ -114,8 +114,8 @@ class OverlandFlowBates(Component):
         # For water discharge
 
         self._surface_water__discharge = grid.add_zeros(
-            "link",
             "surface_water__discharge",
+            at="link",
             units=self._info["surface_water__discharge"]["units"],
         )
 

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -137,7 +137,7 @@ class KinwaveImplicitOverlandFlow(Component):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((4, 5), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> kw = KinwaveImplicitOverlandFlow(rg)
     >>> round(kw.runoff_rate * 1.0e7, 2)
     2.78

--- a/landlab/components/overland_flow/generate_overland_flow_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_kinwave.py
@@ -29,8 +29,8 @@ class KinwaveOverlandFlowModel(Component):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((4, 5), xy_spacing=10.0)
-    >>> z = rg.add_zeros("node", "topographic__elevation")
-    >>> s = rg.add_zeros("link", "topographic__gradient")
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
+    >>> s = rg.add_zeros("topographic__gradient", at="link")
     >>> kw = KinwaveOverlandFlowModel(rg)
     >>> kw.vel_coef
     100.0

--- a/landlab/components/profiler/channel_profiler.py
+++ b/landlab/components/profiler/channel_profiler.py
@@ -290,7 +290,7 @@ class ChannelProfiler(_BaseProfiler):
     ...                0,  0,  0,  0,  0,  0,  0,  0,  0,  0,], dtype=float)
 
     >>> mg = RasterModelGrid((8, 10))
-    >>> z = mg.add_field("node", "topographic__elevation", z)
+    >>> z = mg.add_field("topographic__elevation", z, at="node")
     >>> mg.set_nodata_nodes_to_closed(z, 0)
     >>> fa = FlowAccumulator(mg, flow_director='D4')
     >>> fa.run_one_step()

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -43,8 +43,13 @@ class SinkFiller(Component):
     >>> z += mg.node_x  # add a slope
     >>> z[guard_nodes] += 0.001  # forces the flow out of a particular node
     >>> z[lake] = 0.
-    >>> field = mg.add_field('node', 'topographic__elevation', z,
-    ...                      units='-', copy=True)
+    >>> field = mg.add_field(
+    ...     "topographic__elevation",
+    ...     z,
+    ...     at="node",
+    ...     units="-",
+    ...     copy=True,
+    ... )
     >>> fr = FlowAccumulator(mg, flow_director='D8')
     >>> fr.run_one_step()
     >>> mg.at_node['flow__sink_flag'][mg.core_nodes].sum()

--- a/landlab/components/soil_moisture/infiltrate_soil_green_ampt.py
+++ b/landlab/components/soil_moisture/infiltrate_soil_green_ampt.py
@@ -24,9 +24,9 @@ class SoilInfiltrationGreenAmpt(Component):
     >>> mg = RasterModelGrid((4,3), xy_spacing=10.)
     >>> hydraulic_conductivity = mg.ones('node')*1.e-6
     >>> hydraulic_conductivity.reshape((4,3))[0:2,:] *= 10000.
-    >>> h = mg.add_ones('node', 'surface_water__depth')
+    >>> h = mg.add_ones("surface_water__depth", at="node")
     >>> h *= 0.01
-    >>> d = mg.add_ones('node', 'soil_water_infiltration__depth', dtype=float)
+    >>> d = mg.add_ones("soil_water_infiltration__depth", at="node", dtype=float)
     >>> d *= 0.2
     >>> SI = SoilInfiltrationGreenAmpt(
     ...     mg,hydraulic_conductivity=hydraulic_conductivity)

--- a/landlab/components/spatial_precip/generate_spatial_precip.py
+++ b/landlab/components/spatial_precip/generate_spatial_precip.py
@@ -1415,7 +1415,7 @@ class SpatialPrecipitationDistribution(Component):
         Examples
         --------
         >>> mg = RasterModelGrid((10, 10), xy_spacing=500.)
-        >>> z = mg.add_zeros('node', 'topographic__elevation')
+        >>> z = mg.add_zeros("topographic__elevation", at="node")
         >>> rain = SpatialPrecipitationDistribution(mg)
         >>> mytotals = []
         >>> for yr in range(5):
@@ -1678,7 +1678,7 @@ if __name__ == "__main__":
     dx = 1000.0
     mg = RasterModelGrid((nx, ny), xy_spacing=dx)
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += 1400.0
     rain = SpatialPrecipitationDistribution(mg, number_of_years=1)
     count = 0

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -25,7 +25,7 @@ class SteepnessFinder(Component):
     >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
     ...               mg.nodes_at_top_edge):
     ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-    >>> _ = mg.add_zeros('node', 'topographic__elevation')
+    >>> _ = mg.add_zeros("topographic__elevation", at="node")
     >>> mg.at_node['topographic__elevation'][mg.core_nodes] = mg.node_x[
     ...     mg.core_nodes]/1000.
     >>> fr = FlowAccumulator(mg, flow_director='D8')
@@ -168,7 +168,7 @@ class SteepnessFinder(Component):
         self._elev_step = elev_step
         self._discretization = discretization_length
         self._ksn = self._grid.add_zeros(
-            "node", "channel__steepness_index", clobber=True
+            "channel__steepness_index", at="node", clobber=True
         )
         self._mask = self._grid.ones("node", dtype=bool)
         # this one needs modifying if smooth_elev
@@ -524,7 +524,7 @@ class SteepnessFinder(Component):
         >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-        >>> _ = mg.add_zeros('node', 'topographic__elevation')
+        >>> _ = mg.add_zeros("topographic__elevation", at="node")
         >>> mg.at_node['topographic__elevation'][mg.core_nodes] = mg.node_x[
         ...     mg.core_nodes]/1000.
         >>> np.random.seed(0)

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -296,7 +296,7 @@ class SteepnessFinder(Component):
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
         >>> mg.status_at_node[[6, 12, 13, 14]] = mg.BC_NODE_IS_CLOSED
-        >>> _ = mg.add_field('node', 'topographic__elevation', mg.node_x)
+        >>> _ = mg.add_field("topographic__elevation", mg.node_x, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> sf = SteepnessFinder(mg)
         >>> _ = fr.run_one_step()
@@ -342,7 +342,7 @@ class SteepnessFinder(Component):
         >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-        >>> _ = mg.add_field('node', 'topographic__elevation', mg.node_x**1.1)
+        >>> _ = mg.add_field("topographic__elevation", mg.node_x**1.1, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> sf = SteepnessFinder(mg)
         >>> _ = fr.run_one_step()
@@ -422,7 +422,7 @@ class SteepnessFinder(Component):
         >>> for nodes in (mg.nodes_at_right_edge, mg.nodes_at_bottom_edge,
         ...               mg.nodes_at_top_edge):
         ...     mg.status_at_node[nodes] = mg.BC_NODE_IS_CLOSED
-        >>> _ = mg.add_field('node', 'topographic__elevation', mg.node_x)
+        >>> _ = mg.add_field("topographic__elevation", mg.node_x, at="node")
         >>> fr = FlowAccumulator(mg, flow_director='D8')
         >>> sf = SteepnessFinder(mg)
         >>> _ = fr.run_one_step()

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -50,7 +50,7 @@ class StreamPowerEroder(Component):
     ...               7.,  2.,  3.,  5.,  7.,
     ...               7.,  1., 1.9,  4.,  7.,
     ...               7.,  0.,  7.,  7.,  7.])
-    >>> z = mg.add_field('node', 'topographic__elevation', z)
+    >>> z = mg.add_field("topographic__elevation", z, at="node")
     >>> fr = FlowAccumulator(mg, flow_director='D8')
     >>> sp = StreamPowerEroder(mg, K_sp=1.)
     >>> fr.run_one_step()
@@ -64,7 +64,7 @@ class StreamPowerEroder(Component):
 
     >>> mg2 = RasterModelGrid((3, 7))
     >>> z = np.array(mg2.node_x**2.)
-    >>> z = mg2.add_field('node', 'topographic__elevation', z)
+    >>> z = mg2.add_field("topographic__elevation", z, at="node")
     >>> mg2.status_at_node[mg2.nodes_at_left_edge] = mg2.BC_NODE_IS_FIXED_VALUE
     >>> mg2.status_at_node[mg2.nodes_at_top_edge] = mg2.BC_NODE_IS_CLOSED
     >>> mg2.status_at_node[mg2.nodes_at_bottom_edge] = mg2.BC_NODE_IS_CLOSED
@@ -80,7 +80,7 @@ class StreamPowerEroder(Component):
 
     >>> mg3 = RasterModelGrid((5, 5), xy_spacing=2.)
     >>> z = mg.node_x/100.
-    >>> z = mg3.add_field('node', 'topographic__elevation', z)
+    >>> z = mg3.add_field("topographic__elevation", z, at="node")
     >>> mg3.status_at_node[mg3.nodes_at_left_edge] = mg2.BC_NODE_IS_FIXED_VALUE
     >>> mg3.status_at_node[mg3.nodes_at_top_edge] = mg2.BC_NODE_IS_CLOSED
     >>> mg3.status_at_node[mg3.nodes_at_bottom_edge] = mg2.BC_NODE_IS_CLOSED

--- a/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
+++ b/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
@@ -48,7 +48,7 @@ class TaylorNonLinearDiffuser(Component):
     >>> from landlab import RasterModelGrid
     >>> from landlab.plot.imshow import imshow_grid
     >>> mg = RasterModelGrid((3, 3))
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
     >>> initial_slope=1.0
     >>> leftmost_elev=1000.
     >>> z[:] = leftmost_elev
@@ -99,7 +99,7 @@ class TaylorNonLinearDiffuser(Component):
     Next, lets do an example with dynamic timestepping.
 
     >>> mg = RasterModelGrid((5, 5))
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
 
     We'll use a steep slope.
 
@@ -126,7 +126,7 @@ class TaylorNonLinearDiffuser(Component):
     timesteps.
 
     >>> mg = RasterModelGrid((5, 5))
-    >>> z = mg.add_zeros('node', 'topographic__elevation')
+    >>> z = mg.add_zeros("topographic__elevation", at="node")
     >>> z += mg.node_x.copy()**2
     >>> cubicflux = TaylorNonLinearDiffuser(
     ...     mg,
@@ -222,13 +222,13 @@ class TaylorNonLinearDiffuser(Component):
         if "topographic__slope" in self._grid.at_link:
             self._slope = self._grid.at_link["topographic__slope"]
         else:
-            self._slope = self._grid.add_zeros("link", "topographic__slope")
+            self._slope = self._grid.add_zeros("topographic__slope", at="link")
 
         # soil flux
         if "soil__flux" in self._grid.at_link:
             self._flux = self._grid.at_link["soil__flux"]
         else:
-            self._flux = self._grid.add_zeros("link", "soil__flux")
+            self._flux = self._grid.add_zeros("soil__flux", at="link")
 
     def soilflux(self, dt):
         """Calculate soil flux for a time period 'dt'.

--- a/landlab/components/transport_length_diffusion/transport_length_hillslope_diffusion.py
+++ b/landlab/components/transport_length_diffusion/transport_length_hillslope_diffusion.py
@@ -65,7 +65,7 @@ class TransportLengthHillslopeDiffuser(Component):
     ...               0., 1., 1., 1., 0.,
     ...               0., 1., 1., 1., 0.,
     ...               0., 0., 0., 0., 0.])
-    >>> _ = mg.add_field('node', 'topographic__elevation', z)
+    >>> _ = mg.add_field("topographic__elevation", z, at="node")
 
     Instantiate Flow director (steepest slope type) and TL hillslope diffuser
 

--- a/landlab/components/weathering/exponential_weathering.py
+++ b/landlab/components/weathering/exponential_weathering.py
@@ -42,8 +42,8 @@ class ExponentialWeatherer(Component):
     >>> from landlab import RasterModelGrid
     >>> from landlab.components import ExponentialWeatherer
     >>> mg = RasterModelGrid((5, 5))
-    >>> soilz = mg.add_zeros('node', 'soil__depth')
-    >>> soilrate = mg.add_ones('node', 'soil_production__rate')
+    >>> soilz = mg.add_zeros("soil__depth", at="node")
+    >>> soilrate = mg.add_ones("soil_production__rate", at="node")
     >>> expw = ExponentialWeatherer(mg)
     >>> expw.calc_soil_prod_rate()
     >>> np.allclose(mg.at_node['soil_production__rate'], 1.)
@@ -89,7 +89,7 @@ class ExponentialWeatherer(Component):
         if "soil_production__rate" in grid.at_node:
             self._soil_prod_rate = grid.at_node["soil_production__rate"]
         else:
-            self._soil_prod_rate = grid.add_zeros("node", "soil_production__rate")
+            self._soil_prod_rate = grid.add_zeros("soil_production__rate", at="node")
 
     def calc_soil_prod_rate(self):
         """Calculate soil production rate."""

--- a/landlab/core/model_component.py
+++ b/landlab/core/model_component.py
@@ -380,7 +380,7 @@ class Component:
                 init_vals = np.zeros(size, dtype=type_in)
                 units_in = self.var_units(name)
 
-                self.grid.add_field(at, name, init_vals, units=units_in, copy=False)
+                self.grid.add_field(name, init_vals, at=at, units=units_in, copy=False)
 
     def initialize_optional_output_fields(self):
         """Create fields for a component based on its optional field outputs,
@@ -403,7 +403,7 @@ class Component:
                 init_vals = self.grid.zeros(at, dtype=type_in)
                 units_in = self.var_units(name)
 
-                self.grid.add_field(at, name, init_vals, units=units_in, copy=False)
+                self.grid.add_field(name, init_vals, at=at, units=units_in, copy=False)
 
     @property
     def shape(self):

--- a/landlab/field/graph_field.py
+++ b/landlab/field/graph_field.py
@@ -574,7 +574,7 @@ class GraphFields(object):
         >>> from landlab.field import GraphFields
         >>> fields = GraphFields()
         >>> fields.new_field_location('node', 12)
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
         >>> fields.has_field('node', 'topographic__elevation')
         True
         >>> fields.has_field('cell', 'topographic__elevation')
@@ -679,7 +679,7 @@ class GraphFields(object):
         to the *node* group. The *field_values* method returns a reference
         to the field's data.
 
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
         >>> fields.field_values('node', 'topographic__elevation')
         array([ 1.,  1.,  1.,  1.])
 
@@ -750,7 +750,7 @@ class GraphFields(object):
         to the *node* group. The *field_values* method returns a reference
         to the field's data.
 
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
         >>> fields.field_values('node', 'topographic__elevation')
         array([ 1.,  1.,  1.,  1.])
 
@@ -1194,7 +1194,7 @@ class GraphFields(object):
         >>> from landlab.field import GraphFields
         >>> field = GraphFields()
         >>> field.new_field_location('node', 4)
-        >>> field.add_ones('node', 'topographic__elevation')
+        >>> field.add_ones("topographic__elevation", at="node")
         array([ 1.,  1.,  1.,  1.])
         >>> list(field.keys('node'))
         ['topographic__elevation']

--- a/landlab/field/graph_field.py
+++ b/landlab/field/graph_field.py
@@ -1006,7 +1006,7 @@ class GraphFields(object):
         >>> field = GraphFields()
         >>> field.new_field_location('node', 4)
         >>> values = np.ones(4, dtype=int)
-        >>> field.add_field('node', 'topographic__elevation', values)
+        >>> field.add_field("topographic__elevation", values, at="node")
         array([1, 1, 1, 1])
 
         A new field is added to the collection of fields. The saved value

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -232,7 +232,7 @@ class ModelDataFields(object):
         >>> fields.new_field_location('node', 4)
         >>> list(fields.keys('node'))
         []
-        >>> _ = fields.add_empty('node', 'topographic__elevation')
+        >>> _ = fields.add_empty("topographic__elevation", at="node")
         >>> list(fields.keys('node'))
         ['topographic__elevation']
 

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -87,12 +87,12 @@ class ModelDataFields(object):
     fields are in different groups (node and cell), they can have the same
     name.
 
-    >>> fields.add_ones('node', 'topographic__elevation')
+    >>> fields.add_ones("topographic__elevation", at="node")
     array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.])
     >>> fields.at_node['topographic__elevation']
     array([ 1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.])
 
-    >>> fields.add_ones('cell', 'topographic__elevation')
+    >>> fields.add_ones("topographic__elevation", at="cell")
     array([ 1.,  1.])
     >>> fields.at_cell['topographic__elevation']
     array([ 1.,  1.])
@@ -197,7 +197,7 @@ class ModelDataFields(object):
         >>> from landlab.field import ModelDataFields
         >>> fields = ModelDataFields()
         >>> fields.new_field_location('node', 12)
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
         >>> fields.has_field('node', 'topographic__elevation')
         True
         >>> fields.has_field('cell', 'topographic__elevation')
@@ -360,8 +360,8 @@ class ModelDataFields(object):
         to the *node* group. The *field_values* method returns a reference
         to the field's data.
 
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
-        >>> fields.field_values('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
+        >>> fields.field_values("node", "topographic__elevation")
         array([ 1.,  1.,  1.,  1.])
 
         Raise FieldError if *field* does not exist in *group*.
@@ -424,8 +424,8 @@ class ModelDataFields(object):
         to the *node* group. The *field_values* method returns a reference
         to the field's data.
 
-        >>> _ = fields.add_ones('node', 'topographic__elevation')
-        >>> fields.field_values('node', 'topographic__elevation')
+        >>> _ = fields.add_ones("topographic__elevation", at="node")
+        >>> fields.field_values("node", "topographic__elevation")
         array([ 1.,  1.,  1.,  1.])
 
         Alternatively, if the second argument is an array, its size is
@@ -733,7 +733,7 @@ class ModelDataFields(object):
         >>> from landlab.field import ModelDataFields
         >>> field = ModelDataFields()
         >>> field.new_field_location('node', 4)
-        >>> field.add_ones('node', 'topographic__elevation')
+        >>> field.add_ones("topographic__elevation", at="node")
         array([ 1.,  1.,  1.,  1.])
         >>> list(field.keys('node'))
         ['topographic__elevation']

--- a/landlab/field/grouped.py
+++ b/landlab/field/grouped.py
@@ -134,8 +134,7 @@ class ModelDataFields(object):
         >>> fields = ModelDataFields()
         >>> fields.new_field_location('node', 12)
 
-        >>> fields.add_field("z", [1.] * 12)
-        ...     # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> fields.add_field("z", [1.] * 12) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ValueError: missing group name
         >>> fields.set_default_group('node')

--- a/landlab/field/scalar_data_fields.py
+++ b/landlab/field/scalar_data_fields.py
@@ -123,8 +123,12 @@ class ScalarDataFields(dict):
     >>> from landlab import RasterModelGrid
     >>> import numpy as np
     >>> mg = RasterModelGrid((4, 5))
-    >>> z = mg.add_field('cell', 'topographic__elevation', np.random.rand(
-    ...         mg.number_of_cells), units='m')
+    >>> z = mg.add_field(
+    ...     "topographic__elevation",
+    ...     np.random.rand(mg.number_of_cells),
+    ...     at="cell",
+    ...     units="m",
+    ... )
     >>> mg.at_cell['topographic__elevation'].size == mg.number_of_cells
     True
 

--- a/landlab/grid/divergence.py
+++ b/landlab/grid/divergence.py
@@ -47,7 +47,7 @@ def calc_flux_div_at_node(grid, unit_flux, out=None):
     >>> calc_flux_div_at_node(rg, unit_flux_at_links)
     array([ 0.  ,  0.  ,  0.  ,  0.  ,  0.  ,  1.14,  0.22,  0.  ,  0.  ,
             0.  ,  0.  ,  0.  ])
-    >>> _ = rg.add_field('neg_grad_at_link', -lg, at = 'link')
+    >>> _ = rg.add_field("neg_grad_at_link", -lg, at="link")
     >>> calc_flux_div_at_node(rg, 'neg_grad_at_link')
     array([ 0.  ,  0.  ,  0.  ,  0.  ,  0.  ,  1.64,  0.94,  0.  ,  0.  ,
             0.  ,  0.  ,  0.  ])
@@ -121,7 +121,7 @@ def calc_flux_div_at_cell(grid, unit_flux, out=None):
     >>> unit_flux_at_faces[rg.active_faces] = -fg[rg.active_faces]
     >>> calc_flux_div_at_cell(rg, unit_flux_at_faces)
     array([ 1.14,  0.22])
-    >>> _ = rg.add_field('neg_grad_at_link', -lg, at = 'link')
+    >>> _ = rg.add_field("neg_grad_at_link", -lg, at="link")
     >>> calc_flux_div_at_cell(rg, 'neg_grad_at_link')
     array([ 1.64,  0.94])
 

--- a/landlab/grid/divergence.py
+++ b/landlab/grid/divergence.py
@@ -30,7 +30,7 @@ def calc_flux_div_at_node(grid, unit_flux, out=None):
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.divergence import calc_flux_div_at_node
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)  # there are 17 links
@@ -103,7 +103,7 @@ def calc_flux_div_at_cell(grid, unit_flux, out=None):
     >>> from landlab.grid.divergence import calc_flux_div_at_cell
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
     >>> import numpy as np
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)  # there are 17 links
@@ -179,7 +179,7 @@ def calc_net_flux_at_node(grid, unit_flux_at_links, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)  # there are 17 links
@@ -257,7 +257,7 @@ def _calc_net_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)
@@ -326,7 +326,7 @@ def _calc_face_flux_divergence_at_cell(grid, unit_flux_at_faces):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)
@@ -376,7 +376,7 @@ def _calc_net_active_face_flux_at_cell(grid, unit_flux_at_faces, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> fg = rg.calc_grad_at_link(z)[rg.link_at_face]  # there are 7 faces
@@ -446,7 +446,7 @@ def _calc_active_face_flux_divergence_at_cell(grid, unit_flux_at_faces):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> fg = rg.calc_grad_at_link(z)[rg.link_at_face]  # there are 7 faces
@@ -496,7 +496,7 @@ def _calc_net_active_link_flux_at_node(grid, unit_flux_at_links, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)  # there are 17 links
@@ -570,7 +570,7 @@ def _calc_active_link_flux_divergence_at_node(grid, unit_flux_at_links, out=None
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> lg = rg.calc_grad_at_link(z)  # there are 17 links
@@ -626,7 +626,7 @@ def _calc_net_face_flux_at_node(grid, unit_flux_at_faces, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> fg = rg.calc_grad_at_link(z)[rg.link_at_face]  # there are 7 faces
@@ -696,7 +696,7 @@ def _calc_net_active_face_flux_at_node(grid, unit_flux_at_faces, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> fg = rg.calc_grad_at_link(z)[rg.link_at_face]  # there are 7 faces
@@ -765,7 +765,7 @@ def _calc_active_face_flux_divergence_at_node(grid, unit_flux_at_faces, out=None
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> fg = rg.calc_grad_at_link(z)[rg.link_at_face]  # there are 7 faces

--- a/landlab/grid/gradients.py
+++ b/landlab/grid/gradients.py
@@ -41,7 +41,7 @@ def calc_grad_at_link(grid, node_values, out=None):
     --------
     >>> from landlab import RasterModelGrid
     >>> rg = RasterModelGrid((3, 4), xy_spacing=10.0)
-    >>> z = rg.add_zeros('node', 'topographic__elevation')
+    >>> z = rg.add_zeros("topographic__elevation", at="node")
     >>> z[5] = 50.0
     >>> z[6] = 36.0
     >>> calc_grad_at_link(rg, z)  # there are 17 links

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -568,7 +568,7 @@ def map_min_of_node_links_to_node(grid, var_name, out=None):
              3.,   4.,   5.,   6.,
             10.,  11.,  12.,  13.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
     >>> rtn = map_min_of_node_links_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([  0.,   0.,   1.,   2.,
@@ -629,7 +629,7 @@ def map_max_of_node_links_to_node(grid, var_name, out=None):
             10.,  11.,  12.,  13.,
             14.,  15.,  16.,  16.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
     >>> rtn = map_max_of_node_links_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([  3.,   4.,   5.,   6.,
@@ -696,9 +696,8 @@ def map_upwind_node_link_max_to_node(grid, var_name, out=None):
             0.,  1.,  2.,  1.,
             0.,  1.,  2.,  1.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
-    >>> rtn = map_upwind_node_link_max_to_node(rmg, 'grad',
-    ...                                        out=values_at_nodes)
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
+    >>> rtn = map_upwind_node_link_max_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([ 0.,  1.,  2.,  1.,
             0.,  1.,  2.,  1.,
@@ -762,9 +761,8 @@ def map_downwind_node_link_max_to_node(grid, var_name, out=None):
             1.,  2.,  1.,  0.,
             1.,  2.,  1.,  0.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
-    >>> rtn = map_downwind_node_link_max_to_node(rmg, 'grad',
-    ...                                        out=values_at_nodes)
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
+    >>> rtn = map_downwind_node_link_max_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([ 1.,  2.,  1.,  0.,
             1.,  2.,  1.,  0.,
@@ -829,9 +827,8 @@ def map_upwind_node_link_mean_to_node(grid, var_name, out=None):
             2. ,  2. ,  3. ,  3. ,
             1. ,  1.5,  2.5,  2.5])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
-    >>> rtn = map_upwind_node_link_mean_to_node(rmg, 'grad',
-    ...                                         out=values_at_nodes)
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
+    >>> rtn = map_upwind_node_link_mean_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([ 0. ,  1. ,  2. ,  1. ,
             2. ,  2. ,  3. ,  3. ,
@@ -900,9 +897,8 @@ def map_downwind_node_link_mean_to_node(grid, var_name, out=None):
             1. ,  2. ,  2. ,  4. ,
             1. ,  2. ,  1. ,  0. ])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
-    >>> rtn = map_downwind_node_link_mean_to_node(rmg, 'grad',
-    ...                                         out=values_at_nodes)
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
+    >>> rtn = map_downwind_node_link_mean_to_node(rmg, 'grad', out=values_at_nodes)
     >>> values_at_nodes
     array([ 1.5,  2.5,  2.5,  5. ,
             1. ,  2. ,  2. ,  4. ,
@@ -977,9 +973,10 @@ def map_value_at_upwind_node_link_max_to_node(grid, control_name, value_name, ou
              0.,   7.,   8.,   9.,
              0.,  14.,  15.,  16.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
-    >>> rtn = map_value_at_upwind_node_link_max_to_node(rmg, 'grad', 'vals',
-    ...                                                 out=values_at_nodes)
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
+    >>> rtn = map_value_at_upwind_node_link_max_to_node(
+    ...     rmg, 'grad', 'vals', out=values_at_nodes
+    ... )
     >>> values_at_nodes
     array([  0.,   0.,   1.,   2.,
              0.,   7.,   8.,   9.,
@@ -1057,7 +1054,7 @@ def map_value_at_downwind_node_link_max_to_node(
              7.,   8.,   9.,   0.,
             14.,  15.,  16.,   0.])
 
-    >>> values_at_nodes = rmg.add_empty('node', 'z')
+    >>> values_at_nodes = rmg.add_empty("z", at="node")
     >>> rtn = map_value_at_downwind_node_link_max_to_node(rmg, 'grad', 'vals',
     ...                                                   out=values_at_nodes)
     >>> values_at_nodes

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -202,10 +202,15 @@ def map_min_of_link_nodes_to_link(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('node', 'z',
-    ...                   [[ 0,  1,  2,  3],
-    ...                    [ 7,  6,  5,  4],
-    ...                    [ 8,  9, 10, 11]])
+    >>> _ = rmg.add_field(
+    ...     "z",
+    ...     [
+    ...         [ 0,  1,  2,  3],
+    ...         [ 7,  6,  5,  4],
+    ...         [ 8,  9, 10, 11],
+    ...     ],
+    ...     at="node",
+    ... )
     >>> map_min_of_link_nodes_to_link(rmg, 'z')
     array([  0.,   1.,   2.,   0.,   1.,   2.,   3.,   6.,   5.,   4.,   7.,
              6.,   5.,   4.,   8.,   9.,  10.])
@@ -262,10 +267,15 @@ def map_max_of_link_nodes_to_link(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('node', 'z',
-    ...                   [[0, 1, 2, 3],
-    ...                    [7, 6, 5, 4],
-    ...                    [8, 9, 10, 11]])
+    >>> _ = rmg.add_field(
+    ...     "z",
+    ...     [
+    ...         [0, 1, 2, 3],
+    ...         [7, 6, 5, 4],
+    ...         [8, 9, 10, 11],
+    ...     ],
+    ...     at="node",
+    ... )
     >>> map_max_of_link_nodes_to_link(rmg, 'z')
     array([  1.,   2.,   3.,   7.,   6.,   5.,   4.,   7.,   6.,   5.,   8.,
              9.,  10.,  11.,   9.,  10.,  11.])
@@ -384,14 +394,24 @@ def map_value_at_min_node_to_link(grid, control_name, value_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('node', 'z',
-    ...                   [[0, 1, 2, 3],
-    ...                    [7, 6, 5, 4],
-    ...                    [8, 9, 10, 11]])
-    >>> _ = rmg.add_field('node', 'vals_to_map',
-    ...                   [[0, 10, 20, 30],
-    ...                    [70, 60, 50, 40],
-    ...                    [80, 90, 100, 110]])
+    >>> _ = rmg.add_field(
+    ...     "z",
+    ...     [
+    ...         [0, 1, 2, 3],
+    ...         [7, 6, 5, 4],
+    ...         [8, 9, 10, 11],
+    ...     ],
+    ...     at="node",
+    ... )
+    >>> _ = rmg.add_field(
+    ...     "vals_to_map",
+    ...     [
+    ...         [0, 10, 20, 30],
+    ...         [70, 60, 50, 40],
+    ...         [80, 90, 100, 110],
+    ...     ],
+    ...     at="node",
+    ... )
     >>> map_value_at_min_node_to_link(rmg, 'z', 'vals_to_map')
     array([   0.,   10.,   20.,    0.,   10.,   20.,   30.,   60.,   50.,
              40.,   70.,   60.,   50.,   40.,   80.,   90.,  100.])
@@ -449,14 +469,24 @@ def map_value_at_max_node_to_link(grid, control_name, value_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('node', 'z',
-    ...                   [[0, 1, 2, 3],
-    ...                    [7, 6, 5, 4],
-    ...                    [8, 9, 10, 11]])
-    >>> _ = rmg.add_field('node', 'vals_to_map',
-    ...                   [[0, 10, 20, 30],
-    ...                    [70, 60, 50, 40],
-    ...                    [80, 90, 100, 110]])
+    >>> _ = rmg.add_field(
+    ...     "z",
+    ...     [
+    ...         [0, 1, 2, 3],
+    ...         [7, 6, 5, 4],
+    ...         [8, 9, 10, 11],
+    ...     ],
+    ...     at="node",
+    ... )
+    >>> _ = rmg.add_field(
+    ...     "vals_to_map",
+    ...     [
+    ...         [0, 10, 20, 30],
+    ...         [70, 60, 50, 40],
+    ...         [80, 90, 100, 110],
+    ...     ],
+    ...     at="node",
+    ... )
     >>> map_value_at_max_node_to_link(rmg, 'z', 'vals_to_map')
     array([  10.,   20.,   30.,   70.,   60.,   50.,   40.,   70.,   60.,
              50.,   80.,   90.,  100.,  110.,   90.,  100.,  110.])
@@ -509,7 +539,7 @@ def map_node_to_cell(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('node', 'z', np.arange(12.))
+    >>> _ = rmg.add_field("z", np.arange(12.), at="node")
     >>> map_node_to_cell(rmg, 'z')
     array([ 5.,  6.])
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -1902,7 +1902,7 @@ class RasterModelGrid(
         ...                      -9999.,    67.,    67., -9999.,
         ...                      -9999.,    67.,     0., -9999.,
         ...                      -9999., -9999., -9999., -9999.])
-        >>> _ = rmg.add_field('node', 'topographic__elevation', node_data)
+        >>> _ = rmg.add_field("topographic__elevation", node_data, at="node")
         >>> out_id = rmg.set_watershed_boundary_condition('topographic__elevation',
         ...                                               -9999.,
         ...                                               True)

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -220,7 +220,7 @@ def calc_grad_at_link(grid, node_values, out=None):
     >>> grid = RasterModelGrid((3, 3), xy_spacing=(2, 1))
     >>> grid.calc_grad_at_link(node_values)
     array([ 0.,  0.,  1.,  3.,  1.,  1., -1.,  1., -1.,  1.,  0.,  0.])
-    >>> _ = grid.add_field('node', 'elevation', node_values)
+    >>> _ = grid.add_field("elevation", node_values, at="node")
     >>> grid.calc_grad_at_link('elevation')
     array([ 0.,  0.,  1.,  3.,  1.,  1., -1.,  1., -1.,  1.,  0.,  0.])
 

--- a/landlab/grid/raster_mappers.py
+++ b/landlab/grid/raster_mappers.py
@@ -58,7 +58,7 @@ def map_sum_of_inlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_sum_of_inlinks_to_node(rmg, 'z')
     array([  0.,   0.,   1.,   2.,   3.,  11.,  13.,  15.,  10.,  25.,  27.,
             29.])
@@ -111,7 +111,7 @@ def map_mean_of_inlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_mean_of_inlinks_to_node(rmg, 'z')
     array([  0. ,   0. ,   0.5,   1. ,   1.5,   5.5,   6.5,   7.5,   5. ,
             12.5,  13.5,  14.5])
@@ -165,7 +165,7 @@ def map_max_of_inlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_max_of_inlinks_to_node(rmg, 'z')
     array([  0.,   0.,   1.,   2.,
              3.,   7.,   8.,   9.,
@@ -220,7 +220,7 @@ def map_min_of_inlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_min_of_inlinks_to_node(rmg, 'z')
     array([  0.,   0.,   0.,   0.,   0.,   4.,   5.,   6.,   0.,  11.,  12.,
             13.])
@@ -274,7 +274,7 @@ def map_sum_of_outlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_sum_of_outlinks_to_node(rmg, 'z')
     array([  3.,  5.,  7.,   6.,  17.,  19.,  21.,  13.,  14.,  15.,  16.,
              0.])
@@ -328,7 +328,7 @@ def map_mean_of_outlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_mean_of_outlinks_to_node(rmg, 'z')
     array([  1.5,   2.5,   3.5,   3. ,   8.5,   9.5,  10.5,   6.5,   7. ,
              7.5,   8. ,   0. ])
@@ -382,7 +382,7 @@ def map_max_of_outlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_max_of_outlinks_to_node(rmg, 'z')
     array([  3.,   4.,   5.,   6.,  10.,  11.,  12.,  13.,  14.,  15.,  16.,
              0.])
@@ -436,7 +436,7 @@ def map_min_of_outlinks_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_min_of_outlinks_to_node(rmg, 'z')
     array([ 0.,  1.,  2.,  0.,  7.,  8.,  9.,  0.,  0.,  0.,  0.,  0.])
 
@@ -489,7 +489,7 @@ def map_mean_of_links_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_mean_of_links_to_node(rmg, 'z')
     array([  1.5       ,   1.66666667,   2.66666667,   4.        ,
              6.66666667,   7.5       ,   8.5       ,   9.33333333,
@@ -556,7 +556,7 @@ def map_mean_of_horizontal_links_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_mean_of_horizontal_links_to_node(rmg, 'z')
     array([  0. ,   0.5,   1.5,   2. ,   7. ,   7.5,   8.5,   9. ,  14. ,
             14.5,  15.5,  16. ])
@@ -612,7 +612,7 @@ def map_mean_of_horizontal_active_links_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', -np.arange(17, dtype=float))
+    >>> _ = rmg.add_field("z", -np.arange(17, dtype=float), at="link")
     >>> rmg.status_at_node[rmg.nodes_at_left_edge] = rmg.BC_NODE_IS_CLOSED
     >>> map_mean_of_horizontal_active_links_to_node(rmg, 'z')
     array([ 0. ,  0. ,  0. ,  0. ,  0. , -8. , -8.5, -9. ,  0. ,  0. ,  0. ,
@@ -671,7 +671,7 @@ def map_mean_of_vertical_links_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', np.arange(17.))
+    >>> _ = rmg.add_field("z", np.arange(17.), at="link")
     >>> map_mean_of_vertical_links_to_node(rmg, 'z')
     array([  3. ,   4. ,   5. ,   6. ,   6.5,   7.5,   8.5,   9.5,  10. ,
             11. ,  12. ,  13. ])
@@ -727,7 +727,7 @@ def map_mean_of_vertical_active_links_to_node(grid, var_name, out=None):
     >>> from landlab import RasterModelGrid
 
     >>> rmg = RasterModelGrid((3, 4))
-    >>> _ = rmg.add_field('link', 'z', -np.arange(17, dtype=float))
+    >>> _ = rmg.add_field("z", -np.arange(17, dtype=float), at="link")
     >>> rmg.status_at_node[rmg.nodes_at_bottom_edge] = rmg.BC_NODE_IS_CLOSED
     >>> map_mean_of_vertical_active_links_to_node(rmg, 'z')
     array([  0.,   0.,   0.,   0.,   0., -11., -12.,   0.,   0., -11., -12.,

--- a/landlab/io/esri_ascii.py
+++ b/landlab/io/esri_ascii.py
@@ -500,7 +500,7 @@ def read_esri_ascii(asc_file, grid=None, reshape=False, name=None, halo=0):
             shape, xy_spacing=xy_spacing, xy_of_lower_left=xy_of_lower_left
         )
     if name:
-        grid.add_field("node", name, data)
+        grid.add_field(name, data, at="node")
 
     return (grid, data)
 
@@ -532,13 +532,13 @@ def write_esri_ascii(path, fields, names=None, clobber=False):
     >>> from landlab.io.esri_ascii import write_esri_ascii
 
     >>> grid = RasterModelGrid((4, 5), xy_spacing=(2., 2.))
-    >>> _ = grid.add_field('node', 'air__temperature', np.arange(20.))
+    >>> _ = grid.add_field("air__temperature", np.arange(20.), at="node")
     >>> with cdtemp() as _:
     ...     files = write_esri_ascii('test.asc', grid)
     >>> files
     ['test.asc']
 
-    >>> _ = grid.add_field('node', 'land_surface__elevation', np.arange(20.))
+    >>> _ = grid.add_field("land_surface__elevation", np.arange(20.), at="node")
     >>> with cdtemp() as _:
     ...     files = write_esri_ascii('test.asc', grid)
     >>> files.sort()

--- a/landlab/io/gebco/read.py
+++ b/landlab/io/gebco/read.py
@@ -110,7 +110,7 @@ def read_netcdf(nc_file, just_grid=False):
     if not just_grid:
         fields = _read_netcdf_structured_data(root)
         for (name, values) in fields.items():
-            grid.add_field("node", name, values)
+            grid.add_field(name, values, at="node")
 
     root.close()
 

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -197,7 +197,7 @@ class use_field_name_or_array(object):
 
     The array of values can be a field name.
 
-    >>> _ = grid.add_field('cell', 'elevation', [0, 1, 2, 3, 4, 5])
+    >>> _ = grid.add_field("elevation", [0, 1, 2, 3, 4, 5], at="cell")
     >>> my_func(grid, 'elevation')
     array([  0.,   2.,   4.,   6.,   8.,  10.])
     """
@@ -286,7 +286,7 @@ class use_field_name_array_or_value(object):
 
     The array of values can be a field name.
 
-    >>> _ = grid.add_field('cell', 'elevation', [0, 1, 2, 3, 4, 5])
+    >>> _ = grid.add_field("elevation", [0, 1, 2, 3, 4, 5], at="cell")
     >>> my_func(grid, 'elevation')
     array([  0.,   2.,   4.,   6.,   8.,  10.])
 

--- a/landlab/utils/distance_to_divide.py
+++ b/landlab/utils/distance_to_divide.py
@@ -46,7 +46,7 @@ def calculate_distance_to_divide(
     ...                  0., 20., 20., 0.,
     ...                  0., 30., 30., 0.,
     ...                  0.,  0.,  0., 0.])
-    >>> _ = mg.add_field('node','topographic__elevation', elev)
+    >>> _ = mg.add_field("topographic__elevation", elev, at="node")
     >>> mg.set_closed_boundaries_at_grid_edges(
     ...     bottom_is_closed=False,
     ...     left_is_closed=True,
@@ -79,7 +79,7 @@ def calculate_distance_to_divide(
     ...                  0., 20., 20., 0.,
     ...                  0., 30., 30., 0.,
     ...                  0.,  0.,  0., 0.])
-    >>> _ = mg.add_field('node','topographic__elevation', elev)
+    >>> _ = mg.add_field("topographic__elevation", elev, at="node")
     >>> mg.set_closed_boundaries_at_grid_edges(
     ...     bottom_is_closed=False,
     ...     left_is_closed=True,
@@ -109,9 +109,11 @@ def calculate_distance_to_divide(
     ...     calculate_distance_to_divide)
     >>> dx = 1
     >>> hmg = HexModelGrid((5, 3), dx)
-    >>> _ = hmg.add_field('topographic__elevation',
-    ...                   hmg.node_x + np.round(hmg.node_y),
-    ...                   at = 'node')
+    >>> _ = hmg.add_field(
+    ...     "topographic__elevation",
+    ...     hmg.node_x + np.round(hmg.node_y),
+    ...     at="node",
+    ... )
     >>> hmg.status_at_node[hmg.boundary_nodes] = hmg.BC_NODE_IS_CLOSED
     >>> hmg.status_at_node[0] = hmg.BC_NODE_IS_FIXED_VALUE
     >>> fr = FlowAccumulator(hmg, flow_director = 'D4')

--- a/landlab/utils/flow__distance.py
+++ b/landlab/utils/flow__distance.py
@@ -39,7 +39,7 @@ def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
     ...                  0., 31., 20., 0.,
     ...                  0., 32., 30., 0.,
     ...                  0.,  0.,  0., 0.])
-    >>> _ = mg.add_field('node','topographic__elevation', elev)
+    >>> _ = mg.add_field("topographic__elevation", elev, at="node")
     >>> mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True,
     ...                                        left_is_closed=True,
     ...                                        right_is_closed=True,
@@ -66,11 +66,13 @@ def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
     ...                  0., 31., 20., 0.,
     ...                  0., 32., 30., 0.,
     ...                  0.,  0.,  0., 0.])
-    >>> _ = mg.add_field('node','topographic__elevation', elev)
-    >>> mg.set_closed_boundaries_at_grid_edges(bottom_is_closed=True,
-    ...                                        left_is_closed=True,
-    ...                                        right_is_closed=True,
-    ...                                        top_is_closed=True)
+    >>> _ = mg.add_field("topographic__elevation", elev, at="node")
+    >>> mg.set_closed_boundaries_at_grid_edges(
+    ...     bottom_is_closed=True,
+    ...     left_is_closed=True,
+    ...     right_is_closed=True,
+    ...     top_is_closed=True,
+    ... )
     >>> fr = FlowAccumulator(mg, flow_director = 'D4')
     >>> fr.run_one_step()
     >>> flow__distance = calculate_flow__distance(mg, add_to_grid=True, clobber=True)
@@ -90,9 +92,11 @@ def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
     >>> from landlab.utils.flow__distance import calculate_flow__distance
     >>> dx = 1
     >>> hmg = HexModelGrid((5, 3), spacing=dx)
-    >>> _ = hmg.add_field('topographic__elevation',
-    ...                   hmg.node_x + np.round(hmg.node_y),
-    ...                   at = 'node')
+    >>> _ = hmg.add_field(
+    ...     "topographic__elevation",
+    ...     hmg.node_x + np.round(hmg.node_y),
+    ...     at="node",
+    ... )
     >>> hmg.status_at_node[hmg.boundary_nodes] = hmg.BC_NODE_IS_CLOSED
     >>> hmg.status_at_node[0] = hmg.BC_NODE_IS_FIXED_VALUE
     >>> fr = FlowAccumulator(hmg, flow_director = 'D4')

--- a/tests/ca/boundaries/test_hex_normal_fault.py
+++ b/tests/ca/boundaries/test_hex_normal_fault.py
@@ -83,7 +83,7 @@ def test_shift_link_and_transition_data_upward():
     xnlist.append(Transition((0, 0, 0), (1, 1, 0), 1.0, "frogging"))
     xnlist.append(Transition((0, 0, 1), (1, 1, 1), 1.0, "frogging"))
     xnlist.append(Transition((0, 0, 2), (1, 1, 2), 1.0, "frogging"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     ohcts = OrientedHexCTS(mg, nsd, xnlist, nsg)
 
     assert_array_equal(

--- a/tests/ca/cts_model.py
+++ b/tests/ca/cts_model.py
@@ -126,7 +126,7 @@ class CTSModel(object):
                 node_layout=node_layout,
             )
 
-        self.grid.add_zeros("node", "node_state", dtype=int)
+        self.grid.add_zeros("node_state", at="node", dtype=int)
 
     def node_state_dictionary(self):
         """Create and return a dictionary of all possible node (cell) states.

--- a/tests/ca/grain_hill.py
+++ b/tests/ca/grain_hill.py
@@ -433,7 +433,7 @@ class GrainHill(CTSModel):
         --------
         >>> from landlab import HexModelGrid
         >>> hg = HexModelGrid((4, 5), node_layout='rect', orientation='vertical')
-        >>> ns = hg.add_zeros('node', 'node_state', dtype=int)
+        >>> ns = hg.add_zeros("node_state", at="node", dtype=int)
         >>> ns[[0, 3, 1, 6, 4, 9, 2]] = 8
         >>> ns[[8, 13, 11, 16, 14]] = 7
         >>> gh = GrainHill((3, 7))  # grid size arbitrary here

--- a/tests/ca/test_celllab_cts.py
+++ b/tests/ca/test_celllab_cts.py
@@ -69,7 +69,7 @@ def test_raster_cts():
     ns_dict = {0: "black", 1: "white"}
     xn_list = []
     xn_list.append(Transition((1, 0, 0), (0, 1, 0), 0.1, "", True, callback_function))
-    pd = mg.add_zeros("node", "property_data", dtype=int)
+    pd = mg.add_zeros("property_data", at="node", dtype=int)
     pd[5] = 50
     ca = RasterCTS(
         mg, ns_dict, xn_list, node_state_grid, prop_data=pd, prop_reset_value=0
@@ -125,7 +125,7 @@ def test_raster_cts():
     mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
     nsg = mg.add_ones("node_state_map", at="node", dtype=int)
     nsg[6] = 0
-    pd = mg.add_zeros("node", "property_data", dtype=int)
+    pd = mg.add_zeros("property_data", at="node", dtype=int)
     pd[5] = 50
     ca = RasterCTS(mg, ns_dict, xn_list, nsg, prop_data=pd, prop_reset_value=0, seed=1)
     prior_first_event_time = event_time
@@ -139,7 +139,7 @@ def test_oriented_raster_cts():
     nsd = {0: "oui", 1: "non"}
     xnlist = []
     xnlist.append(Transition((0, 1, 0), (1, 1, 0), 1.0, "hopping"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     orcts = OrientedRasterCTS(mg, nsd, xnlist, nsg)
 
     assert orcts.num_link_states == 8
@@ -159,7 +159,7 @@ def test_hex_cts():
     nsd = {0: "zero", 1: "one"}
     xnlist = []
     xnlist.append(Transition((0, 1, 0), (1, 1, 0), 1.0, "transitioning"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     hcts = HexCTS(mg, nsd, xnlist, nsg)
 
     assert hcts.num_link_states == 4
@@ -178,7 +178,7 @@ def test_oriented_hex_cts():
     nsd = {0: "zero", 1: "one"}
     xnlist = []
     xnlist.append(Transition((0, 1, 0), (1, 1, 0), 1.0, "transitioning"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     ohcts = OrientedHexCTS(mg, nsd, xnlist, nsg)
 
     assert ohcts.num_link_states == 12
@@ -343,7 +343,7 @@ def test_transitions_as_ids():
     nsd = {0: "zero", 1: "one"}
     xnlist = []
     xnlist.append(Transition(2, 3, 1.0, "transitioning"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     cts = HexCTS(mg, nsd, xnlist, nsg)
     assert cts.num_link_states == 4, "wrong number of transitions"
 
@@ -354,7 +354,7 @@ def test_handle_grid_mismatch():
     nsd = {0: "zero", 1: "one"}
     xnlist = []
     xnlist.append(Transition(2, 3, 1.0, "transitioning"))
-    nsg = mg.add_zeros("node", "node_state_grid")
+    nsg = mg.add_zeros("node_state_grid", at="node")
     assert_raises(TypeError, RasterCTS, mg, nsd, xnlist, nsg)
     assert_raises(TypeError, OrientedRasterCTS, mg, nsd, xnlist, nsg)
 

--- a/tests/ca/test_celllab_cts.py
+++ b/tests/ca/test_celllab_cts.py
@@ -64,7 +64,7 @@ def test_raster_cts():
     # Set up a small grid with no events scheduled
     mg = RasterModelGrid((4, 4))
     mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    node_state_grid = mg.add_ones("node", "node_state_map", dtype=int)
+    node_state_grid = mg.add_ones("node_state_map", at="node", dtype=int)
     node_state_grid[6] = 0
     ns_dict = {0: "black", 1: "white"}
     xn_list = []
@@ -123,7 +123,7 @@ def test_raster_cts():
     # a different random seed.
     mg = RasterModelGrid((4, 4))
     mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    nsg = mg.add_ones("node", "node_state_map", dtype=int)
+    nsg = mg.add_ones("node_state_map", at="node", dtype=int)
     nsg[6] = 0
     pd = mg.add_zeros("node", "property_data", dtype=int)
     pd[5] = 50

--- a/tests/components/chi_index/test_chi_finder.py
+++ b/tests/components/chi_index/test_chi_finder.py
@@ -6,7 +6,7 @@ from landlab.components import ChiFinder, FlowAccumulator
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -17,7 +17,7 @@ def test_route_to_multiple_error_raised():
 
 def test_bad_reference_area():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg)
     fa.run_one_step()
@@ -28,7 +28,7 @@ def test_bad_reference_area():
 
 def test_functions_with_Hex():
     mg = HexModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg)
     fa.run_one_step()

--- a/tests/components/depression_finder/conftest.py
+++ b/tests/components/depression_finder/conftest.py
@@ -120,7 +120,7 @@ def dans_grid3():
         ]
     ).flatten()
 
-    mg.add_field("node", "topographic__elevation", z, units="-")
+    mg.add_field("topographic__elevation", z, at="node", units="-")
 
     fr = FlowAccumulator(mg, flow_director="D8")
     lf = DepressionFinderAndRouter(mg)
@@ -170,8 +170,8 @@ def d4_grid():
     z = mg1.node_x.copy() + 1.0
     lake_nodes = np.array([10, 16, 17, 18, 24, 32, 33, 38, 40])
     z[lake_nodes] = 0.0
-    mg1.add_field("node", "topographic__elevation", z, units="-")
-    mg2.add_field("node", "topographic__elevation", z, units="-")
+    mg1.add_field("topographic__elevation", z, at="node", units="-")
+    mg2.add_field("topographic__elevation", z, at="node", units="-")
 
     frD8 = FlowAccumulator(mg1, flow_director="D8")
     frD4 = FlowAccumulator(mg2, flow_director="D4")

--- a/tests/components/depression_finder/test_lake_mapper.py
+++ b/tests/components/depression_finder/test_lake_mapper.py
@@ -23,7 +23,7 @@ PERIOD_Y = 4.0
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -41,7 +41,7 @@ def create_test_grid():
     rmg = RasterModelGrid((NUM_GRID_ROWS, NUM_GRID_COLS))
 
     # Create topography field
-    z = rmg.add_zeros("node", "topographic__elevation")
+    z = rmg.add_zeros("topographic__elevation", at="node")
 
     # Make topography into sinusoidal hills and depressions
     z[:] = sin(2 * pi * rmg.node_x / PERIOD_X) * sin(2 * pi * rmg.node_y / PERIOD_Y)

--- a/tests/components/depression_finder/test_lake_mapper.py
+++ b/tests/components/depression_finder/test_lake_mapper.py
@@ -1279,7 +1279,7 @@ def test_edge_draining():
         ]
     ).flatten()
 
-    mg.add_field("node", "topographic__elevation", z, units="-")
+    mg.add_field("topographic__elevation", z, at="node", units="-")
 
     fr = FlowAccumulator(mg, flow_director="D8")
     lf = DepressionFinderAndRouter(mg)
@@ -1302,7 +1302,7 @@ def test_degenerate_drainage():
     z_init[22] = 0.0  # the common spill pt for both lakes
     z_init[21] = 0.1  # an adverse bump in the spillway
     z_init[20] = -0.2  # the spillway
-    mg.add_field("node", "topographic__elevation", z_init)
+    mg.add_field("topographic__elevation", z_init, at="node")
 
     fr = FlowAccumulator(mg, flow_director="D8")
     lf = DepressionFinderAndRouter(mg)
@@ -1378,7 +1378,7 @@ def test_three_pits():
     multiple pits.
     """
     mg = RasterModelGrid((10, 10))
-    z = mg.add_field("node", "topographic__elevation", mg.node_x.copy())
+    z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
     # a sloping plane
     # np.random.seed(seed=0)
     # z += np.random.rand(100)/10000.
@@ -1530,7 +1530,7 @@ def test_composite_pits():
     multiple pits, inset into each other.
     """
     mg = RasterModelGrid((10, 10))
-    z = mg.add_field("node", "topographic__elevation", mg.node_x.copy())
+    z = mg.add_field("topographic__elevation", mg.node_x.copy(), at="node")
     # a sloping plane
     # np.random.seed(seed=0)
     # z += np.random.rand(100)/10000.

--- a/tests/components/depth_dependent_diffusion/test_depth_dependent_diffuser.py
+++ b/tests/components/depth_dependent_diffusion/test_depth_dependent_diffuser.py
@@ -13,9 +13,9 @@ from landlab.components import DepthDependentDiffuser, ExponentialWeatherer
 
 def test_raise_kwargs_error():
     mg = RasterModelGrid((5, 5))
-    soilTh = mg.add_zeros("node", "soil__depth")
-    z = mg.add_zeros("node", "topographic__elevation")
-    BRz = mg.add_zeros("node", "bedrock__elevation")
+    soilTh = mg.add_zeros("soil__depth", at="node")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    BRz = mg.add_zeros("bedrock__elevation", at="node")
     z += mg.node_x.copy()
     BRz += mg.node_x / 2.0
     soilTh[:] = z - BRz

--- a/tests/components/depth_dependent_taylor_soil_creep/test_depth_dependent_taylor_diffuser.py
+++ b/tests/components/depth_dependent_taylor_soil_creep/test_depth_dependent_taylor_diffuser.py
@@ -23,8 +23,8 @@ def test_4x7_grid_vs_analytical_solution():
     mg.set_closed_boundaries_at_grid_edges(False, True, False, True)
 
     # Create an elevation field, initially zero
-    z = mg.add_zeros("node", "topographic__elevation")
-    _ = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    mg.add_zeros("soil__depth", at="node")
 
     # Instantiate components, and set their parameters. Note that traditional
     # diffusivity, D, is D = SCE x H*, where SCE is soil-creep efficiency.
@@ -70,9 +70,9 @@ def test_4x7_grid_vs_analytical_solution():
 
 def test_raise_stability_error():
     mg = RasterModelGrid((5, 5))
-    soilTh = mg.add_zeros("node", "soil__depth")
-    z = mg.add_zeros("node", "topographic__elevation")
-    BRz = mg.add_zeros("node", "bedrock__elevation")
+    soilTh = mg.add_zeros("soil__depth", at="node")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    BRz = mg.add_zeros("bedrock__elevation", at="node")
     z += mg.node_x.copy() ** 2
     BRz = z.copy() - 1.0
     soilTh[:] = z - BRz
@@ -85,9 +85,9 @@ def test_raise_stability_error():
 
 def test_raise_kwargs_error():
     mg = RasterModelGrid((5, 5))
-    soilTh = mg.add_zeros("node", "soil__depth")
-    z = mg.add_zeros("node", "topographic__elevation")
-    BRz = mg.add_zeros("node", "bedrock__elevation")
+    soilTh = mg.add_zeros("soil__depth", at="node")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    BRz = mg.add_zeros("bedrock__elevation", at="node")
     z += mg.node_x.copy() ** 2
     BRz = z.copy() - 1.0
     soilTh[:] = z - BRz
@@ -98,9 +98,9 @@ def test_raise_kwargs_error():
 def test_infinite_taylor_error():
 
     mg = RasterModelGrid((5, 5))
-    soilTh = mg.add_zeros("node", "soil__depth")
-    z = mg.add_zeros("node", "topographic__elevation")
-    BRz = mg.add_zeros("node", "bedrock__elevation")
+    soilTh = mg.add_zeros("soil__depth", at="node")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    BRz = mg.add_zeros("bedrock__elevation", at="node")
     z += mg.node_x.copy() ** 4
     BRz = z.copy() - 1.0
     soilTh[:] = z - BRz
@@ -113,9 +113,9 @@ def test_infinite_taylor_error():
 
 # def test_warn():
 #    mg = RasterModelGrid((5, 5))
-#    soilTh = mg.add_zeros('node', 'soil__depth')
-#    z = mg.add_zeros('node', 'topographic__elevation')
-#    BRz = mg.add_zeros('node', 'bedrock__elevation')
+#    soilTh = mg.add_zeros("soil__depth", at="node")
+#    z = mg.add_zeros("topographic__elevation", at="node")
+#    BRz = mg.add_zeros("bedrock__elevation", at="node")
 #    z += mg.node_x.copy()**2
 #    BRz = z.copy() - 1.0
 #    soilTh[:] = z - BRz

--- a/tests/components/drainage_density/test_drainage_density.py
+++ b/tests/components/drainage_density/test_drainage_density.py
@@ -8,7 +8,7 @@ from landlab.components import DrainageDensity, FastscapeEroder, FlowAccumulator
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -21,7 +21,7 @@ def test_route_to_multiple_error_raised():
 
 def test_mask_is_stable():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     np.random.seed(3542)
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
@@ -49,7 +49,7 @@ def test_mask_is_stable():
 
 def test_float_mask():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -62,7 +62,7 @@ def test_float_mask():
 
 def test_bool_mask():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -75,7 +75,7 @@ def test_bool_mask():
 
 def test_missing_fields():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     with pytest.raises(FieldError):
         DrainageDensity(
             mg,
@@ -89,7 +89,7 @@ def test_missing_fields():
 
 def test_updating_with_array_provided():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -103,8 +103,8 @@ def test_updating_with_array_provided():
 
 def test_mask_field_exists():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
-    mg.add_zeros("node", "channel__mask", dtype=np.uint8)
+    mg.add_zeros("topographic__elevation", at="node")
+    mg.add_zeros("channel__mask", at="node", dtype=np.uint8)
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -117,7 +117,7 @@ def test_mask_field_exists():
 
 def test_bad_mask_size():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -131,7 +131,7 @@ def test_bad_mask_size():
 
 def test_providing_array_and_kwargs():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -152,7 +152,7 @@ def test_providing_array_and_kwargs():
 
 def test_missing_channel_threshold():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -169,7 +169,7 @@ def test_missing_channel_threshold():
 
 def test_missing_slope_exponent():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -186,7 +186,7 @@ def test_missing_slope_exponent():
 
 def test_missing_slope_coefficient():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -203,7 +203,7 @@ def test_missing_slope_coefficient():
 
 def test_missing_area_exponent():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")
@@ -220,7 +220,7 @@ def test_missing_area_exponent():
 
 def test_missing_area_coefficient():
     mg = RasterModelGrid((10, 10))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     noise = np.random.rand(mg.size("node"))
     mg.at_node["topographic__elevation"] += noise
     fr = FlowAccumulator(mg, flow_director="D8")

--- a/tests/components/erosion_deposition/test_erodep.py
+++ b/tests/components/erosion_deposition/test_erodep.py
@@ -16,7 +16,7 @@ from landlab.components import ErosionDeposition, FlowAccumulator
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -35,7 +35,7 @@ def test_bad_solver_name():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 10000 + mg.node_x / 10000 + np.random.rand(len(mg.node_y)) / 10000
@@ -83,7 +83,7 @@ def test_steady_state_with_basic_solver_option():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -175,7 +175,7 @@ def test_can_run_with_hex():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     mg = HexModelGrid((7, 7))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * mg.x_of_node
 
     # Create a D8 flow handler
@@ -215,7 +215,7 @@ def test_phi_affects_transience():
 
     # Set up one 5x5 grid with open boundaries and low initial elevations.
     mg1 = HexModelGrid((7, 7))
-    z1 = mg1.add_zeros("node", "topographic__elevation")
+    z1 = mg1.add_zeros("topographic__elevation", at="node")
     z1[:] = 0.01 * mg1.x_of_node
 
     # Create a D8 flow handler
@@ -241,7 +241,7 @@ def test_phi_affects_transience():
 
     # Set up a second 5x5 grid with open boundaries and low initial elevations.
     mg2 = HexModelGrid((7, 7))
-    z2 = mg2.add_zeros("node", "topographic__elevation")
+    z2 = mg2.add_zeros("topographic__elevation", at="node")
     z2[:] = 0.01 * mg2.x_of_node
 
     # Create a D8 flow handler

--- a/tests/components/erosion_deposition/test_erodep_steady_state.py
+++ b/tests/components/erosion_deposition/test_erodep_steady_state.py
@@ -18,7 +18,7 @@ def test_erodep_slope_area_small_vs():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     rg = RasterModelGrid((5, 5))
-    z = rg.add_zeros("node", "topographic__elevation")
+    z = rg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * rg.x_of_node
 
     # Create a D8 flow handler
@@ -58,7 +58,7 @@ def test_erodep_slope_area_big_vs():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     rg = RasterModelGrid((5, 5))
-    z = rg.add_zeros("node", "topographic__elevation")
+    z = rg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * rg.x_of_node
 
     # Create a D8 flow handler
@@ -97,7 +97,7 @@ def test_erodep_slope_area_with_vs_unity():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     rg = RasterModelGrid((5, 5))
-    z = rg.add_zeros("node", "topographic__elevation")
+    z = rg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * rg.x_of_node
 
     # Create a D8 flow handler
@@ -137,7 +137,7 @@ def test_erodep_slope_area_shear_stress_scaling():
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     rg = RasterModelGrid((5, 5))
     rg.set_closed_boundaries_at_grid_edges(True, True, True, False)
-    z = rg.add_zeros("node", "topographic__elevation")
+    z = rg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * rg.x_of_node
 
     # Create a D8 flow handler
@@ -177,7 +177,7 @@ def test_erodep_slope_area_with_threshold():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     rg = RasterModelGrid((5, 5))
-    z = rg.add_zeros("node", "topographic__elevation")
+    z = rg.add_zeros("topographic__elevation", at="node")
     z[:] = 0.01 * rg.x_of_node
 
     # Create a D8 flow handler

--- a/tests/components/erosion_deposition/test_general_erodep.py
+++ b/tests/components/erosion_deposition/test_general_erodep.py
@@ -17,7 +17,7 @@ def test_Ff_too_high_vals():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -63,7 +63,7 @@ def test_Ff_too_low_vals():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -109,7 +109,7 @@ def test_phi_too_high_vals():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -155,7 +155,7 @@ def test_phi_too_low_vals():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -201,8 +201,8 @@ def test_q_as_field():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
-    q = mg.add_zeros("node", "user_imposed_discharge")
+    mg.add_zeros("topographic__elevation", at="node")
+    q = mg.add_zeros("user_imposed_discharge", at="node")
     q[:] += 1.0  # add 1.0 m3/yr of water
 
     mg["node"]["topographic__elevation"] += (
@@ -257,7 +257,7 @@ def test_q_as_array():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     q = np.zeros(mg.number_of_nodes)
     q[:] += 1.0  # add 1.0 m3/yr of water
 
@@ -313,8 +313,8 @@ def test_sediment__flux_already_created():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    mg.add_zeros("node", "topographic__elevation")
-    qs = mg.add_zeros("node", "sediment__flux")
+    mg.add_zeros("topographic__elevation", at="node")
+    qs = mg.add_zeros("sediment__flux", at="node")
     qs[:] += 1.0  # add 1.0 m3/yr of flux
 
     mg["node"]["topographic__elevation"] += (

--- a/tests/components/flexure/conftest.py
+++ b/tests/components/flexure/conftest.py
@@ -8,15 +8,15 @@ from landlab.components.flexure.flexure_1d import Flexure1D
 @pytest.fixture
 def flex():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     return Flexure(grid)
 
 
 @pytest.fixture
 def flex1d():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
     return Flexure1D(grid)
 
 

--- a/tests/components/flexure/test_flexure.py
+++ b/tests/components/flexure/test_flexure.py
@@ -13,7 +13,7 @@ from landlab.components import Flexure
 
 def test_method_names():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     assert Flexure(grid, method="airy").method == "airy"
     assert Flexure(grid, method="flexure").method == "flexure"
     with pytest.raises(ValueError):
@@ -22,7 +22,7 @@ def test_method_names():
 
 def test_eet_attribute():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     for val in (10e3, 1e3):
         assert Flexure(grid, eet=val).eet == pytest.approx(val)
     with pytest.raises(ValueError):
@@ -31,21 +31,21 @@ def test_eet_attribute():
 
 def test_youngs_attribute():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     for val in (10e3, 1e3):
         assert Flexure(grid, youngs=val).youngs == pytest.approx(val)
 
 
 def test_gravity_attribute():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     for val in (10e3, 1e3):
         assert Flexure(grid, gravity=val).gravity == pytest.approx(val)
 
 
 def test_rho_mantle_attribute():
     grid = RasterModelGrid((20, 20), xy_spacing=10e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     for val in (10e3, 1e3):
         assert Flexure(grid, rho_mantle=val).rho_mantle == pytest.approx(val)
 
@@ -109,7 +109,7 @@ def test_update():
     load_0 = 1e9
 
     grid = RasterModelGrid((n, n), xy_spacing=1e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     flex = Flexure(grid, method="flexure")
 
     load = grid.at_node["lithosphere__overlying_pressure_increment"]
@@ -128,7 +128,7 @@ def test_subside_loads():
     n, load_0 = 11, 1e9
 
     grid = RasterModelGrid((n, n), xy_spacing=1e3)
-    grid.add_zeros("node", "lithosphere__overlying_pressure_increment")
+    grid.add_zeros("lithosphere__overlying_pressure_increment", at="node")
     flex = Flexure(grid, method="flexure")
 
     grid.at_node["lithosphere__overlying_pressure_increment"][0] = load_0

--- a/tests/components/flexure/test_flexure_1d.py
+++ b/tests/components/flexure/test_flexure_1d.py
@@ -69,8 +69,8 @@ def test_info(flex1d):
 def test_calc_airy():
     """Test airy isostasy."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy")
     flex.load_at_node[:] = flex.gamma_mantle
@@ -84,8 +84,8 @@ def test_with_method_flexure():
     n = 101
     i_mid = (n - 1) // 2
     grid = RasterModelGrid((3, n))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="flexure")
     flex.load_at_node[1, i_mid] = 1.0
@@ -101,8 +101,8 @@ def test_with_method_flexure():
 def test_run_one_step():
     """Test the run_one_step method."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy")
     flex.load_at_node[:] = flex.gamma_mantle
@@ -115,8 +115,8 @@ def test_run_one_step():
 def test_with_one_row():
     """Test calculating on one row."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy", rows=1)
     flex.load_at_node[:] = flex.gamma_mantle
@@ -131,8 +131,8 @@ def test_with_one_row():
 def test_with_two_row():
     """Test calculating on one row."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy", rows=(0, 2))
     flex.load_at_node[:] = -flex.gamma_mantle
@@ -147,8 +147,8 @@ def test_with_two_row():
 def test_field_is_updated():
     """Test the output field is updated."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy", rows=(0, 2))
     flex.load_at_node[:] = -flex.gamma_mantle
@@ -208,8 +208,8 @@ DEPENDS_ON = {
 def test_setters(flexure_keyword):
     EPS = 1e-6
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
     val_before = {}
@@ -225,8 +225,8 @@ def test_setters(flexure_keyword):
 def test_method_keyword():
     """Test using the method keyword."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy")
     assert flex.method == "airy"
@@ -238,8 +238,8 @@ def test_method_keyword():
 
 def test_flexure_keywords(flexure_keyword):
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
     flex = Flexure1D(grid, **{flexure_keyword: 1.0})
     assert getattr(flex, flexure_keyword) == 1.0
     assert isinstance(getattr(flex, flexure_keyword), float)
@@ -250,8 +250,8 @@ def test_flexure_keywords(flexure_keyword):
 def test_x_at_node():
     """Test x_at_node is reshaped and shares memory with the grid."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
 
@@ -268,8 +268,8 @@ def test_x_at_node():
 def test_dz_at_node():
     """Test dz_at_node is reshaped and shares memory with its field."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
 
@@ -283,8 +283,8 @@ def test_dz_at_node():
 def test_load_at_node():
     """Test load_at_node is reshaped and shares memory with its field."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
 
@@ -298,8 +298,8 @@ def test_load_at_node():
 def test_x_is_contiguous():
     """Test that x_at_node is contiguous."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
     assert flex.x_at_node.flags["C_CONTIGUOUS"]
@@ -308,8 +308,8 @@ def test_x_is_contiguous():
 def test_dz_is_contiguous():
     """Test that dz_at_node is contiguous."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
     assert flex.dz_at_node.flags["C_CONTIGUOUS"]
@@ -318,8 +318,8 @@ def test_dz_is_contiguous():
 def test_load_is_contiguous():
     """Test that load_at_node is contiguous."""
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid)
     assert flex.load_at_node.flags["C_CONTIGUOUS"]
@@ -327,8 +327,8 @@ def test_load_is_contiguous():
 
 def test_subside_loads():
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="airy")
     dz_airy = flex.subside_loads([0.0, 0.0, flex.gamma_mantle, 0.0, 0])
@@ -336,8 +336,8 @@ def test_subside_loads():
     assert np.all(dz_airy == [0.0, 0.0, 1.0, 0.0, 0])
 
     grid = RasterModelGrid((3, 5))
-    grid.add_zeros("node", "lithosphere_surface__increment_of_elevation")
-    grid.add_zeros("node", "lithosphere__increment_of_overlying_pressure")
+    grid.add_zeros("lithosphere_surface__increment_of_elevation", at="node")
+    grid.add_zeros("lithosphere__increment_of_overlying_pressure", at="node")
 
     flex = Flexure1D(grid, method="flexure")
     dz_flexure = flex.subside_loads([0.0, 0.0, flex.gamma_mantle, 0.0, 0])

--- a/tests/components/flow_accum/conftest.py
+++ b/tests/components/flow_accum/conftest.py
@@ -68,7 +68,7 @@ def dans_grid1():
         ]
     ).flatten()
 
-    mg.add_field("node", "topographic__elevation", z, units="-")
+    mg.add_field("topographic__elevation", z, at="node", units="-")
 
     class DansGrid(object):
         pass
@@ -144,7 +144,7 @@ def internal_closed():
 
     steepest_target[np.array([8, 17])] = 1.0 / np.sqrt(2.0)
 
-    mg.add_field("node", "topographic__elevation", z, units="-")
+    mg.add_field("topographic__elevation", z, at="node", units="-")
 
     class DansGrid(object):
         pass
@@ -268,7 +268,7 @@ def dans_grid2():
         ]
     ).flatten()
 
-    mg.add_field("node", "topographic__elevation", z, units="-")
+    mg.add_field("topographic__elevation", z, at="node", units="-")
 
     class DansGrid(object):
         pass

--- a/tests/components/flow_accum/test_flow_accumulator.py
+++ b/tests/components/flow_accum/test_flow_accumulator.py
@@ -375,7 +375,7 @@ def test_field_name_array_float_case1():
             0.0,
         ]
     )
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
     fa = FlowAccumulator(mg, "topographic__elevation", runoff_rate=10.0)
@@ -494,8 +494,8 @@ def test_field_name_array_float_case2():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
-    mg.add_field("node", "runoff_rate", runoff_rate)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
+    mg.add_field("runoff_rate", runoff_rate, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -612,7 +612,7 @@ def test_field_name_array_float_case3():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -705,7 +705,7 @@ def test_field_name_array_float_case4():
             0.0,
         ]
     )
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
     fa = FlowAccumulator(mg, topographic__elevation, runoff_rate=10.0)
@@ -824,8 +824,8 @@ def test_field_name_array_float_case5():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
-    mg.add_field("node", "runoff_rate", runoff_rate)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
+    mg.add_field("runoff_rate", runoff_rate, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -942,7 +942,7 @@ def test_field_name_array_float_case6():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 

--- a/tests/components/flow_accum/test_flow_routing.py
+++ b/tests/components/flow_accum/test_flow_routing.py
@@ -23,7 +23,7 @@ def test_check_fields(dans_grid1):
 def test_check_field_input(dans_grid1):
     """Check we can successfully pass water__discharge_in."""
     dans_grid1.mg.add_field(
-        "node", "water__unit_flux_in", np.full(25, 3.0), units="m**3/s"
+        "water__unit_flux_in", np.full(25, 3.0), at="node", units="m**3/s"
     )
     FlowAccumulator(dans_grid1.mg, flow_director="D8")
 
@@ -60,7 +60,7 @@ def test_variable_Qin(dans_grid1):
     """Test variable Qin field."""
     Qin_local = np.zeros(25, dtype=float)
     Qin_local[13] = 2.0
-    dans_grid1.mg.add_field("node", "water__unit_flux_in", Qin_local, units="m**3/s")
+    dans_grid1.mg.add_field("water__unit_flux_in", Qin_local, at="node", units="m**3/s")
     fr = FlowAccumulator(dans_grid1.mg, flow_director="D8")
 
     fr.run_one_step()

--- a/tests/components/flow_accum/test_lossy_flow_accumulator.py
+++ b/tests/components/flow_accum/test_lossy_flow_accumulator.py
@@ -472,7 +472,7 @@ def test_field_name_array_float_case1():
             0.0,
         ]
     )
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
     fa = LossyFlowAccumulator(mg, "topographic__elevation", runoff_rate=10.0)
@@ -591,8 +591,8 @@ def test_field_name_array_float_case2():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
-    mg.add_field("node", "runoff_rate", runoff_rate)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
+    mg.add_field("runoff_rate", runoff_rate, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -709,7 +709,7 @@ def test_field_name_array_float_case3():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -802,7 +802,7 @@ def test_field_name_array_float_case4():
             0.0,
         ]
     )
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
     fa = LossyFlowAccumulator(mg, topographic__elevation, runoff_rate=10.0)
@@ -921,8 +921,8 @@ def test_field_name_array_float_case5():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
-    mg.add_field("node", "runoff_rate", runoff_rate)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
+    mg.add_field("runoff_rate", runoff_rate, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 
@@ -1039,7 +1039,7 @@ def test_field_name_array_float_case6():
         5.0,
     ]
 
-    mg.add_field("node", "topographic__elevation", topographic__elevation)
+    mg.add_field("topographic__elevation", topographic__elevation, at="node")
 
     mg.set_closed_boundaries_at_grid_edges(True, True, True, False)
 

--- a/tests/components/flow_director/test_dinf.py
+++ b/tests/components/flow_director/test_dinf.py
@@ -152,7 +152,7 @@ def test_D_infinity_open_boundary_conditions():
 
 def test_D_infinity_flat():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     fd = FlowDirectorDINF(mg)
     fd.run_one_step()
@@ -172,7 +172,7 @@ def test_D_infinity_flat():
 
 def test_D_infinity_flat_closed_lower():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z[mg.core_nodes] += 1
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=True,
@@ -199,7 +199,7 @@ def test_D_infinity_flat_closed_lower():
 
 def test_D_infinity_flat_closed_upper():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z[mg.core_nodes] -= 1
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=True,

--- a/tests/components/flow_director/test_dinf.py
+++ b/tests/components/flow_director/test_dinf.py
@@ -21,7 +21,7 @@ def test_D_infinity_low_closed_boundary_conditions():
         [[0, 0, 0, 0], [0, 21, 10, 0], [0, 31, 20, 0], [0, 32, 30, 0], [0, 0, 0, 0]],
         dtype="float64",
     )
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=True,
         left_is_closed=True,
@@ -90,7 +90,7 @@ def test_D_infinity_low_closed_boundary_conditions():
 def test_D_infinity_open_boundary_conditions():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
     z = mg.x_of_node + 2.0 * mg.y_of_node
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     fd = FlowDirectorDINF(mg)
     fd.run_one_step()

--- a/tests/components/flow_director/test_mfd.py
+++ b/tests/components/flow_director/test_mfd.py
@@ -30,7 +30,7 @@ def test_bad_argument_mfd():
 
 def test_mfd_on_flat_terrain():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
 
     fd = FlowDirectorMFD(mg)
     fd.run_one_step()
@@ -50,7 +50,7 @@ def test_mfd_on_flat_terrain():
 
 def test_mfd_flat_closed_lower():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z[mg.core_nodes] += 1
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=True,
@@ -77,7 +77,7 @@ def test_mfd_flat_closed_lower():
 
 def test_mfd_flat_closed_upper():
     mg = RasterModelGrid((5, 4), xy_spacing=(1, 1))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z[mg.core_nodes] -= 1
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=True,

--- a/tests/components/groundwater/test_dupuit_percolator.py
+++ b/tests/components/groundwater/test_dupuit_percolator.py
@@ -37,7 +37,7 @@ def test_simple_water_table():
     boundaries = {"top": "closed", "left": "closed", "bottom": "closed"}
     rg = RasterModelGrid((3, 3), bc=boundaries)
     rg.add_zeros("node", "aquifer_base__elevation")
-    rg.add_ones("node", "topographic__elevation")
+    rg.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(
         rg, recharge_rate=1.0e-8, hydraulic_conductivity=0.01
     )
@@ -60,7 +60,7 @@ def test_simple_surface_leakage():
     grid = RasterModelGrid((3, 3), xy_spacing=1.0)
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
     grid.add_zeros("node", "aquifer_base__elevation")
-    grid.add_ones("node", "topographic__elevation")
+    grid.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(grid, recharge_rate=1.0e-6)
 
     for i in range(1000):
@@ -83,7 +83,7 @@ def test_simple_water_table_adaptive_dt():
     boundaries = {"top": "closed", "left": "closed", "bottom": "closed"}
     rg = RasterModelGrid((3, 3), bc=boundaries)
     rg.add_zeros("node", "aquifer_base__elevation")
-    rg.add_ones("node", "topographic__elevation")
+    rg.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(
         rg, recharge_rate=1.0e-8, hydraulic_conductivity=0.01, courant_coefficient=0.01
     )

--- a/tests/components/groundwater/test_dupuit_percolator.py
+++ b/tests/components/groundwater/test_dupuit_percolator.py
@@ -36,7 +36,7 @@ def test_simple_water_table():
     """
     boundaries = {"top": "closed", "left": "closed", "bottom": "closed"}
     rg = RasterModelGrid((3, 3), bc=boundaries)
-    rg.add_zeros("node", "aquifer_base__elevation")
+    rg.add_zeros("aquifer_base__elevation", at="node")
     rg.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(
         rg, recharge_rate=1.0e-8, hydraulic_conductivity=0.01
@@ -59,7 +59,7 @@ def test_simple_surface_leakage():
     """
     grid = RasterModelGrid((3, 3), xy_spacing=1.0)
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
-    grid.add_zeros("node", "aquifer_base__elevation")
+    grid.add_zeros("aquifer_base__elevation", at="node")
     grid.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(grid, recharge_rate=1.0e-6)
 
@@ -82,7 +82,7 @@ def test_simple_water_table_adaptive_dt():
     """
     boundaries = {"top": "closed", "left": "closed", "bottom": "closed"}
     rg = RasterModelGrid((3, 3), bc=boundaries)
-    rg.add_zeros("node", "aquifer_base__elevation")
+    rg.add_zeros("aquifer_base__elevation", at="node")
     rg.add_ones("topographic__elevation", at="node")
     gdp = GroundwaterDupuitPercolator(
         rg, recharge_rate=1.0e-8, hydraulic_conductivity=0.01, courant_coefficient=0.01
@@ -107,11 +107,11 @@ def test_conservation_of_mass_adaptive_dt():
 
     grid = RasterModelGrid((3, 10), xy_spacing=10.0)
     grid.set_closed_boundaries_at_grid_edges(True, True, False, True)
-    elev = grid.add_zeros("node", "topographic__elevation")
-    grid.add_zeros("node", "aquifer_base__elevation")
+    elev = grid.add_zeros("topographic__elevation", at="node")
+    grid.add_zeros("aquifer_base__elevation", at="node")
 
     elev[:] = grid.x_of_node / 100 + 1
-    wt = grid.add_zeros("node", "water_table__elevation")
+    wt = grid.add_zeros("water_table__elevation", at="node")
     wt[:] = elev
 
     # initialize the groundwater model
@@ -158,11 +158,11 @@ def test_symmetry_of_solution():
     hmg = HexModelGrid(shape=(7, 4), spacing=10.0)
     x = hmg.x_of_node
     y = hmg.y_of_node
-    elev = hmg.add_zeros("node", "topographic__elevation")
+    elev = hmg.add_zeros("topographic__elevation", at="node")
     elev[:] = 1e-3 * (x * (max(x) - x) + y * (max(y) - y)) + 2
-    base = hmg.add_zeros("node", "aquifer_base__elevation")
+    base = hmg.add_zeros("aquifer_base__elevation", at="node")
     base[:] = elev - 2
-    wt = hmg.add_zeros("node", "water_table__elevation")
+    wt = hmg.add_zeros("water_table__elevation", at="node")
     wt[:] = elev
     wt[hmg.open_boundary_nodes] = 0.0
 

--- a/tests/components/hack_calculator/test_hack.py
+++ b/tests/components/hack_calculator/test_hack.py
@@ -7,7 +7,7 @@ from landlab.components import FlowAccumulator, HackCalculator
 @pytest.fixture()
 def simple_hack_test_grid():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg)
     fa.run_one_step()

--- a/tests/components/lake_fill/test_lake_fill.py
+++ b/tests/components/lake_fill/test_lake_fill.py
@@ -22,7 +22,7 @@ various docstrings.
 
 def test_route_to_multiple_error_raised_init():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -32,7 +32,7 @@ def test_route_to_multiple_error_raised_init():
 
 def test_bad_init_method1():
     rmg = RasterModelGrid((5, 5), xy_spacing=2.0)
-    rmg.add_zeros("node", "topographic__elevation", dtype=float)
+    rmg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(rmg, flow_director="D8")
     with pytest.raises(ValueError):
         LakeMapperBarnes(rmg, method="Nope")
@@ -40,7 +40,7 @@ def test_bad_init_method1():
 
 def test_bad_init_method2():
     rmg = RasterModelGrid((5, 5), xy_spacing=2.0)
-    rmg.add_zeros("node", "topographic__elevation", dtype=float)
+    rmg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(rmg, flow_director="D8")
     with pytest.raises(ValueError):
         LakeMapperBarnes(rmg, method="d8")
@@ -48,7 +48,7 @@ def test_bad_init_method2():
 
 def test_bad_init_gridmethod():
     hmg = HexModelGrid((30, 29), spacing=3.0)
-    hmg.add_zeros("node", "topographic__elevation", dtype=float)
+    hmg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(hmg, flow_director="Steepest")
     with pytest.raises(ValueError):
         LakeMapperBarnes(hmg, method="D8")
@@ -58,7 +58,7 @@ def test_closed_up_grid():
     mg = RasterModelGrid((5, 5))
     for edge in ("left", "right", "top", "bottom"):
         mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg, flow_director="D8")
     with pytest.raises(ValueError):
         LakeMapperBarnes(mg)
@@ -66,14 +66,14 @@ def test_closed_up_grid():
 
 def test_neighbor_shaping_no_fldir():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     with pytest.raises(FieldError):
         LakeMapperBarnes(mg, method="D8", redirect_flow_steepest_descent=True)
 
 
 def test_neighbor_shaping_no_creation():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg)
     lmb = LakeMapperBarnes(mg, method="D8", redirect_flow_steepest_descent=False)
     with pytest.raises(AttributeError):
@@ -82,7 +82,7 @@ def test_neighbor_shaping_no_creation():
 
 def test_neighbor_shaping_D8():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg)
     lmb = LakeMapperBarnes(mg, method="D8", redirect_flow_steepest_descent=True)
     for arr in (lmb._neighbor_arrays, lmb._link_arrays):
@@ -94,7 +94,7 @@ def test_neighbor_shaping_D8():
 
 def test_neighbor_shaping_D4():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg)
     lmb = LakeMapperBarnes(mg, method="Steepest", redirect_flow_steepest_descent=True)
     for arr in (lmb._neighbor_arrays, lmb._link_arrays):
@@ -105,7 +105,7 @@ def test_neighbor_shaping_D4():
 
 def test_neighbor_shaping_hex():
     hmg = HexModelGrid((6, 5), spacing=1.0)
-    hmg.add_zeros("node", "topographic__elevation", dtype=float)
+    hmg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(hmg)
     lmb = LakeMapperBarnes(hmg, redirect_flow_steepest_descent=True)
     for arr in (lmb._neighbor_arrays, lmb._link_arrays):
@@ -116,7 +116,7 @@ def test_neighbor_shaping_hex():
 
 def test_accum_wo_reroute():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg)
     with pytest.raises(ValueError):
         LakeMapperBarnes(
@@ -129,7 +129,7 @@ def test_accum_wo_reroute():
 
 def test_redirect_no_lakes():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     _ = FlowAccumulator(mg)
     with pytest.raises(ValueError):
         LakeMapperBarnes(
@@ -139,7 +139,7 @@ def test_redirect_no_lakes():
 
 def test_route_to_many():
     mg = RasterModelGrid((5, 5))
-    mg.add_zeros("node", "topographic__elevation", dtype=float)
+    mg.add_zeros("topographic__elevation", at="node", dtype=float)
     fd = FlowDirectorDINF(mg, "topographic__elevation")
     _ = FlowAccumulator(mg)
     fd.run_one_step()
@@ -152,7 +152,7 @@ def test_permitted_overfill():
     mg = RasterModelGrid((3, 7))
     for edge in ("top", "right", "bottom"):
         mg.status_at_node[mg.nodes_at_edge(edge)] = mg.BC_NODE_IS_CLOSED
-    z = mg.add_zeros("node", "topographic__elevation", dtype=float)
+    z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
     z.reshape(mg.shape)[1, 1:-1] = [1.0, 0.2, 0.1, 1.0000000000000004, 1.5]
     _ = FlowAccumulator(mg)
     lmb = LakeMapperBarnes(mg, method="Steepest")
@@ -173,7 +173,7 @@ def test_permitted_overfill():
 
 def test_no_reroute():
     mg = RasterModelGrid((5, 5), xy_spacing=2.0)
-    z = mg.add_zeros("node", "topographic__elevation", dtype=float)
+    z = mg.add_zeros("topographic__elevation", at="node", dtype=float)
     z[1] = -1.0
     z[6] = -2.0
     z[19] = -2.0

--- a/tests/components/lateral_erosion/test_latero.py
+++ b/tests/components/lateral_erosion/test_latero.py
@@ -35,7 +35,7 @@ def test_lateral_erosion_and_node():
     for edge in mg.nodes_at_bottom_edge:
         mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     loading_vector = np.linspace(1, 4, num=nr)
     ramp = np.repeat(loading_vector, nc)
     # the tweaks to elevation below make lateral node at node 7
@@ -128,7 +128,7 @@ def test_matches_detlim_solution():
     for edge in mg.nodes_at_bottom_edge:
         mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     ir2 = np.random.uniform(low=0.0, high=0.5, size=(z.size))
     loading_vector = np.linspace(1, 4, num=nr)
     ramp = np.repeat(loading_vector, nc)
@@ -193,7 +193,7 @@ def test_ss_sed_flux():
     for edge in mg.nodes_at_bottom_edge:
         mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     ir2 = np.random.uniform(low=0.0, high=0.5, size=(z.size))
     loading_vector = np.linspace(1, 2.5, num=nr)
     ramp = np.repeat(loading_vector, nc)
@@ -257,7 +257,7 @@ def test_variable_bedrock_K():
     for edge in mg.nodes_at_bottom_edge:
         mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     loading_vector = np.linspace(1, 4, num=nr)
     ramp = np.repeat(loading_vector, nc)
     ramp += np.random.random_sample(nnodes) * 0.8
@@ -329,7 +329,7 @@ def test_latero_steady_inlet():
     for edge in mg.nodes_at_bottom_edge:
         mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     loading_vector = np.linspace(1, 2.5, num=nr)
     ramp = np.repeat(loading_vector, nc)
     ramp += np.random.random_sample(mg.number_of_nodes) * 0.8

--- a/tests/components/lithology/test_lithology.py
+++ b/tests/components/lithology/test_lithology.py
@@ -22,7 +22,7 @@ def test_lithology_as_bmi():
 def test_bad_layer_method():
     """Test passing a bad name for the layer method."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1]
     ids = [1, 2, 1, 2]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -44,7 +44,7 @@ def test_thickness_ids_wrong_shape():
     """Test wrong size thickness and id shapes."""
     # first with thicknesses and IDs both as ndim = 1 arrays
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -54,7 +54,7 @@ def test_thickness_ids_wrong_shape():
     # next as both as ndim = 2 arrays
     ones = np.ones(mg.number_of_nodes)
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1 * ones, 2 * ones, 4 * ones, 1 * ones, 5 * ones]
     ids = [1 * ones, 2 * ones, 1 * ones, 2 * ones]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -77,7 +77,7 @@ def test_thickness_ndim3():
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
     mg = RasterModelGrid((3, 3))
     ones = np.ones((mg.number_of_nodes, 2))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1 * ones, 2 * ones, 4 * ones, 1 * ones, 5 * ones]
     ids = [1, 2, 1, 2]
     with pytest.raises(ValueError):
@@ -92,7 +92,7 @@ def test_id_ndim3():
     ones = np.ones(mg.number_of_nodes)
 
     extra_ones = np.ones((mg.number_of_nodes, 2))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1 * ones, 2 * ones, 4 * ones, 1 * ones, 5 * ones]
     ids = [1 * extra_ones, 2 * extra_ones, 1 * extra_ones, 2 * extra_ones]
     with pytest.raises(ValueError):
@@ -102,7 +102,7 @@ def test_id_ndim3():
 def test_thickness_nodes_wrong_shape():
     """Test wrong size thickness and id shapes."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     ones = np.ones(mg.number_of_nodes + 1)
     thicknesses = [1 * ones, 2 * ones, 4 * ones, 1 * ones, 5 * ones]
     ids = [1 * ones, 2 * ones, 1 * ones, 2 * ones, 1 * ones]
@@ -114,7 +114,7 @@ def test_thickness_nodes_wrong_shape():
 def test_atts_lack_ids():
     """Test Lithology missing ID."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {2: 0.0001}, "age": {1: 100, 2: 300}}
@@ -125,7 +125,7 @@ def test_atts_lack_ids():
 def test_erode_to_zero_thickness():
     """Test that eroding Lithology to zero thickness raises an error."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -137,7 +137,7 @@ def test_erode_to_zero_thickness():
 def test_deposit_with_no_rock_id():
     """Test that adding a deposit to Lithology with no id raises an error."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -149,7 +149,7 @@ def test_deposit_with_no_rock_id():
 def test_deposit_with_bad_rock_id():
     """Test that adding a deposit to Lithology with no id raises an error."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -166,7 +166,7 @@ def test_deposit_with_bad_rock_id():
 def test_adding_existing_attribute():
     """Test adding an existing attribute."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -181,7 +181,7 @@ def test_adding_existing_attribute():
 def test_adding_new_attribute_missing_rock_id():
     """Test adding an new attribute missing an existing rock id."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -196,7 +196,7 @@ def test_adding_new_attribute_missing_rock_id():
 def test_adding_new_attribute_extra_rock_id():
     """Test adding an new attribute with an extra rock id."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -211,7 +211,7 @@ def test_adding_new_attribute_extra_rock_id():
 def test_adding_new_id_existing_rock_type():
     """Test adding an rock type that already exists."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -226,7 +226,7 @@ def test_adding_new_id_existing_rock_type():
 def test_adding_new_id_extra_attribute():
     """Test adding an new rock type with an extra attribute."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -241,7 +241,7 @@ def test_adding_new_id_extra_attribute():
 def test_adding_new_id_missing_attribute():
     """Test adding an new rock type with an extra attribute."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -254,7 +254,7 @@ def test_adding_new_id_missing_attribute():
 def test_updating_attribute_that_doesnt_exist():
     """Test updating an attribute that doesn't exist."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -266,7 +266,7 @@ def test_updating_attribute_that_doesnt_exist():
 def test_updating_rock_type_that_doesnt_exist():
     """Test adding an new rock type with an extra attribute."""
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -278,7 +278,7 @@ def test_updating_rock_type_that_doesnt_exist():
 def test_run_one_step_deposit_no_id_raises_error():
     """Test that giving the run one step method a deposit with no id raises an error."""
     mg = RasterModelGrid((3, 3))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -291,7 +291,7 @@ def test_run_one_step_deposit_no_id_raises_error():
 def test_run_one_step_erodes_all_raises_error():
     """Test that eroding all material with the run one step method raises an error."""
     mg = RasterModelGrid((3, 3))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     thicknesses = [1, 2, 4, 1, 5]
     ids = [1, 2, 1, 2, 1]
     attrs = {"K_sp": {1: 0.001, 2: 0.0001}}
@@ -306,7 +306,7 @@ def test_rock_block_xarray():
     sample_depths = np.arange(0, 10, 1)
 
     mg = RasterModelGrid((3, 3))
-    mg.add_zeros("node", "topographic__elevation")
+    mg.add_zeros("topographic__elevation", at="node")
     layer_ids = np.tile([0, 1, 2, 3], 5)
     layer_elevations = 3.0 * np.arange(-10, 10)
     layer_elevations[-1] = layer_elevations[-2] + 100

--- a/tests/components/normal_fault/test_normal_fault.py
+++ b/tests/components/normal_fault/test_normal_fault.py
@@ -10,7 +10,7 @@ def test_dx_equals_zero():
     """Test a vertical fault trace."""
     grid = RasterModelGrid((6, 6), xy_spacing=10)
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
     param_dict = {
         "faulted_surface": "topographic__elevation",
@@ -41,7 +41,7 @@ def test_anti_aximuth_greq_2pi():
     """Test anti azimuth over 2*pi."""
     grid = RasterModelGrid((6, 6), xy_spacing=10)
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
     param_dict = {
         "faulted_surface": "topographic__elevation",
@@ -74,7 +74,7 @@ def test_non_raster():
     """Test a hex model grid."""
     grid = HexModelGrid((7, 3), spacing=10, xy_of_lower_left=(-15.0, 0.0))
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
     param_dict = {
         "faulted_surface": "topographic__elevation",
@@ -138,7 +138,7 @@ def test_dip_geq_90():
     """Test dip angles of >90 degrees."""
     grid = RasterModelGrid((6, 6), xy_spacing=10)
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
     with pytest.raises(ValueError):
         NormalFault(grid, fault_dip_angle=90.001)
@@ -148,9 +148,9 @@ def test_uplifting_multiple_fields():
     """Test uplifting multiple fields with NormalFault."""
     grid = RasterModelGrid((6, 6), xy_spacing=10)
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
-    zbr = grid.add_zeros("node", "bedrock__elevation")
+    zbr = grid.add_zeros("bedrock__elevation", at="node")
 
     zbr -= 1.0
 
@@ -256,9 +256,9 @@ def test_uplifting_a_not_yet_created_field():
     """Test uplifting a field that does not exist with  NormalFault."""
     grid = RasterModelGrid((6, 6), xy_spacing=10)
 
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
 
-    zbr = grid.add_zeros("node", "bedrock__elevation")
+    zbr = grid.add_zeros("bedrock__elevation", at="node")
 
     zbr -= 1.0
 
@@ -299,9 +299,9 @@ def test_uplifting_a_not_yet_created_field():
     # running NormalFault after adding spam and eggs will result in NormalFault
     # modifying these fields.
 
-    grid.add_zeros("node", "eggs")
+    grid.add_zeros("eggs", at="node")
 
-    grid.add_zeros("node", "spam")
+    grid.add_zeros("spam", at="node")
 
     nf.run_one_step(dt=10)
 

--- a/tests/components/overland_flow/test_bates_overland_flow.py
+++ b/tests/components/overland_flow/test_bates_overland_flow.py
@@ -59,8 +59,8 @@ def test_Bates_analytical():
     from landlab import RasterModelGrid
 
     grid = RasterModelGrid((32, 240), xy_spacing=25)
-    grid.add_zeros("node", "surface_water__depth")
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("surface_water__depth", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
     bates = OverlandFlowBates(grid, mannings_n=0.01, h_init=0.001)
     time = 0.0

--- a/tests/components/overland_flow/test_dealmeida_overland_flow.py
+++ b/tests/components/overland_flow/test_dealmeida_overland_flow.py
@@ -48,8 +48,8 @@ def test_grid_shape(deAlm):
 
 def test_deAlm_analytical():
     grid = RasterModelGrid((32, 240), xy_spacing=25)
-    grid.add_zeros("node", "surface_water__depth")
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("surface_water__depth", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
     left_inactive_ids = left_edge_horizontal_ids(grid.shape)
     deAlm = OverlandFlow(grid, mannings_n=0.01, h_init=0.001)
@@ -81,8 +81,8 @@ def test_deAlm_analytical():
 
 def test_deAlm_analytical_imposed_dt_short():
     grid = RasterModelGrid((32, 240), xy_spacing=25)
-    grid.add_zeros("node", "surface_water__depth")
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("surface_water__depth", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
     left_inactive_ids = left_edge_horizontal_ids(grid.shape)
     deAlm = OverlandFlow(grid, mannings_n=0.01, h_init=0.001)
@@ -114,8 +114,8 @@ def test_deAlm_analytical_imposed_dt_short():
 
 def test_deAlm_analytical_imposed_dt_long():
     grid = RasterModelGrid((32, 240), xy_spacing=25)
-    grid.add_zeros("node", "surface_water__depth")
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("surface_water__depth", at="node")
+    grid.add_zeros("topographic__elevation", at="node")
     grid.set_closed_boundaries_at_grid_edges(True, True, True, True)
     left_inactive_ids = left_edge_horizontal_ids(grid.shape)
     deAlm = OverlandFlow(grid, mannings_n=0.01, h_init=0.001)

--- a/tests/components/overland_flow/test_kinwave.py
+++ b/tests/components/overland_flow/test_kinwave.py
@@ -50,8 +50,8 @@ def test_run_one_step():
     from landlab.components.overland_flow import KinwaveOverlandFlowModel
 
     grid = RasterModelGrid((10, 10), xy_spacing=0.5)
-    grid.add_zeros("node", "topographic__elevation", dtype=float)
-    grid.add_zeros("link", "topographic__gradient")
+    grid.add_zeros("topographic__elevation", at="node", dtype=float)
+    grid.add_zeros("topographic__gradient", at="link")
 
     topo_arr = np.ones(100).reshape(10, 10)
     i = 0

--- a/tests/components/overland_flow/test_kinwave_implicit.py
+++ b/tests/components/overland_flow/test_kinwave_implicit.py
@@ -18,7 +18,7 @@ def test_initialization():
     """Test initialization with various parameters.
     """
     rg = RasterModelGrid((3, 4), xy_spacing=2.0)
-    rg.add_zeros("node", "topographic__elevation")
+    rg.add_zeros("topographic__elevation", at="node")
     kw = KinwaveImplicitOverlandFlow(rg)
 
     # Make sure fields have been created

--- a/tests/components/pet/conftest.py
+++ b/tests/components/pet/conftest.py
@@ -9,5 +9,5 @@ from landlab.components.pet.potential_evapotranspiration_field import (
 @pytest.fixture
 def pet():
     grid = RasterModelGrid((20, 20), xy_spacing=10e0)
-    grid.add_zeros("cell", "radiation__ratio_to_flat_surface")
+    grid.add_zeros("radiation__ratio_to_flat_surface", at="cell")
     return PotentialEvapotranspiration(grid)

--- a/tests/components/potentiality_flowrouting/test_sniff_pot_fr.py
+++ b/tests/components/potentiality_flowrouting/test_sniff_pot_fr.py
@@ -454,11 +454,11 @@ def test_in_network():
 
     mg = RasterModelGrid((NROWS, NCOLS), xy_spacing=(DX, DX))
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     Qin = np.ones_like(z) * 100.0 / (60.0 * 60.0 * 24.0 * 365.25)
     # ^remember, flux is /s, so this is a small number!
-    mg.add_field("node", "water__unit_flux_in", Qin)
+    mg.add_field("water__unit_flux_in", Qin, at="node")
 
     pfr = PotentialityFlowRouter(mg, flow_equation="Manning")
     pfr.run_one_step()

--- a/tests/components/potentiality_flowrouting/test_sniff_pot_fr.py
+++ b/tests/components/potentiality_flowrouting/test_sniff_pot_fr.py
@@ -127,7 +127,7 @@ def test_sheetflow():
     mg.at_node["topographic__elevation"] = z
 
     mg.set_closed_boundaries_at_grid_edges(False, True, True, True)
-    mg.add_ones("node", "water__unit_flux_in")
+    mg.add_ones("water__unit_flux_in", at="node")
 
     pfr = PotentialityFlowRouter(mg)
     pfr.run_one_step()

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -368,7 +368,7 @@ def test_different_kwargs(profile_example_grid):
 
 def test_re_calculating_nodes_and_distance():
     mg = RasterModelGrid((20, 20), xy_spacing=100)
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += np.random.rand(z.size)
     mg.set_closed_boundaries_at_grid_edges(
         bottom_is_closed=False,
@@ -427,7 +427,7 @@ def test_re_calculating_nodes_and_distance():
 def test_getting_all_the_way_to_the_divide(main, nshed):
     np.random.seed(42)
     mg = RasterModelGrid((10, 12))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += np.random.rand(z.size)
 
     fa = FlowAccumulator(mg, flow_director="D8")

--- a/tests/components/radiation/conftest.py
+++ b/tests/components/radiation/conftest.py
@@ -7,5 +7,5 @@ from landlab.components.radiation.radiation import Radiation
 @pytest.fixture
 def rad():
     grid = RasterModelGrid((20, 20), xy_spacing=10e0)
-    grid.add_zeros("node", "topographic__elevation")
+    grid.add_zeros("topographic__elevation", at="node")
     return Radiation(grid)

--- a/tests/components/sink_fill/conftest.py
+++ b/tests/components/sink_fill/conftest.py
@@ -68,7 +68,7 @@ def sink_grid3():
     z[guard_nodes] += 0.001
     z[lake] = 0.0
 
-    sink_grid.add_field("node", "topographic__elevation", z, units="-")
+    sink_grid.add_field("topographic__elevation", z, at="node", units="-")
     sink_grid.lake1 = lake1
     sink_grid.lake2 = lake2
 
@@ -101,7 +101,7 @@ def sink_grid4():
     # depr_outlet_target.fill(XX)
     # depr_outlet_target = XX  # not well defined in this simplest case...?
 
-    sink_grid.add_field("node", "topographic__elevation", z, units="-")
+    sink_grid.add_field("topographic__elevation", z, at="node", units="-")
     sink_grid.lake1 = lake1
     sink_grid.lake2 = lake2
 
@@ -150,7 +150,7 @@ def sink_grid5():
     # depr_outlet_target.fill(XX)
     # depr_outlet_target = XX  # not well defined in this simplest case...?
 
-    sink_grid.add_field("node", "topographic__elevation", z, units="-")
+    sink_grid.add_field("topographic__elevation", z, at="node", units="-")
     sink_grid.lake1 = lake1
     sink_grid.lake2 = lake2
 

--- a/tests/components/sink_fill/test_sink_filler.py
+++ b/tests/components/sink_fill/test_sink_filler.py
@@ -16,7 +16,7 @@ from landlab.components import FlowAccumulator, SinkFiller, SinkFillerBarnes
 
 def test_route_to_multiple_error_raised_init():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -26,7 +26,7 @@ def test_route_to_multiple_error_raised_init():
 
 def test_route_to_multiple_error_raised_run():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     sfb = SinkFillerBarnes(mg)
     fa = FlowAccumulator(mg, flow_director="MFD")
@@ -37,7 +37,7 @@ def test_route_to_multiple_error_raised_run():
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()

--- a/tests/components/soil_moisture/test_green_ampt_infil.py
+++ b/tests/components/soil_moisture/test_green_ampt_infil.py
@@ -73,8 +73,8 @@ def test_calc_moisture_deficit(si):
 
 def test_run_one_step():
     grid = RasterModelGrid((10, 10), xy_spacing=25)
-    grid.add_ones("node", "soil_water_infiltration__depth", dtype=float)
-    grid.add_ones("node", "surface_water__depth")
+    grid.add_ones("soil_water_infiltration__depth", at="node", dtype=float)
+    grid.add_ones("surface_water__depth", at="node")
     hydraulic_conductivity = 2.5 * (10 ** -6)
     grid["node"]["surface_water__depth"] *= 5.0
     grid["node"]["soil_water_infiltration__depth"] *= 10 ** -5

--- a/tests/components/space/test_space.py
+++ b/tests/components/space/test_space.py
@@ -8,7 +8,7 @@ from landlab.components import FlowAccumulator, Space
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -39,9 +39,9 @@ def test_bad_solver_name():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
-    soil = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
+    soil = mg.add_zeros("soil__depth", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 10000 + mg.node_x / 10000 + np.random.rand(len(mg.node_y)) / 10000
@@ -88,9 +88,9 @@ def test_soil_field_already_on_grid():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
-    soil = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
+    soil = mg.add_zeros("soil__depth", at="node")
     soil += 1.0  # add 1m of soil everywehre
 
     mg["node"]["topographic__elevation"] += (
@@ -145,10 +145,10 @@ def test_br_field_already_on_grid():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
     br += 1.0  # make bedrock elevation 5m below surface
-    soil = mg.add_zeros("node", "soil__depth")
+    soil = mg.add_zeros("soil__depth", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 10000 + mg.node_x / 10000 + np.random.rand(len(mg.node_y)) / 10000
@@ -202,9 +202,9 @@ def test_matches_detachment_solution():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
-    soil = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
+    soil = mg.add_zeros("soil__depth", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 10000 + mg.node_x / 10000 + np.random.rand(len(mg.node_y)) / 10000
@@ -285,9 +285,9 @@ def test_matches_transport_solution():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
-    soil = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
+    soil = mg.add_zeros("soil__depth", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -400,9 +400,9 @@ def test_matches_bedrock_alluvial_solution():
     nc = 5
     mg = RasterModelGrid((nr, nc), xy_spacing=10.0)
 
-    z = mg.add_zeros("node", "topographic__elevation")
-    br = mg.add_zeros("node", "bedrock__elevation")
-    soil = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    br = mg.add_zeros("bedrock__elevation", at="node")
+    soil = mg.add_zeros("soil__depth", at="node")
 
     mg["node"]["topographic__elevation"] += (
         mg.node_y / 100000 + mg.node_x / 100000 + np.random.rand(len(mg.node_y)) / 10000
@@ -499,8 +499,8 @@ def test_can_run_with_hex():
 
     # Set up a 5x5 grid with open boundaries and low initial elevations.
     mg = HexModelGrid((7, 7))
-    z = mg.add_zeros("node", "topographic__elevation")
-    _ = mg.add_zeros("node", "soil__depth")
+    z = mg.add_zeros("topographic__elevation", at="node")
+    _ = mg.add_zeros("soil__depth", at="node")
     z[:] = 0.01 * mg.x_of_node
 
     # Create a D8 flow handler

--- a/tests/components/spatial_precip/test_spatial_storm_generator.py
+++ b/tests/components/spatial_precip/test_spatial_storm_generator.py
@@ -54,8 +54,8 @@ def test_MS_params():
     # gauge_elev = np.loadtxt(os.path.join(_THIS_DIR, 'model_input', 'gauge_elev.csv'))
     # # This is the list of gauge numbers. It will be sampled below.
     # # put the elevs on the grid. Mind the ordering
-    # vdg_z = vdg.add_field('node', 'topographic__elevation',
-    #                       gauge_elev[np.argsort(Northing)])
+    # vdg_z = vdg.add_field("topographic__elevation",
+    #                       gauge_elev[np.argsort(Northing)], at="node")
     # numgauges = len(gauges)
     #
     # mg = RasterModelGrid((12, 26), (1042.3713, 1102.0973))
@@ -72,9 +72,9 @@ def test_MS_params():
     mg = RasterModelGrid((12, 26), xy_spacing=(1102.0973, 1042.3713))
     mg.status_at_node = np.loadtxt(os.path.join(_THIS_DIR, "BCs_Singer.txt"))
     mg.add_field(
-        "node",
         "topographic__elevation",
         np.loadtxt(os.path.join(_THIS_DIR, "elevs_Singer.txt")),
+        at="node",
     )
 
     np.random.seed(10)
@@ -119,7 +119,7 @@ def test_MS_params():
     # z = XYZ[:, 2]
     # vdg = VoronoiDelaunayGrid(X+np.random.rand(len(X)), Y+np.random.rand(len(Y)))
     # vdg = RasterModelGrid((12, 25), (1042.3713, 1102.0973))
-    # z = vdg.add_field('node', 'topographic__elevation', z)
+    # z = vdg.add_field("topographic__elevation", z, at="node")
     # rain = SpatialPrecipitationDistribution(vdg, number_of_years=1,
     #                                         orographic_scenario='Singer')
     #

--- a/tests/components/spatial_precip/test_spatial_storm_generator.py
+++ b/tests/components/spatial_precip/test_spatial_storm_generator.py
@@ -61,7 +61,7 @@ def test_MS_params():
     # mg = RasterModelGrid((12, 26), (1042.3713, 1102.0973))
     # mg.status_at_node[:] = 4
     # mg.status_at_node[isin.flatten()] = 0
-    # z = mg.add_zeros('node', 'topographic__elevation')
+    # z = mg.add_zeros("topographic__elevation", at="node")
     #
     # closest_core_node_in_vdg = []
     # for E, N in zip(Xin, Yin):

--- a/tests/components/steepness_index/test_steepness_finder.py
+++ b/tests/components/steepness_index/test_steepness_finder.py
@@ -6,7 +6,7 @@ from landlab.components import FlowAccumulator, SteepnessFinder
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()

--- a/tests/components/stream_power/test_not_implemented_errors.py
+++ b/tests/components/stream_power/test_not_implemented_errors.py
@@ -12,7 +12,7 @@ from landlab.components import (
 
 def test_route_to_multiple_error_raised_init_FastscapeEroder():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -23,7 +23,7 @@ def test_route_to_multiple_error_raised_init_FastscapeEroder():
 
 def test_route_to_multiple_error_raised_init_SedDepEroder():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -34,7 +34,7 @@ def test_route_to_multiple_error_raised_init_SedDepEroder():
 
 def test_route_to_multiple_error_raised_init_StreamPowerSmoothThresholdEroder():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -45,7 +45,7 @@ def test_route_to_multiple_error_raised_init_StreamPowerSmoothThresholdEroder():
 
 def test_route_to_multiple_error_raised_init_StreamPowerEroder():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()

--- a/tests/components/stream_power/test_sed_flux_dep.py
+++ b/tests/components/stream_power/test_sed_flux_dep.py
@@ -71,7 +71,7 @@ def test_sed_dep_new():
     for edge in (mg.nodes_at_left_edge, mg.nodes_at_top_edge, mg.nodes_at_right_edge):
         mg.status_at_node[edge] = mg.BC_NODE_IS_CLOSED
 
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
 
     fr = FlowAccumulator(mg, flow_director="D8")
     sde = SedDepEroder(

--- a/tests/components/stream_power/test_voronoi_sp.py
+++ b/tests/components/stream_power/test_voronoi_sp.py
@@ -21,7 +21,10 @@ def test_sp_voronoi():
 
     np.random.seed(2)
     z = mg.add_field(
-        "node", "topographic__elevation", np.random.rand(nnodes) / 10000.0, copy=False
+        "topographic__elevation",
+        np.random.rand(nnodes) / 10000.0,
+        at="node",
+        copy=False,
     )
 
     fr = FlowAccumulator(mg)

--- a/tests/components/taylor_nonlinear_hillslope_flux/test_taylor_nonlinear_hillslope_flux.py
+++ b/tests/components/taylor_nonlinear_hillslope_flux/test_taylor_nonlinear_hillslope_flux.py
@@ -13,7 +13,7 @@ from landlab.components import TaylorNonLinearDiffuser
 
 def test_raise_stability_error():
     mg = RasterModelGrid((5, 5))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.node_x.copy() ** 2
     Cdiff = TaylorNonLinearDiffuser(mg, if_unstable="raise")
     with pytest.raises(RuntimeError):
@@ -22,7 +22,7 @@ def test_raise_stability_error():
 
 def test_raise_kwargs_error():
     mg = RasterModelGrid((5, 5))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.node_x.copy() ** 2
     with pytest.raises(TypeError):
         TaylorNonLinearDiffuser(mg, bad_name="true")
@@ -30,7 +30,7 @@ def test_raise_kwargs_error():
 
 def test_infinite_taylor_error():
     mg = RasterModelGrid((5, 5))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.node_x.copy() ** 4
     Cdiff = TaylorNonLinearDiffuser(mg, nterms=400)
     with pytest.raises(RuntimeError):
@@ -39,7 +39,7 @@ def test_infinite_taylor_error():
 
 # def test_warn():
 #    mg = RasterModelGrid((5, 5))
-#    z = mg.add_zeros('node', 'topographic__elevation')
+#    z = mg.add_zeros("topographic__elevation", at="node")
 #    z += mg.node_x.copy()**2
 #    Cdiff = TaylorNonLinearDiffuser(mg)
 #

--- a/tests/components/transport_length_diffusion/test_tl_hill_diff.py
+++ b/tests/components/transport_length_diffusion/test_tl_hill_diff.py
@@ -75,7 +75,7 @@ def test_tl_hill_diff():
             0.0,
         ]
     )
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
     mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
 
     # Parameter values for test

--- a/tests/components/transport_length_diffusion/test_tl_hill_diff.py
+++ b/tests/components/transport_length_diffusion/test_tl_hill_diff.py
@@ -20,7 +20,7 @@ from landlab.components import (
 
 def test_route_to_multiple_error_raised():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()

--- a/tests/field/test_graph_fields.py
+++ b/tests/field/test_graph_fields.py
@@ -177,7 +177,7 @@ def test_delete_field():
     with pytest.raises(AttributeError):
         fields.at_node
 
-    fields.add_zeros("link", "vals")
+    fields.add_zeros("vals", at="link")
     assert_array_equal(np.zeros(17), fields.at_link["vals"])
 
     with pytest.raises(KeyError):

--- a/tests/field/test_grouped_fields.py
+++ b/tests/field/test_grouped_fields.py
@@ -173,7 +173,7 @@ def test_delete_field():
     with pytest.raises(AttributeError):
         fields.at_node
 
-    fields.add_zeros("link", "vals")
+    fields.add_zeros("vals", at="link")
     assert_array_equal(np.zeros(17), fields.at_link["vals"])
 
     with pytest.raises(KeyError):

--- a/tests/grid/test_hex_grid/testing_flux_divergence_hex_grid.py
+++ b/tests/grid/test_hex_grid/testing_flux_divergence_hex_grid.py
@@ -140,7 +140,7 @@ def testing_flux_divergence_with_hex():
     """
     hmg = HexModelGrid(3, 3, reorient_links=True)
 
-    f = hmg.add_zeros("link", "test_flux")
+    f = hmg.add_zeros("test_flux", at="link")
     f[:] = np.arange(hmg.number_of_links)
 
     make_links_at_node_array(hmg)

--- a/tests/grid/test_raster_grid/test_mappers.py
+++ b/tests/grid/test_raster_grid/test_mappers.py
@@ -8,7 +8,7 @@ from landlab import RasterModelGrid
 class TestLinkEndsToLink:
     def test_max(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)
 
@@ -55,7 +55,7 @@ class TestLinkEndsToLink:
 
     def test_min(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)
 
@@ -104,7 +104,7 @@ class TestLinkEndsToLink:
 class TestNodeToLinkMappers:
     def test_to_node(self):
         rmg = RasterModelGrid((4, 5), xy_spacing=(1.0, 1.0))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
 
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)
@@ -156,7 +156,7 @@ class TestNodeToLinkMappers:
 
     def test_from_node(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
 
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)
@@ -205,7 +205,7 @@ class TestNodeToLinkMappers:
 
     def test_mean_node(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
 
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)
@@ -253,7 +253,7 @@ class TestNodeToLinkMappers:
 
     def test_cell(self):
         rmg = RasterModelGrid((4, 5))
-        rmg.add_empty("node", "values")
+        rmg.add_empty("values", at="node")
 
         node_values = rmg.at_node["values"]
         node_values[:] = np.arange(rmg.number_of_nodes)

--- a/tests/grid/test_raster_grid/test_save.py
+++ b/tests/grid/test_raster_grid/test_save.py
@@ -10,7 +10,7 @@ from landlab.io.netcdf import read_netcdf
 
 def test_save_esri_ascii(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=2.0)
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         grid.save("test.asc", format="esri-ascii")
@@ -19,7 +19,7 @@ def test_save_esri_ascii(tmpdir):
 
 def test_add_extension(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=2.0)
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         grid.save("test", format="esri-ascii")
@@ -32,7 +32,7 @@ def test_add_extension(tmpdir):
 
 def test_replace_extension(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=2.0)
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         grid.save("test.nc", format="esri-ascii")
@@ -45,7 +45,7 @@ def test_replace_extension(tmpdir):
 
 def test_guess_format(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=2.0)
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         grid.save("test.asc")

--- a/tests/io/netcdf/test_write_netcdf.py
+++ b/tests/io/netcdf/test_write_netcdf.py
@@ -17,7 +17,7 @@ _TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 def test_netcdf_write_int64_field_netcdf4(tmpdir):
     """Test write_netcdf with a grid that has an int64 field."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12, dtype=np.int64))
+    field.add_field("topographic__elevation", np.arange(12, dtype=np.int64), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF4")
@@ -35,7 +35,7 @@ def test_netcdf_write_int64_field_netcdf4(tmpdir):
 def test_netcdf_write_uint8_field_netcdf4(tmpdir):
     """Test write_netcdf with a grid that has an uint8 field."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12, dtype=np.uint8))
+    field.add_field("topographic__elevation", np.arange(12, dtype=np.uint8), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF4")
@@ -55,8 +55,8 @@ def test_netcdf_write_as_netcdf3_64bit(tmpdir):
     from scipy.io import netcdf
 
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", 2.0 * np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", 2.0 * np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF3_64BIT")
@@ -75,8 +75,8 @@ def test_netcdf_write_as_netcdf3_classic(tmpdir):
     from scipy.io import netcdf
 
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", 2.0 * np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", 2.0 * np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF3_CLASSIC")
@@ -93,7 +93,7 @@ def test_netcdf_write_as_netcdf3_classic(tmpdir):
 def test_netcdf_write(tmpdir):
     """Test generic write_netcdf."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF4")
@@ -126,8 +126,8 @@ def test_netcdf_write(tmpdir):
 def test_netcdf_write_as_netcdf4_classic(tmpdir):
     """Test write_netcdf to netcdf4 classic format."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, format="NETCDF4_CLASSIC")
@@ -143,8 +143,8 @@ def test_netcdf_write_as_netcdf4_classic(tmpdir):
 def test_netcdf_write_names_keyword_as_list(tmpdir):
     """Test write_netcdf using a list for the *names* keyword."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf(
@@ -165,8 +165,8 @@ def test_netcdf_write_names_keyword_as_list(tmpdir):
 def test_netcdf_write_names_keyword_as_str(tmpdir):
     """Test write_netcdf using a ``str`` for the *names* keyword."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, names="uplift_rate", format="NETCDF4")
@@ -184,8 +184,8 @@ def test_netcdf_write_names_keyword_as_str(tmpdir):
 def test_netcdf_write_names_keyword_as_none(tmpdir):
     """Test write_netcdf using ``None`` for the *names* keyword."""
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_netcdf("test.nc", field, names=None, format="NETCDF4")
@@ -259,8 +259,12 @@ def test_1d_uneven_spacing():
 def test_netcdf_write_at_cells(tmpdir):
     """Test write_netcdf using with cell fields"""
     field = RasterModelGrid((4, 3))
-    field.add_field("cell", "topographic__elevation", np.arange(field.number_of_cells))
-    field.add_field("cell", "uplift_rate", np.arange(field.number_of_cells))
+    field.add_field(
+        "topographic__elevation",
+        np.arange(field.number_of_cells),
+        at="cell",
+    )
+    field.add_field("uplift_rate", np.arange(field.number_of_cells), at="cell")
 
     with tmpdir.as_cwd():
         write_netcdf("test-cells.nc", field, format="NETCDF4")

--- a/tests/io/netcdf/test_write_raster_netcdf.py
+++ b/tests/io/netcdf/test_write_raster_netcdf.py
@@ -12,7 +12,7 @@ except ImportError:
 
 def test_append_with_time(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+    field.add_field("topographic__elevation", np.ones(12, dtype=np.int64), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf("test.nc", field, append=False, format="NETCDF4", time=0)
@@ -42,7 +42,7 @@ def test_append_with_time(tmpdir):
 
 def test_without_time(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+    field.add_field("topographic__elevation", np.ones(12, dtype=np.int64), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf("test.nc", field, append=False, format="NETCDF4")
@@ -65,7 +65,7 @@ def test_without_time(tmpdir):
 
 def test_with_time(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.ones(12, dtype=np.int64))
+    field.add_field("topographic__elevation", np.ones(12, dtype=np.int64), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf("test.nc", field, append=False, format="NETCDF4", time=0.0)
@@ -89,8 +89,8 @@ def test_with_time(tmpdir):
 
 def test_with_time_netcdf3(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", 2.0 * np.arange(12.0))
-    field.add_field("node", "uplift_rate", 2.0 * np.arange(12.0))
+    field.add_field("topographic__elevation", 2.0 * np.arange(12.0), at="node")
+    field.add_field("uplift_rate", 2.0 * np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf("test.nc", field, format="NETCDF3_64BIT", time=10.0)
@@ -178,8 +178,8 @@ def test_append_without_time_netcdf3(tmpdir):
 
 def test_without_time_netcdf3(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", 2.0 * np.arange(12.0))
-    field.add_field("node", "uplift_rate", 2.0 * np.arange(12.0))
+    field.add_field("topographic__elevation", 2.0 * np.arange(12.0), at="node")
+    field.add_field("uplift_rate", 2.0 * np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf("test.nc", field, format="NETCDF3_64BIT")
@@ -209,8 +209,8 @@ def test_without_time_netcdf3(tmpdir):
 
 def test_names_keyword(tmpdir):
     field = RasterModelGrid((4, 3))
-    field.add_field("node", "topographic__elevation", np.arange(12.0))
-    field.add_field("node", "uplift_rate", 2.0 * np.arange(12.0))
+    field.add_field("topographic__elevation", np.arange(12.0), at="node")
+    field.add_field("uplift_rate", 2.0 * np.arange(12.0), at="node")
 
     with tmpdir.as_cwd():
         write_raster_netcdf(

--- a/tests/io/test_read_write_native.py
+++ b/tests/io/test_read_write_native.py
@@ -67,7 +67,7 @@ def compare_dictionaries(dict_1, dict_2, dict_1_name, dict_2_name, path=""):
 def test_pickle():
     # Make a simple-ish grid
     mg1 = RasterModelGrid((10, 10), xy_spacing=2.0)
-    z = mg1.add_zeros("node", "topographic__elevation")
+    z = mg1.add_zeros("topographic__elevation", at="node")
     z += mg1.node_x.copy()
     fa = FlowAccumulator(mg1, flow_director="D8")
     fa.run_one_step()

--- a/tests/io/test_write_esri_ascii.py
+++ b/tests/io/test_write_esri_ascii.py
@@ -20,7 +20,7 @@ def test_grid_with_no_fields(tmpdir):
 
 def test_grid_with_one_field(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
     with tmpdir.as_cwd():
         files = write_esri_ascii("test.asc", grid)
         assert files == ["test.asc"]
@@ -30,8 +30,8 @@ def test_grid_with_one_field(tmpdir):
 
 def test_grid_with_two_fields(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
-    grid.add_field("node", "land_surface__elevation", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
+    grid.add_field("land_surface__elevation", np.arange(20.0), at="node")
     with tmpdir.as_cwd():
         files = write_esri_ascii("test.asc", grid)
         files.sort()
@@ -67,8 +67,8 @@ def test_names_keyword_as_list(tmpdir):
 
 def test_names_keyword_multiple_names(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
-    grid.add_field("node", "land_surface__elevation", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
+    grid.add_field("land_surface__elevation", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         files = write_esri_ascii(
@@ -85,7 +85,7 @@ def test_names_keyword_multiple_names(tmpdir):
 
 def test_names_keyword_with_bad_name(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         with pytest.raises(ValueError):
@@ -94,7 +94,7 @@ def test_names_keyword_with_bad_name(tmpdir):
 
 def test_clobber_keyword(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         write_esri_ascii("test.asc", grid)
@@ -107,7 +107,7 @@ def test_clobber_keyword(tmpdir):
 
 def test_write_then_read(tmpdir):
     grid = RasterModelGrid((4, 5), xy_spacing=(2.0, 2.0), xy_of_lower_left=(15.0, 10.0))
-    grid.add_field("node", "air__temperature", np.arange(20.0))
+    grid.add_field("air__temperature", np.arange(20.0), at="node")
 
     with tmpdir.as_cwd():
         write_esri_ascii("test.asc", grid)

--- a/tests/utils/test_distance_from_divide.py
+++ b/tests/utils/test_distance_from_divide.py
@@ -17,8 +17,8 @@ def test_no_flow_receivers():
 def test_no_upstream_array():
     """Test that correct error is raised when no flow__upstream_node_order."""
     mg = RasterModelGrid((30, 70))
-    mg.add_ones("node", "topographic__elevation")
-    mg.add_ones("node", "drainage_area")
+    mg.add_ones("topographic__elevation", at="node")
+    mg.add_ones("drainage_area", at="node")
     fd = FlowDirectorSteepest(mg)
     fd.run_one_step()
     with pytest.raises(FieldError):
@@ -28,8 +28,8 @@ def test_no_upstream_array():
 def test_drainage_area():
     """Test that correct error is raised when no flow__upstream_node_order."""
     mg = RasterModelGrid((30, 70))
-    mg.add_ones("node", "topographic__elevation")
-    mg.add_ones("node", "flow__upstream_node_order")
+    mg.add_ones("topographic__elevation", at="node")
+    mg.add_ones("flow__upstream_node_order", at="node")
     fd = FlowDirectorSteepest(mg)
     fd.run_one_step()
     with pytest.raises(FieldError):

--- a/tests/utils/test_flow__distance.py
+++ b/tests/utils/test_flow__distance.py
@@ -62,7 +62,7 @@ def test_flow__distance_regular_grid_d8():
 
     # add the elevation field to the grid
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     # instantiate the expected flow__distance array
     # considering flow directions calculated with D8 algorithm
@@ -124,7 +124,7 @@ def test_flow__distance_regular_grid_d4():
 
     # add the elevation field to the grid
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     # instantiate the expected flow__distance array
     # considering flow directions calculated with D4 algorithm
@@ -237,7 +237,7 @@ def test_flow__distance_raster_MFD_diagonals_true():
 
     # add the elevation field to the grid
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     # instantiate the expected flow__distance array
     # considering flow directions calculated with MFD algorithm
@@ -297,7 +297,7 @@ def test_flow__distance_raster_MFD_diagonals_false():
 
     # add the elevation field to the grid
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     # instantiate the expected flow__distance array
     # considering flow directions calculated with MFD algorithm
@@ -346,7 +346,7 @@ def test_flow__distance_raster_D_infinity():
 
     # add the elevation field to the grid
 
-    mg.add_field("node", "topographic__elevation", z)
+    mg.add_field("topographic__elevation", z, at="node")
 
     # instantiate the expected flow_length array
 

--- a/tests/utils/test_flow__distance.py
+++ b/tests/utils/test_flow__distance.py
@@ -32,7 +32,7 @@ def test_no_upstream_array():
 
     # Add a field called topographic__elevation to mg
 
-    mg.add_ones("node", "topographic__elevation")
+    mg.add_ones("topographic__elevation", at="node")
 
     # Run the FlowDirectorSteepest component
 

--- a/tests/utils/test_watershed.py
+++ b/tests/utils/test_watershed.py
@@ -248,7 +248,7 @@ def test_get_watershed_outlet():
 
 def test_route_to_multiple_error_raised_watershed_outlet():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()
@@ -259,7 +259,7 @@ def test_route_to_multiple_error_raised_watershed_outlet():
 
 def test_route_to_multiple_error_raised_watershed_mask():
     mg = RasterModelGrid((10, 10))
-    z = mg.add_zeros("node", "topographic__elevation")
+    z = mg.add_zeros("topographic__elevation", at="node")
     z += mg.x_of_node + mg.y_of_node
     fa = FlowAccumulator(mg, flow_director="MFD")
     fa.run_one_step()


### PR DESCRIPTION
This pull request changes all of the grid *add_** methods to use the new-style signature. That is,
```python
>>> grid.add_ones("elevation", at="node")
```
rather than
```python
>>> grid.add_ones("node", "elevation")
```
The old-style still works and hasn't been deprecated but, unless I missed something, shouldn't be used anywhere.

Methods changed:
* [x] *add_field*
* [x] *add_ones*
* [x] *add_zeros*
* [x] *add_empty*
* [x] *add_full*