### PR TITLE
Remove uses of old node and link status flags

### DIFF
--- a/docs/source/user_guide/grid.rst
+++ b/docs/source/user_guide/grid.rst
@@ -452,7 +452,7 @@ either *active* or *inactive* (Figure 3).
 A closed boundary is one at which no flux is permitted enter or leave, ever.
 By definition, all links coming into or out of a closed boundary node must be inactive.
 There is effectively no value assigned to a closed boundary; it will probably have a
-BAD_INDEX_VALUE or null value of some kind.
+grid.BAD_INDEX_VALUE or null value of some kind.
 An open boundary is one at which flux can enter or leave, but whose value is controlled
 by some boundary condition rule, updated at the end of each timestep.
 

--- a/docs/source/user_guide/landlab_one_to_two.rst
+++ b/docs/source/user_guide/landlab_one_to_two.rst
@@ -35,15 +35,26 @@ TODO List of these, including replacements if any.
 Changes to field creation
 -------------------------
 - no more `noclobber`, instead we have `clobber`
+- recommended field init (eg. at="")
 
 Changes to Boundary Condition Flags
 -----------------------------------
-- no more use of unbound flags (e.g., `from landlab import CLOSED_NODE`)
+- no more use of unbound flags AND unbound flags are not importable
+  from top level or grid submodule (e.g., `from landlab import CLOSED_NODE`)
   now we use `Grid.BC_NODE_IS_CLOSED`.
 
-Changes to Field initialization
--------------------------------
-- PUT HERE IF THIS HAPPENS
+  Old name                  New name
+  ========================= ====================================
+  BAD_INDEX_VALUE           ModelGrid.BAD_INDEX
+  CORE_NODE                 ModelGrid.BC_NODE_IS_CORE
+  FIXED_VALUE_BOUNDARY      ModelGrid.BC_NODE_IS_FIXED_VALUE
+  FIXED_GRADIENT_BOUNDARY   ModelGrid.BC_NODE_IS_FIXED_GRADIENT
+  LOOPED_BOUNDARY           ModelGrid.BC_NODE_IS_LOOPED
+  CLOSED_BOUNDARY           ModelGrid.BC_NODE_IS_CLOSED
+  ACTIVE_LINK               ModelGrid.BC_LINK_IS_ACTIVE
+  INACTIVE_LINK             ModelGrid.BC_LINK_IS_INACTIVE
+  FIXED_LINK                ModelGrid.BC_LINK_IS_FIXED
+
 
 Standardization and deprecation within the component library
 ------------------------------------------------------------

--- a/landlab/__init__.py
+++ b/landlab/__init__.py
@@ -35,6 +35,8 @@ from .grid import (
     VoronoiDelaunayGrid,
     create_grid,
 )
+from .grid.linkstatus import LinkStatus
+from .grid.nodestatus import NodeStatus
 from .plot import imshow_grid, imshow_grid_at_node
 
 try:
@@ -60,6 +62,8 @@ __all__ = [
     "VoronoiDelaunayGrid",
     "NetworkModelGrid",
     "BAD_INDEX_VALUE",
+    "LinkStatus",
+    "NodeStatus",
     "CORE_NODE",
     "FIXED_VALUE_BOUNDARY",
     "FIXED_GRADIENT_BOUNDARY",

--- a/landlab/__init__.py
+++ b/landlab/__init__.py
@@ -19,13 +19,6 @@ from .core.model_component import Component
 from .core.model_parameter_loader import load_params
 from .field.scalar_data_fields import FieldError
 from .grid import (
-    ACTIVE_LINK,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_LINK,
-    FIXED_VALUE_BOUNDARY,
-    INACTIVE_LINK,
-    LOOPED_BOUNDARY,
     HexModelGrid,
     ModelGrid,
     NetworkModelGrid,
@@ -62,13 +55,6 @@ __all__ = [
     "NetworkModelGrid",
     "LinkStatus",
     "NodeStatus",
-    "CORE_NODE",
-    "FIXED_VALUE_BOUNDARY",
-    "FIXED_GRADIENT_BOUNDARY",
-    "LOOPED_BOUNDARY",
-    "ACTIVE_LINK",
-    "FIXED_LINK",
-    "INACTIVE_LINK",
     "create_grid",
     "imshow_grid",
     "imshow_grid_at_node",

--- a/landlab/__init__.py
+++ b/landlab/__init__.py
@@ -20,7 +20,6 @@ from .core.model_parameter_loader import load_params
 from .field.scalar_data_fields import FieldError
 from .grid import (
     ACTIVE_LINK,
-    BAD_INDEX_VALUE,
     CORE_NODE,
     FIXED_GRADIENT_BOUNDARY,
     FIXED_LINK,
@@ -61,7 +60,6 @@ __all__ = [
     "RasterModelGrid",
     "VoronoiDelaunayGrid",
     "NetworkModelGrid",
-    "BAD_INDEX_VALUE",
     "LinkStatus",
     "NodeStatus",
     "CORE_NODE",

--- a/landlab/ca/boundaries/hex_lattice_tectonicizer.py
+++ b/landlab/ca/boundaries/hex_lattice_tectonicizer.py
@@ -30,7 +30,7 @@ from numpy import (
     zeros,
 )
 
-from landlab import HexModelGrid
+from landlab import HexModelGrid, LinkStatus
 from landlab.core.utils import as_id_array
 
 from ..cfuncs import get_next_event_new  # , update_link_state_new
@@ -534,14 +534,14 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         g = self.grid
         lower_active = logical_and(
             arange(g.number_of_links) < self.first_link_shifted_to,
-            g.status_at_link == g.BC_LINK_IS_ACTIVE,
+            g.status_at_link == LinkStatus.ACTIVE,
         )
         link_in_fw = logical_or(
             in_footwall[g.node_at_link_tail], in_footwall[g.node_at_link_head]
         )
         lower_active_fw = logical_and(lower_active, link_in_fw)
         active_bnd = logical_and(
-            g.status_at_link == g.BC_LINK_IS_ACTIVE,
+            g.status_at_link == LinkStatus.ACTIVE,
             logical_or(
                 g.status_at_node[g.node_at_link_tail] != 0,
                 g.status_at_node[g.node_at_link_head] != 0,
@@ -549,7 +549,7 @@ class LatticeNormalFault(HexLatticeTectonicizer):
         )
         active_bnd_fw = logical_and(active_bnd, link_in_fw)
         crosses_fw = logical_and(
-            g.status_at_link == g.BC_LINK_IS_ACTIVE,
+            g.status_at_link == LinkStatus.ACTIVE,
             logical_xor(
                 in_footwall[g.node_at_link_tail], in_footwall[g.node_at_link_head]
             ),

--- a/landlab/ca/celllab_cts.py
+++ b/landlab/ca/celllab_cts.py
@@ -129,12 +129,13 @@ from landlab.ca.cfuncs import (
     push_transitions_to_event_queue,
     run_cts_new,
 )
+from landlab.grid.nodestatus import NodeStatus
 
 _NEVER = 1e50
 
 _DEBUG = False
 
-_CORE = landlab.grid.base.CORE_NODE
+_CORE = NodeStatus.CORE
 
 
 class Transition(object):

--- a/landlab/ca/cfuncs.pyx
+++ b/landlab/ca/cfuncs.pyx
@@ -7,16 +7,17 @@ Created on Thu Jun 30 12:40:39 2016
 import numpy as np
 cimport numpy as np
 cimport cython
-from landlab import CORE_NODE
+from landlab.grid.nodestatus import NodeStatus
 from _heapq import heappush, heappop
 from libc.stdlib cimport rand
 from libc.math cimport log
+
 
 import sys # for debug
 
 cdef double _NEVER = 1.0e50
 
-cdef int _CORE = CORE_NODE
+cdef int _CORE = NodeStatus.CORE
 
 DTYPE = np.double
 ctypedef np.double_t DTYPE_t
@@ -118,7 +119,7 @@ cdef class Event:
         self.xn_to = xn_to
         self.propswap = propswap
         self.prop_update_fn = prop_update_fn
-        
+
     def __richcmp__(self, Event other, int op):
         """
         Overridden less-than operator: returns true if the event on the left
@@ -130,7 +131,7 @@ cdef class Event:
 @cython.boundscheck(True)
 @cython.wraparound(False)
 cdef int current_link_state(DTYPE_INT_t link_id,
-                       np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                       np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                        np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                        np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                        np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -160,7 +161,7 @@ cdef int current_link_state(DTYPE_INT_t link_id,
         Total number of possible node states
     num_node_states_sq : int
         Square of number of node states (precomputed for speed)
-    
+
     Returns
     -------
     int
@@ -183,7 +184,7 @@ cdef int current_link_state(DTYPE_INT_t link_id,
 @cython.wraparound(False)
 cpdef update_link_states_and_transitions(
                              np.ndarray[DTYPE_INT_t, ndim=1] active_links,
-                             np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                             np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                              np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                              np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                              np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -193,7 +194,7 @@ cpdef update_link_states_and_transitions(
                              event_queue,
                              np.ndarray[DTYPE_t, ndim=1] next_update,
                              np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                             np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                             np.ndarray[DTYPE_t, ndim=2] xn_rate,
                              DTYPE_INT_t num_node_states,
                              DTYPE_INT_t num_node_states_sq,
                              DTYPE_t current_time,
@@ -226,9 +227,9 @@ cpdef update_link_states_and_transitions(
             if current_state != link_state[i]:
                 update_link_state(i, current_state, current_time, bnd_lnk,
                                   node_state, node_at_link_tail,
-                                  node_at_link_head, link_orientation, 
+                                  node_at_link_head, link_orientation,
                                   num_node_states, num_node_states_sq,
-                                  link_state, n_xn, event_queue, next_update, 
+                                  link_state, n_xn, event_queue, next_update,
                                   xn_to, xn_rate,xn_propswap,
                                   xn_prop_update_fn)
 
@@ -237,7 +238,7 @@ cpdef update_link_states_and_transitions(
 @cython.wraparound(False)
 cpdef update_link_states_and_transitions_new(
                              np.ndarray[DTYPE_INT_t, ndim=1] active_links,
-                             np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                             np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                              np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                              np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                              np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -248,7 +249,7 @@ cpdef update_link_states_and_transitions_new(
                              np.ndarray[DTYPE_t, ndim=1] next_update,
                              np.ndarray[DTYPE_INT_t, ndim=1] next_trn_id,
                              np.ndarray[DTYPE_INT_t, ndim=2] trn_id,
-                             np.ndarray[DTYPE_t, ndim=1] trn_rate, 
+                             np.ndarray[DTYPE_t, ndim=1] trn_rate,
                              DTYPE_INT_t num_node_states,
                              DTYPE_INT_t num_node_states_sq,
                              DTYPE_t current_time):
@@ -279,9 +280,9 @@ cpdef update_link_states_and_transitions_new(
             if current_state != link_state[i]:
                 update_link_state_new(i, current_state, current_time, bnd_lnk,
                                   node_state, node_at_link_tail,
-                                  node_at_link_head, link_orientation, 
+                                  node_at_link_head, link_orientation,
                                   num_node_states, num_node_states_sq,
-                                  link_state, n_trn, priority_queue, next_update, 
+                                  link_state, n_trn, priority_queue, next_update,
                                   next_trn_id, trn_id, trn_rate)
 
 
@@ -290,7 +291,7 @@ cpdef update_link_states_and_transitions_new(
 @cython.cdivision(True)
 cpdef update_node_states(np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                        np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
-                       DTYPE_INT_t tail_node, 
+                       DTYPE_INT_t tail_node,
                        DTYPE_INT_t head_node,
                        DTYPE_INT_t new_link_state,
                        DTYPE_INT_t num_states):
@@ -309,8 +310,8 @@ cpdef update_node_states(np.ndarray[DTYPE_INT_t, ndim=1] node_state,
 
 @cython.boundscheck(True)
 @cython.wraparound(False)
-cpdef get_next_event(DTYPE_INT_t link, DTYPE_INT_t current_state, 
-                   DTYPE_t current_time, 
+cpdef get_next_event(DTYPE_INT_t link, DTYPE_INT_t current_state,
+                   DTYPE_t current_time,
                    np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                    np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
                    np.ndarray[DTYPE_t, ndim=2] xn_rate,
@@ -384,8 +385,8 @@ cpdef get_next_event(DTYPE_INT_t link, DTYPE_INT_t current_state,
 
 @cython.boundscheck(True)
 @cython.wraparound(False)
-cpdef get_next_event_new(DTYPE_INT_t link, DTYPE_INT_t current_state, 
-                   DTYPE_t current_time, 
+cpdef get_next_event_new(DTYPE_INT_t link, DTYPE_INT_t current_state,
+                   DTYPE_t current_time,
                    np.ndarray[DTYPE_INT_t, ndim=1] n_trn,
                    np.ndarray[DTYPE_INT_t, ndim=2] trn_id,
                    np.ndarray[DTYPE_t, ndim=1] trn_rate):
@@ -474,10 +475,10 @@ cpdef push_transitions_to_event_queue(int number_of_active_links,
 
 @cython.boundscheck(True)
 @cython.wraparound(False)
-cdef void update_link_state(DTYPE_INT_t link, DTYPE_INT_t new_link_state, 
+cdef void update_link_state(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
                       DTYPE_t current_time,
                       np.ndarray[DTYPE_INT8_t, ndim=1] bnd_lnk,
-                      np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                      np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                       np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -487,7 +488,7 @@ cdef void update_link_state(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
                       np.ndarray[DTYPE_INT_t, ndim=1] n_xn, event_queue,
                       np.ndarray[DTYPE_t, ndim=1] next_update,
                       np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                      np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                      np.ndarray[DTYPE_t, ndim=2] xn_rate,
                       np.ndarray[DTYPE_INT8_t, ndim=2] xn_propswap,
                       np.ndarray[object, ndim=2] xn_prop_update_fn):
     """
@@ -530,10 +531,10 @@ cdef void update_link_state(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
 
 @cython.boundscheck(True)
 @cython.wraparound(False)
-cdef void update_link_state_new(DTYPE_INT_t link, DTYPE_INT_t new_link_state, 
+cdef void update_link_state_new(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
                       DTYPE_t current_time,
                       np.ndarray[DTYPE_INT8_t, ndim=1] bnd_lnk,
-                      np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                      np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                       np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -581,7 +582,7 @@ cdef void update_link_state_new(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
 
     link_state[link] = new_link_state
     if n_trn[new_link_state] > 0:
-        (event_time, this_trn_id) = get_next_event_new(link, new_link_state, 
+        (event_time, this_trn_id) = get_next_event_new(link, new_link_state,
                                                        current_time,
                                                        n_trn, trn_id, trn_rate)
         priority_queue.push(link, event_time)
@@ -594,10 +595,10 @@ cdef void update_link_state_new(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
 @cython.boundscheck(True)
 @cython.wraparound(False)
 cdef void do_transition(Event event,
-                  np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_state,            
+                  np.ndarray[DTYPE_t, ndim=1] next_update,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                   np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                   np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -605,7 +606,7 @@ cdef void do_transition(Event event,
                   object prop_data,
                   np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                   np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                  np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                  np.ndarray[DTYPE_t, ndim=2] xn_rate,
                   np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                   DTYPE_INT_t num_node_states,
@@ -766,8 +767,8 @@ cdef void do_transition(Event event,
 cpdef void do_transition_new(DTYPE_INT_t event_link,
                   DTYPE_t event_time,
                   PriorityQueue priority_queue,
-                  np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
+                  np.ndarray[DTYPE_t, ndim=1] next_update,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                   np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                   np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                   np.ndarray[DTYPE_INT_t, ndim=1] next_trn_id,
@@ -780,7 +781,7 @@ cpdef void do_transition_new(DTYPE_INT_t event_link,
                   np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                   np.ndarray[DTYPE_INT_t, ndim=1] n_trn,
                   np.ndarray[DTYPE_INT_t, ndim=2] trn_id,
-                  np.ndarray[DTYPE_t, ndim=1] trn_rate, 
+                  np.ndarray[DTYPE_t, ndim=1] trn_rate,
                   np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=1] trn_propswap,
@@ -898,7 +899,7 @@ cpdef void do_transition_new(DTYPE_INT_t event_link,
                         orientation * num_node_states_sq +
                         node_state[this_link_tail_node] * num_node_states +
                         node_state[this_link_head_node])
-                    update_link_state_new(link, new_link_state, event_time, 
+                    update_link_state_new(link, new_link_state, event_time,
                                           bnd_lnk,
                                           node_state, node_at_link_tail,
                                           node_at_link_head, link_orientation,
@@ -921,7 +922,7 @@ cpdef void do_transition_new(DTYPE_INT_t event_link,
                         orientation * num_node_states_sq +
                         node_state[this_link_tail_node] * num_node_states +
                         node_state[this_link_head_node])
-                    update_link_state_new(link, new_link_state, event_time, 
+                    update_link_state_new(link, new_link_state, event_time,
                                           bnd_lnk,
                                           node_state, node_at_link_tail,
                                           node_at_link_head, link_orientation,
@@ -952,11 +953,11 @@ cpdef void do_transition_new(DTYPE_INT_t event_link,
 
 cpdef double run_cts_new(double run_to, double current_time,
                      PriorityQueue priority_queue,
-                     np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,            
-                     np.ndarray[DTYPE_INT_t, ndim=1] next_trn_id,            
+                     np.ndarray[DTYPE_t, ndim=1] next_update,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,
+                     np.ndarray[DTYPE_INT_t, ndim=1] next_trn_id,
                      np.ndarray[DTYPE_INT_t, ndim=1] trn_to,
                      np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
                      DTYPE_INT_t num_node_states,
@@ -966,7 +967,7 @@ cpdef double run_cts_new(double run_to, double current_time,
                      np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                      np.ndarray[DTYPE_INT_t, ndim=1] n_trn,
                      np.ndarray[DTYPE_INT_t, ndim=2] trn_id,
-                     np.ndarray[DTYPE_t, ndim=1] trn_rate, 
+                     np.ndarray[DTYPE_t, ndim=1] trn_rate,
                      np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=1] trn_propswap,
@@ -1012,7 +1013,7 @@ cpdef double run_cts_new(double run_to, double current_time,
             do_transition_new(ev_link, ev_time, priority_queue, next_update,
                               node_at_link_tail,
                               node_at_link_head,
-                              node_state, 
+                              node_state,
                               next_trn_id,
                               trn_to,
                               status_at_node,
@@ -1049,10 +1050,10 @@ cpdef double run_cts(double run_to, double current_time,
                      char plot_each_transition,
                      object plotter,
                      object event_queue,
-                     np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,            
+                     np.ndarray[DTYPE_t, ndim=1] next_update,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                      np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                      np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -1060,7 +1061,7 @@ cpdef double run_cts(double run_to, double current_time,
                      object prop_data,
                      np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                      np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                     np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                     np.ndarray[DTYPE_t, ndim=2] xn_rate,
                      np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                      DTYPE_INT_t num_node_states,
@@ -1115,7 +1116,7 @@ cpdef double run_cts(double run_to, double current_time,
 
             # Update current time
             current_time = ev.time
-            
+
         # If there is no event scheduled for this span of time, simply
         # advance current_time to the end of the current run period.
         else:
@@ -1126,8 +1127,8 @@ cpdef double run_cts(double run_to, double current_time,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef get_next_event_lean(DTYPE_INT_t link, DTYPE_INT_t current_state, 
-                   DTYPE_t current_time, 
+cpdef get_next_event_lean(DTYPE_INT_t link, DTYPE_INT_t current_state,
+                   DTYPE_t current_time,
                    np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                    np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
                    np.ndarray[DTYPE_t, ndim=2] xn_rate):
@@ -1194,10 +1195,10 @@ cpdef get_next_event_lean(DTYPE_INT_t link, DTYPE_INT_t current_state,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void update_link_state_lean(DTYPE_INT_t link, DTYPE_INT_t new_link_state, 
+cdef void update_link_state_lean(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
                       DTYPE_t current_time,
                       np.ndarray[DTYPE_INT8_t, ndim=1] bnd_lnk,
-                      np.ndarray[DTYPE_INT_t, ndim=1] node_state, 
+                      np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
                       np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
                       np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
@@ -1211,7 +1212,7 @@ cdef void update_link_state_lean(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
     """
     Implements a link transition by updating the current state of the link
     and (if appropriate) choosing the next transition event and pushing it
-    on to the event queue. This "lean" version omits parameters related to 
+    on to the event queue. This "lean" version omits parameters related to
     property exchange and callback function.
 
     Parameters
@@ -1250,16 +1251,16 @@ cdef void update_link_state_lean(DTYPE_INT_t link, DTYPE_INT_t new_link_state,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 cdef void do_transition_lean(Event event,
-                  np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,                  
-                  np.ndarray[DTYPE_INT_t, ndim=1] node_state,            
+                  np.ndarray[DTYPE_t, ndim=1] next_update,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
+                  np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                   np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                   np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
                   np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                   np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                  np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                  np.ndarray[DTYPE_t, ndim=2] xn_rate,
                   np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                   np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                   DTYPE_INT_t num_node_states,
@@ -1387,16 +1388,16 @@ cdef void do_transition_lean(Event event,
 @cython.boundscheck(False)
 cpdef double run_cts_lean(double run_to, double current_time,
                      object event_queue,
-                     np.ndarray[DTYPE_t, ndim=1] next_update,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,                  
-                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,            
+                     np.ndarray[DTYPE_t, ndim=1] next_update,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_tail,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_at_link_head,
+                     np.ndarray[DTYPE_INT_t, ndim=1] node_state,
                      np.ndarray[DTYPE_INT_t, ndim=1] link_state,
                      np.ndarray[DTYPE_UINT8_t, ndim=1] status_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=1] link_orientation,
                      np.ndarray[DTYPE_INT_t, ndim=1] n_xn,
                      np.ndarray[DTYPE_INT_t, ndim=2] xn_to,
-                     np.ndarray[DTYPE_t, ndim=2] xn_rate, 
+                     np.ndarray[DTYPE_t, ndim=2] xn_rate,
                      np.ndarray[DTYPE_INT_t, ndim=2] links_at_node,
                      np.ndarray[DTYPE_INT8_t, ndim=2] active_link_dirs_at_node,
                      DTYPE_INT_t num_node_states,
@@ -1412,7 +1413,7 @@ cpdef double run_cts_lean(double run_to, double current_time,
     (see celllab_cts.py for other parameters)
     """
     cdef Event ev
-    
+
     # Continue until we've run out of either time or events
     while current_time < run_to and event_queue:
 
@@ -1420,7 +1421,7 @@ cpdef double run_cts_lean(double run_to, double current_time,
         if event_queue[0].time <= run_to:
 
             #print 'popping'
-            
+
             # If so, pick the next transition event from the event queue
             ev = heappop(event_queue)
 
@@ -1438,7 +1439,7 @@ cpdef double run_cts_lean(double run_to, double current_time,
 
             # Update current time
             current_time = ev.time
-            
+
         # If there is no event scheduled for this span of time, simply
         # advance current_time to the end of the current run period.
         else:

--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -7,7 +7,7 @@
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE, Component, RasterModelGrid
+from landlab import Component, RasterModelGrid
 
 try:
     from itertools import izip
@@ -402,7 +402,7 @@ class ChiFinder(Component):
         for node in valid_upstr_order:
             dstr_node = receivers[node]
             dstr_link = links[node]
-            if dstr_link != BAD_INDEX_VALUE:
+            if dstr_link != self._grid.BAD_INDEX_VALUE:
                 dstr_length = self._link_lengths[dstr_link]
                 half_head_val = half_integrand[node]
                 half_tail_val = half_integrand[dstr_node]
@@ -444,7 +444,7 @@ class ChiFinder(Component):
         2.2761423749153966
         """
         ch_links = self._grid.at_node["flow__link_to_receiver_node"][ch_nodes]
-        ch_links_valid = ch_links[ch_links != BAD_INDEX_VALUE]
+        ch_links_valid = ch_links[ch_links != self._grid.BAD_INDEX_VALUE]
 
         valid_link_lengths = self._link_lengths[ch_links_valid]
         return valid_link_lengths.mean()

--- a/landlab/components/chi_index/channel_chi.py
+++ b/landlab/components/chi_index/channel_chi.py
@@ -402,7 +402,7 @@ class ChiFinder(Component):
         for node in valid_upstr_order:
             dstr_node = receivers[node]
             dstr_link = links[node]
-            if dstr_link != self._grid.BAD_INDEX_VALUE:
+            if dstr_link != self._grid.BAD_INDEX:
                 dstr_length = self._link_lengths[dstr_link]
                 half_head_val = half_integrand[node]
                 half_tail_val = half_integrand[dstr_node]
@@ -444,7 +444,7 @@ class ChiFinder(Component):
         2.2761423749153966
         """
         ch_links = self._grid.at_node["flow__link_to_receiver_node"][ch_nodes]
-        ch_links_valid = ch_links[ch_links != self._grid.BAD_INDEX_VALUE]
+        ch_links_valid = ch_links[ch_links != self._grid.BAD_INDEX]
 
         valid_link_lengths = self._link_lengths[ch_links_valid]
         return valid_link_lengths.mean()

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -259,7 +259,9 @@ class DepressionFinderAndRouter(Component):
         self._lake_outlets = []  # a list of each unique lake outlet
         # ^note this is nlakes-long
 
-        self._is_pit = self._grid.add_ones("is_pit", at="node", dtype=bool, clobber=True)
+        self._is_pit = self._grid.add_ones(
+            "is_pit", at="node", dtype=bool, clobber=True
+        )
         self._flood_status = self._grid.add_zeros(
             "flood_status_code", at="node", dtype=int, clobber=True
         )

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -143,7 +143,7 @@ class DepressionFinderAndRouter(Component):
             "optional": False,
             "units": "-",
             "mapping": "node",
-            "doc": "If a depression, the id of the outlet node for that depression, otherwise grid.BAD_INDEX_VALUE",
+            "doc": "If a depression, the id of the outlet node for that depression, otherwise grid.BAD_INDEX",
         },
         "flood_status_code": {
             "dtype": int,
@@ -241,14 +241,14 @@ class DepressionFinderAndRouter(Component):
         # Create output variables.
         #
         # Note that we initialize depression
-        # outlet ID to self._grid.BAD_INDEX_VALUE (which is a major clue!)
+        # outlet ID to self._grid.BAD_INDEX (which is a major clue!)
         self._depression_depth = self._grid.add_zeros(
             "depression__depth", at="node", clobber=True
         )
         self._depression_outlet_map = self._grid.add_zeros(
             "depression__outlet_node", at="node", dtype=int, clobber=True
         )
-        self._depression_outlet_map += self._grid.BAD_INDEX_VALUE
+        self._depression_outlet_map += self._grid.BAD_INDEX
 
         # Later on, we'll need a number that's guaranteed to be larger than the
         # highest elevation in the grid.
@@ -266,7 +266,7 @@ class DepressionFinderAndRouter(Component):
             "flood_status_code", at="node", dtype=int, clobber=True
         )
         self._lake_map = np.empty(self._grid.number_of_nodes, dtype=int)
-        self._lake_map.fill(self._grid.BAD_INDEX_VALUE)
+        self._lake_map.fill(self._grid.BAD_INDEX)
 
     def updated_boundary_conditions(self):
         """Call this if boundary conditions on the grid are updated after the
@@ -657,7 +657,7 @@ class DepressionFinderAndRouter(Component):
             ``True`` if the node can drain. Otherwise, ``False``.
         """
         nbrs = self._node_nbrs[the_node]
-        not_bad = nbrs != self._grid.BAD_INDEX_VALUE
+        not_bad = nbrs != self._grid.BAD_INDEX
         not_too_high = self._elev[nbrs] < self._elev[the_node]
         not_current_lake = np.not_equal(self._flood_status[nbrs], _CURRENT_LAKE)
         not_flooded = np.not_equal(self._flood_status[nbrs], _FLOODED)
@@ -745,7 +745,7 @@ class DepressionFinderAndRouter(Component):
         # possible to have two lakes overlapping... We can test this with an
         # assertion that out total # of *tracked* lakes matches the accumulated
         # total of unique vals in lake_map.
-        fresh_nodes = np.equal(self._lake_map[n], self._grid.BAD_INDEX_VALUE)
+        fresh_nodes = np.equal(self._lake_map[n], self._grid.BAD_INDEX)
         if np.all(fresh_nodes):  # a new lake
             self._flood_status[n] = _FLOODED
             self._depression_depth[n] = self._elev[outlet_id] - self._elev[n]
@@ -761,13 +761,13 @@ class DepressionFinderAndRouter(Component):
             self._depression_outlet_map[n] = outlet_id
             # ^these two will just get stamped over as needed
             subsumed_lakes = np.unique(self._lake_map[n])  # IDed by pit_node
-            # the final entry is self._grid.BAD_INDEX_VALUE
+            # the final entry is self._grid.BAD_INDEX
             subs_lakes_where = np.searchsorted(self._pit_node_ids, subsumed_lakes[1:])
             pit_node_where = np.searchsorted(self._pit_node_ids, pit_node)
             self._unique_pits[subs_lakes_where] = False
             self._unique_pits[pit_node_where] = True
             self._pits_flooded -= subsumed_lakes.size - 2
-            # -1 for the self._grid.BAD_INDEX_VALUE that must be present; another -1
+            # -1 for the self._grid.BAD_INDEX that must be present; another -1
             # because a single lake is just replaced by a new lake.
             self._lake_map[n] = pit_node
         else:  # lake is subsumed within an existing lake
@@ -807,7 +807,7 @@ class DepressionFinderAndRouter(Component):
                 nodes_this_depression
             )
             # note this can return the supplied node, if - somehow - the
-            # surrounding nodes are all self._grid.BAD_INDEX_VALUE
+            # surrounding nodes are all self._grid.BAD_INDEX
             # I BELIEVE THE IS_VALID_OUTLET FN SHOULD ASSIGN FLOW DIR
             found_outlet = self.is_valid_outlet(lowest_node_on_perimeter)
 
@@ -860,7 +860,7 @@ class DepressionFinderAndRouter(Component):
         # debug_count = 0
         for pit_node in self._pit_node_ids:
             if self._flood_status[pit_node] != _PIT:
-                self._depression_outlets.append(self._grid.BAD_INDEX_VALUE)
+                self._depression_outlets.append(self._grid.BAD_INDEX)
             else:
                 self.find_depression_from_pit(pit_node, reroute_flow)
                 self._pits_flooded += 1
@@ -902,8 +902,8 @@ class DepressionFinderAndRouter(Component):
         if self._bc_set_code != self._grid.bc_set_code:
             self.updated_boundary_conditions()
             self._bc_set_code = self._grid.bc_set_code
-        self._lake_map.fill(self._grid.BAD_INDEX_VALUE)
-        self._depression_outlet_map.fill(self._grid.BAD_INDEX_VALUE)
+        self._lake_map.fill(self._grid.BAD_INDEX)
+        self._depression_outlet_map.fill(self._grid.BAD_INDEX)
         self._depression_depth.fill(0.0)
         self._depression_outlets = []  # reset these
         # Locate nodes with pits
@@ -1166,7 +1166,7 @@ class DepressionFinderAndRouter(Component):
                     new_link = self._grid.links_at_node[outlet_node, find_recs]
 
                 if new_link.size == 0:
-                    new_link = self._grid.BAD_INDEX_VALUE
+                    new_link = self._grid.BAD_INDEX
                 self._links[outlet_node] = new_link
 
                 # make a check
@@ -1291,7 +1291,7 @@ class DepressionFinderAndRouter(Component):
         with a unique (non-consecutive) code corresponding to each unique lake.
 
         The codes used can be obtained with *lake_codes*. Nodes not in a
-        lake are labelled with self._grid.BAD_INDEX_VALUE.
+        lake are labelled with self._grid.BAD_INDEX
         """
         return self._lake_map
 
@@ -1299,7 +1299,7 @@ class DepressionFinderAndRouter(Component):
     def lake_at_node(self):
         """Return a boolean array, True if the node is flooded, False
         otherwise."""
-        return self._lake_map != self._grid.BAD_INDEX_VALUE
+        return self._lake_map != self._grid.BAD_INDEX
 
     @property
     def lake_areas(self):

--- a/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
+++ b/landlab/components/depth_dependent_diffusion/hillslope_depth_dependent_linear_flux.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 
-from landlab import INACTIVE_LINK, Component
+from landlab import Component, LinkStatus
 
 
 class DepthDependentDiffuser(Component):
@@ -217,7 +217,7 @@ class DepthDependentDiffuser(Component):
 
         # Calculate gradients
         slope = self._grid.calc_grad_at_link(self._elev)
-        slope[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+        slope[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
         # Calculate flux
         self._flux[:] = (

--- a/landlab/components/depth_dependent_taylor_soil_creep/hillslope_depth_dependent_taylor_flux.py
+++ b/landlab/components/depth_dependent_taylor_soil_creep/hillslope_depth_dependent_taylor_flux.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 
-from landlab import INACTIVE_LINK, Component
+from landlab import Component, LinkStatus
 
 
 class DepthDependentTaylorDiffuser(Component):
@@ -369,7 +369,7 @@ class DepthDependentTaylorDiffuser(Component):
 
             # Calculate gradients
             self._slope = self._grid.calc_grad_at_link(self._elev)
-            self._slope[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+            self._slope[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
             # Test for time stepping courant condition
             # Test for time stepping courant condition

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -8,13 +8,8 @@ style
 
 import numpy as np
 
-from landlab import (
-    FIXED_GRADIENT_BOUNDARY,
-    INACTIVE_LINK,
-    Component,
-    FieldError,
-    RasterModelGrid,
-)
+from landlab import Component, FieldError, LinkStatus, NodeStatus, RasterModelGrid
+
 
 _ALPHA = 0.15  # time-step stability factor
 # ^0.25 not restrictive enough at meter scales w S~1 (possible cases)
@@ -356,7 +351,7 @@ class LinearDiffuser(Component):
         True
         """
         fixed_grad_nodes = np.where(
-            self._grid.status_at_node == FIXED_GRADIENT_BOUNDARY
+            self._grid.status_at_node == NodeStatus.FIXED_GRADIENT
         )[0]
         heads = self._grid.node_at_link_head[self._grid.fixed_links]
         tails = self._grid.node_at_link_tail[self._grid.fixed_links]
@@ -389,11 +384,11 @@ class LinearDiffuser(Component):
                 mg.node_at_link_tail[self._vert], 0:3:2
             ]
             self._vert_link_badlinks = np.logical_or(
-                mg.status_at_link[self._vert_link_neighbors] == INACTIVE_LINK,
+                mg.status_at_link[self._vert_link_neighbors] == LinkStatus.INACTIVE,
                 self._vert_link_neighbors == -1,
             )
             self._hoz_link_badlinks = np.logical_or(
-                mg.status_at_link[self._hoz_link_neighbors] == INACTIVE_LINK,
+                mg.status_at_link[self._hoz_link_neighbors] == LinkStatus.INACTIVE,
                 self._hoz_link_neighbors == -1,
             )
 
@@ -445,7 +440,7 @@ class LinearDiffuser(Component):
             # need this else diffusivities on inactive links deform off-angle
             # calculations
             kd_links = kd_links.copy()
-            kd_links[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+            kd_links[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
         # Take the smaller of delt or built-in time-step size self._dt
         self._tstep_ratio = dt / self._dt

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from landlab import Component, FieldError, LinkStatus, NodeStatus, RasterModelGrid
 
-
 _ALPHA = 0.15  # time-step stability factor
 # ^0.25 not restrictive enough at meter scales w S~1 (possible cases)
 

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -14,7 +14,6 @@ together.
 import numpy as np
 
 from landlab import (  # for type tests
-    BAD_INDEX_VALUE,
     Component,
     FieldError,
     NetworkModelGrid,
@@ -728,13 +727,13 @@ class FlowAccumulator(Component):
 
         self._upstream_ordered_nodes = grid.at_node["flow__upstream_node_order"]
         if np.all(self._upstream_ordered_nodes == 0):
-            self._upstream_ordered_nodes.fill(BAD_INDEX_VALUE)
+            self._upstream_ordered_nodes.fill(self._grid.BAD_INDEX_VALUE)
 
         self._delta_structure = grid.at_node["flow__data_structure_delta"]
         if np.all(self._delta_structure == 0):
-            self._delta_structure[:] = BAD_INDEX_VALUE
+            self._delta_structure[:] = self._grid.BAD_INDEX_VALUE
 
-        self._D_structure = BAD_INDEX_VALUE * grid.ones(at="link", dtype=int)
+        self._D_structure = self._grid.BAD_INDEX_VALUE * grid.ones(at="link", dtype=int)
         self._nodes_not_in_stack = True
 
         if len(self._kwargs) > 0:
@@ -812,7 +811,7 @@ class FlowAccumulator(Component):
             self._upstream_ordered_nodes
         ]
         out = downstream_links.flatten()
-        return out[out != BAD_INDEX_VALUE]
+        return out[out != self._grid.BAD_INDEX_VALUE]
 
     def headwater_nodes(self):
         """Return the headwater nodes.

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -727,13 +727,13 @@ class FlowAccumulator(Component):
 
         self._upstream_ordered_nodes = grid.at_node["flow__upstream_node_order"]
         if np.all(self._upstream_ordered_nodes == 0):
-            self._upstream_ordered_nodes.fill(self._grid.BAD_INDEX_VALUE)
+            self._upstream_ordered_nodes.fill(self._grid.BAD_INDEX)
 
         self._delta_structure = grid.at_node["flow__data_structure_delta"]
         if np.all(self._delta_structure == 0):
-            self._delta_structure[:] = self._grid.BAD_INDEX_VALUE
+            self._delta_structure[:] = self._grid.BAD_INDEX
 
-        self._D_structure = self._grid.BAD_INDEX_VALUE * grid.ones(at="link", dtype=int)
+        self._D_structure = self._grid.BAD_INDEX * grid.ones(at="link", dtype=int)
         self._nodes_not_in_stack = True
 
         if len(self._kwargs) > 0:
@@ -811,7 +811,7 @@ class FlowAccumulator(Component):
             self._upstream_ordered_nodes
         ]
         out = downstream_links.flatten()
-        return out[out != self._grid.BAD_INDEX_VALUE]
+        return out[out != self._grid.BAD_INDEX]
 
     def headwater_nodes(self):
         """Return the headwater nodes.

--- a/landlab/components/flow_director/flow_direction_DN.py
+++ b/landlab/components/flow_director/flow_direction_DN.py
@@ -10,12 +10,10 @@ Modified Feb 2014
 """
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
+from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.core.utils import as_id_array
 
 from .cfuncs import adjust_flow_receivers
-
-UNDEFINED_INDEX = BAD_INDEX_VALUE
 
 
 def flow_directions(
@@ -60,7 +58,7 @@ def flow_directions(
         IDs of nodes that are flow sinks (they are their own receivers)
     receiver_link : ndarray
         ID of link that leads from each node to its receiver, or
-        UNDEFINED_INDEX if none.
+        BAD_INDEX_VALUE if none.
 
     Examples
     --------
@@ -94,7 +92,7 @@ def flow_directions(
     num_nodes = len(elev)
     steepest_slope = np.zeros(num_nodes)
     receiver = np.arange(num_nodes)
-    receiver_link = UNDEFINED_INDEX + np.zeros(num_nodes, dtype=np.int)
+    receiver_link = BAD_INDEX_VALUE + np.zeros(num_nodes, dtype=np.int)
 
     # For each link, find the higher of the two nodes. The higher is the
     # potential donor, and the lower is the potential receiver. If the slope
@@ -122,7 +120,7 @@ def flow_directions(
     # Optionally, handle baselevel nodes: they are their own receivers
     if baselevel_nodes is not None:
         receiver[baselevel_nodes] = node_id[baselevel_nodes]
-        receiver_link[baselevel_nodes] = UNDEFINED_INDEX
+        receiver_link[baselevel_nodes] = BAD_INDEX_VALUE
         steepest_slope[baselevel_nodes] = 0.0
 
     # The sink nodes are those that are their own receivers (this will normally

--- a/landlab/components/flow_director/flow_direction_DN.py
+++ b/landlab/components/flow_director/flow_direction_DN.py
@@ -10,8 +10,8 @@ Modified Feb 2014
 """
 import numpy as np
 
-from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.core.utils import as_id_array
+from landlab.grid.base import BAD_INDEX_VALUE
 
 from .cfuncs import adjust_flow_receivers
 

--- a/landlab/components/flow_director/flow_direction_dinf.py
+++ b/landlab/components/flow_director/flow_direction_dinf.py
@@ -12,11 +12,8 @@ KRB Feb 2017
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
 from landlab.core.utils import as_id_array
 from landlab.utils.return_array import return_array_at_node
-
-UNDEFINED_INDEX = BAD_INDEX_VALUE
 
 
 def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=None):
@@ -43,9 +40,9 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     -------
     receivers : ndarray of size (num nodes, max neighbors at node)
         For each node, the IDs of the nodes that receive its flow. For nodes
-        that do not direct flow to all neighbors, BAD_INDEX_VALUE is given as
-        a placeholder. The ID of the node itself is given if no other receiver
-        is assigned.
+        that do not direct flow to all neighbors, grid.BAD_INDEX_VALUE is given
+        as a placeholder. The ID of the node itself is given if no other
+        receiver is assigned.
     proportions : ndarray of size (num nodes, max neighbors at node)
         For each receiver, the proportion of flow (between 0 and 1) is given.
         A proportion of zero indicates that the link does not have flow along
@@ -58,15 +55,15 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
         The slope value (positive downhill) in the direction of flow.
     steepest_receiver : ndarray
         For each node, the node ID of the node connected by the steepest link.
-        BAD_INDEX_VALUE is given if no flow emmanates from the node.
+        grid.BAD_INDEX_VALUE is given if no flow emmanates from the node.
     sink : ndarray
         IDs of nodes that are flow sinks (they are their own receivers)
     receiver_links : ndarray of size (num nodes, max neighbors at node)
         ID of links that leads from each node to its receiver, or
-        UNDEFINED_INDEX if no flow occurs on this link.
+        grid.BAD_INDEX_VALUE if no flow occurs on this link.
     steepest_link : ndarray
         For each node, the link ID of the steepest link.
-        BAD_INDEX_VALUE is given if no flow emmanates from the node.
+        grid.BAD_INDEX_VALUE is given if no flow emmanates from the node.
 
     Examples
     --------
@@ -275,10 +272,14 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     thresh = np.arctan(d2 / d1)
 
     # Step 4, Initialize receiver and proportion arrays
-    receivers = UNDEFINED_INDEX * np.ones((num_nodes, num_receivers), dtype=int)
-    receiver_closed = UNDEFINED_INDEX * np.ones((num_nodes, num_receivers), dtype=int)
+    receivers = grid.BAD_INDEX_VALUE * np.ones((num_nodes, num_receivers), dtype=int)
+    receiver_closed = grid.BAD_INDEX_VALUE * np.ones(
+        (num_nodes, num_receivers), dtype=int
+    )
     proportions = np.zeros((num_nodes, num_receivers), dtype=float)
-    receiver_links = UNDEFINED_INDEX * np.ones((num_nodes, num_receivers), dtype=int)
+    receiver_links = grid.BAD_INDEX_VALUE * np.ones(
+        (num_nodes, num_receivers), dtype=int
+    )
     slopes_to_receivers = np.zeros((num_nodes, num_receivers), dtype=float)
 
     # Step  5  begin the algorithm in earnest
@@ -427,7 +428,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     proportions[closed_nodes, 1] = 0.0
 
     # mask the receiver_links by where flow doesn't occur to return
-    receiver_links[drains_to_self, :] = UNDEFINED_INDEX
+    receiver_links[drains_to_self, :] = grid.BAD_INDEX_VALUE
 
     # identify the steepest link so that the steepest receiver, link, and slope
     # can be returned.
@@ -439,7 +440,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
 
     # identify the steepest link and steepest receiever.
     steepest_link = receiver_links[slope_sort]
-    steepest_link[drains_to_self] = UNDEFINED_INDEX
+    steepest_link[drains_to_self] = grid.BAD_INDEX_VALUE
 
     steepest_receiver = receivers[slope_sort]
     steepest_receiver[drains_to_self] = node_id[drains_to_self]
@@ -450,7 +451,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
         receivers[baselevel_nodes, 1:] = -1
         proportions[baselevel_nodes, 0] = 1
         proportions[baselevel_nodes, 1:] = 0
-        receiver_links[baselevel_nodes, :] = UNDEFINED_INDEX
+        receiver_links[baselevel_nodes, :] = grid.BAD_INDEX_VALUE
         steepest_slope[baselevel_nodes] = 0.0
 
     # ensure that if there is a -1, it is in the second column.

--- a/landlab/components/flow_director/flow_direction_dinf.py
+++ b/landlab/components/flow_director/flow_direction_dinf.py
@@ -40,7 +40,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     -------
     receivers : ndarray of size (num nodes, max neighbors at node)
         For each node, the IDs of the nodes that receive its flow. For nodes
-        that do not direct flow to all neighbors, grid.BAD_INDEX_VALUE is given
+        that do not direct flow to all neighbors, grid.BAD_INDEX is given
         as a placeholder. The ID of the node itself is given if no other
         receiver is assigned.
     proportions : ndarray of size (num nodes, max neighbors at node)
@@ -55,15 +55,15 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
         The slope value (positive downhill) in the direction of flow.
     steepest_receiver : ndarray
         For each node, the node ID of the node connected by the steepest link.
-        grid.BAD_INDEX_VALUE is given if no flow emmanates from the node.
+        grid.BAD_INDEX is given if no flow emmanates from the node.
     sink : ndarray
         IDs of nodes that are flow sinks (they are their own receivers)
     receiver_links : ndarray of size (num nodes, max neighbors at node)
         ID of links that leads from each node to its receiver, or
-        grid.BAD_INDEX_VALUE if no flow occurs on this link.
+        grid.BAD_INDEX if no flow occurs on this link.
     steepest_link : ndarray
         For each node, the link ID of the steepest link.
-        grid.BAD_INDEX_VALUE is given if no flow emmanates from the node.
+        grid.BAD_INDEX is given if no flow emmanates from the node.
 
     Examples
     --------
@@ -272,12 +272,12 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     thresh = np.arctan(d2 / d1)
 
     # Step 4, Initialize receiver and proportion arrays
-    receivers = grid.BAD_INDEX_VALUE * np.ones((num_nodes, num_receivers), dtype=int)
-    receiver_closed = grid.BAD_INDEX_VALUE * np.ones(
+    receivers = grid.BAD_INDEX * np.ones((num_nodes, num_receivers), dtype=int)
+    receiver_closed = grid.BAD_INDEX * np.ones(
         (num_nodes, num_receivers), dtype=int
     )
     proportions = np.zeros((num_nodes, num_receivers), dtype=float)
-    receiver_links = grid.BAD_INDEX_VALUE * np.ones(
+    receiver_links = grid.BAD_INDEX * np.ones(
         (num_nodes, num_receivers), dtype=int
     )
     slopes_to_receivers = np.zeros((num_nodes, num_receivers), dtype=float)
@@ -428,7 +428,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
     proportions[closed_nodes, 1] = 0.0
 
     # mask the receiver_links by where flow doesn't occur to return
-    receiver_links[drains_to_self, :] = grid.BAD_INDEX_VALUE
+    receiver_links[drains_to_self, :] = grid.BAD_INDEX
 
     # identify the steepest link so that the steepest receiver, link, and slope
     # can be returned.
@@ -440,7 +440,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
 
     # identify the steepest link and steepest receiever.
     steepest_link = receiver_links[slope_sort]
-    steepest_link[drains_to_self] = grid.BAD_INDEX_VALUE
+    steepest_link[drains_to_self] = grid.BAD_INDEX
 
     steepest_receiver = receivers[slope_sort]
     steepest_receiver[drains_to_self] = node_id[drains_to_self]
@@ -451,7 +451,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
         receivers[baselevel_nodes, 1:] = -1
         proportions[baselevel_nodes, 0] = 1
         proportions[baselevel_nodes, 1:] = 0
-        receiver_links[baselevel_nodes, :] = grid.BAD_INDEX_VALUE
+        receiver_links[baselevel_nodes, :] = grid.BAD_INDEX
         steepest_slope[baselevel_nodes] = 0.0
 
     # ensure that if there is a -1, it is in the second column.

--- a/landlab/components/flow_director/flow_direction_mfd.py
+++ b/landlab/components/flow_director/flow_direction_mfd.py
@@ -10,8 +10,8 @@ KRB Jan 2017
 
 import numpy as np
 
-from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.core.utils import as_id_array
+from landlab.grid.base import BAD_INDEX_VALUE
 
 
 def flow_directions_mfd(

--- a/landlab/components/flow_director/flow_direction_mfd.py
+++ b/landlab/components/flow_director/flow_direction_mfd.py
@@ -10,10 +10,8 @@ KRB Jan 2017
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
+from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.core.utils import as_id_array
-
-UNDEFINED_INDEX = BAD_INDEX_VALUE
 
 
 def flow_directions_mfd(
@@ -79,7 +77,7 @@ def flow_directions_mfd(
         IDs of nodes that are flow sinks (they are their own receivers)
     receiver_links : ndarray of size (num nodes, max neighbors at node)
         ID of links that leads from each node to its receiver, or
-        UNDEFINED_INDEX if no flow occurs on this link.
+        BAD_INDEX_VALUE if no flow occurs on this link.
     steepest_link : ndarray
         For each node, the link ID of the steepest link.
         BAD_INDEX_VALUE is given if no flow emmanates from the node.
@@ -248,7 +246,7 @@ def flow_directions_mfd(
     receiver_links = links_at_node.copy()
 
     # some of these potential recievers may have already been assigned as
-    # UNDEFINED_INDEX because the link was inactive. Make a mask of these for
+    # BAD_INDEX_VALUE because the link was inactive. Make a mask of these for
     # future use. Also find the close nodes.
     inactive_link_to_neighbor = active_link_dir_at_node == 0
     closed_nodes = np.sum(np.abs(active_link_dir_at_node), 1) == 0
@@ -263,11 +261,11 @@ def flow_directions_mfd(
     # find where flow does not occur (source is lower that receiver)
     flow_does_not_occur = source_node_elev <= potential_receiver_elev
 
-    # Where the source is lower, set receivers to UNDEFINED_INDEX
-    receivers[flow_does_not_occur] = UNDEFINED_INDEX
+    # Where the source is lower, set receivers to BAD_INDEX_VALUE
+    receivers[flow_does_not_occur] = BAD_INDEX_VALUE
 
-    # Where the link is not active, set receivers to UNDEFINED_INDEX
-    receivers[inactive_link_to_neighbor] = UNDEFINED_INDEX
+    # Where the link is not active, set receivers to BAD_INDEX_VALUE
+    receivers[inactive_link_to_neighbor] = BAD_INDEX_VALUE
 
     # Next, find where a node drains to itself
     drains_to_self = receivers.sum(1) == -1 * max_number_of_neighbors
@@ -301,11 +299,11 @@ def flow_directions_mfd(
     proportions[drains_to_self, 1:] = 0
 
     # Might need to sort by proportions and rearrange to follow expectations
-    # of no UNDEFINED_INDEX value in first column. KRB NOT SURE
+    # of no BAD_INDEX_VALUE value in first column. KRB NOT SURE
 
     # mask the receiver_links by where flow doesn't occur to return
-    receiver_links[flow_does_not_occur] = UNDEFINED_INDEX
-    receiver_links[inactive_link_to_neighbor] = UNDEFINED_INDEX
+    receiver_links[flow_does_not_occur] = BAD_INDEX_VALUE
+    receiver_links[inactive_link_to_neighbor] = BAD_INDEX_VALUE
 
     # identify the steepest link so that the steepest receiver, link, and slope
     # can be returned.
@@ -325,7 +323,7 @@ def flow_directions_mfd(
         receivers[baselevel_nodes, 1:] = -1
         proportions[baselevel_nodes, 0] = 1
         proportions[baselevel_nodes, 1:] = 0
-        receiver_links[baselevel_nodes, :] = UNDEFINED_INDEX
+        receiver_links[baselevel_nodes, :] = BAD_INDEX_VALUE
         steepest_slope[baselevel_nodes] = 0.0
 
     # The sink nodes are those that are their own receivers (this will normally

--- a/landlab/components/flow_director/flow_director_d8.py
+++ b/landlab/components/flow_director/flow_director_d8.py
@@ -12,6 +12,7 @@ FlowDirectorSteepest instead.
 
 import numpy
 
+from landlab import LinkStatus
 from landlab.components.flow_director import flow_direction_DN
 from landlab.components.flow_director.flow_director_to_one import _FlowDirectorToOne
 
@@ -215,7 +216,7 @@ class FlowDirectorD8(_FlowDirectorToOne):
 
         # step 1. Calculate link slopes.
         link_slope = -self._grid.calc_grad_at_d8(self._surface_values)
-        link_slope[self._grid.status_at_d8 != self._grid.BC_LINK_IS_ACTIVE] = 0
+        link_slope[self._grid.status_at_d8 != LinkStatus.ACTIVE] = 0
 
         # Step 2. Find and save base level nodes.
         (baselevel_nodes,) = numpy.where(

--- a/landlab/components/flow_director/flow_director_dinf.py
+++ b/landlab/components/flow_director/flow_director_dinf.py
@@ -9,7 +9,7 @@ Tarboton 1997.
 
 import numpy
 
-from landlab import FIXED_GRADIENT_BOUNDARY, FIXED_VALUE_BOUNDARY
+from landlab import NodeStatus
 from landlab.components.flow_director import flow_direction_dinf
 from landlab.components.flow_director.flow_director_to_many import _FlowDirectorToMany
 
@@ -326,8 +326,8 @@ class FlowDirectorDINF(_FlowDirectorToMany):
         # Step 1. Find and save base level nodes.
         (baselevel_nodes,) = numpy.where(
             numpy.logical_or(
-                self._grid.status_at_node == FIXED_VALUE_BOUNDARY,
-                self._grid.status_at_node == FIXED_GRADIENT_BOUNDARY,
+                self._grid.status_at_node == NodeStatus.FIXED_VALUE,
+                self._grid.status_at_node == NodeStatus.FIXED_GRADIENT,
             )
         )
 

--- a/landlab/components/flow_director/flow_director_mfd.py
+++ b/landlab/components/flow_director/flow_director_mfd.py
@@ -11,7 +11,7 @@ use FlowDirectorD8.
 
 import numpy
 
-from landlab import FIXED_GRADIENT_BOUNDARY, FIXED_VALUE_BOUNDARY, VoronoiDelaunayGrid
+from landlab import NodeStatus, VoronoiDelaunayGrid
 from landlab.components.flow_director import flow_direction_mfd
 from landlab.components.flow_director.flow_director_to_many import _FlowDirectorToMany
 
@@ -482,8 +482,8 @@ class FlowDirectorMFD(_FlowDirectorToMany):
         # Step 2. Find and save base level nodes.
         (baselevel_nodes,) = numpy.where(
             numpy.logical_or(
-                self._grid.status_at_node == FIXED_VALUE_BOUNDARY,
-                self._grid.status_at_node == FIXED_GRADIENT_BOUNDARY,
+                self._grid.status_at_node == NodeStatus.FIXED_VALUE,
+                self._grid.status_at_node == NodeStatus.FIXED_GRADIENT,
             )
         )
 

--- a/landlab/components/flow_director/flow_director_steepest.py
+++ b/landlab/components/flow_director/flow_director_steepest.py
@@ -11,7 +11,7 @@ use FlowDirectorD8.
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE, NodeStatus, VoronoiDelaunayGrid
+from landlab import NodeStatus, VoronoiDelaunayGrid
 from landlab.components.flow_director import flow_direction_DN
 from landlab.components.flow_director.flow_director_to_one import _FlowDirectorToOne
 

--- a/landlab/components/flow_director/flow_director_steepest.py
+++ b/landlab/components/flow_director/flow_director_steepest.py
@@ -32,7 +32,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
     -  Node array of steepest downhill slopes:
        *'topographic__steepest_slope'*
     -  Node array containing ID of link that leads from each node to its
-       receiver, or BAD_INDEX_VALUE if no link:
+       receiver, or grid.BAD_INDEX_VALUE if no link:
        *'flow__link_to_receiver_node'*
     -  Boolean node array of all local lows: *'flow__sink_flag'*
     -  Link array identifing if flow goes with (1) or against (-1) the link
@@ -407,7 +407,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         self._flow_link_direction[:] = 0
 
         # identify where flow is active on links
-        is_active_flow_link = self._links_to_receiver != BAD_INDEX_VALUE
+        is_active_flow_link = self._links_to_receiver != self._grid.BAD_INDEX_VALUE
 
         # make an array that says which link ID is active
         active_flow_links = self._links_to_receiver[is_active_flow_link]
@@ -576,7 +576,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         flow_link_direction_at_node = self._flow_link_direction[
             self._grid.links_at_node
         ]
-        flow_to_bad = self._grid.links_at_node == BAD_INDEX_VALUE
+        flow_to_bad = self._grid.links_at_node == self._grid.BAD_INDEX_VALUE
         flow_link_direction_at_node[flow_to_bad] = 0
 
         return flow_link_direction_at_node

--- a/landlab/components/flow_director/flow_director_steepest.py
+++ b/landlab/components/flow_director/flow_director_steepest.py
@@ -11,12 +11,7 @@ use FlowDirectorD8.
 
 import numpy as np
 
-from landlab import (
-    BAD_INDEX_VALUE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-    VoronoiDelaunayGrid,
-)
+from landlab import BAD_INDEX_VALUE, NodeStatus, VoronoiDelaunayGrid
 from landlab.components.flow_director import flow_direction_DN
 from landlab.components.flow_director.flow_director_to_one import _FlowDirectorToOne
 
@@ -372,8 +367,8 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         # Step 2. Find and save base level nodes.
         (baselevel_nodes,) = np.where(
             np.logical_or(
-                self._grid.status_at_node == FIXED_VALUE_BOUNDARY,
-                self._grid.status_at_node == FIXED_GRADIENT_BOUNDARY,
+                self._grid.status_at_node == NodeStatus.FIXED_VALUE,
+                self._grid.status_at_node == NodeStatus.FIXED_GRADIENT,
             )
         )
 

--- a/landlab/components/flow_director/flow_director_steepest.py
+++ b/landlab/components/flow_director/flow_director_steepest.py
@@ -32,7 +32,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
     -  Node array of steepest downhill slopes:
        *'topographic__steepest_slope'*
     -  Node array containing ID of link that leads from each node to its
-       receiver, or grid.BAD_INDEX_VALUE if no link:
+       receiver, or grid.BAD_INDEX if no link:
        *'flow__link_to_receiver_node'*
     -  Boolean node array of all local lows: *'flow__sink_flag'*
     -  Link array identifing if flow goes with (1) or against (-1) the link
@@ -407,7 +407,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         self._flow_link_direction[:] = 0
 
         # identify where flow is active on links
-        is_active_flow_link = self._links_to_receiver != self._grid.BAD_INDEX_VALUE
+        is_active_flow_link = self._links_to_receiver != self._grid.BAD_INDEX
 
         # make an array that says which link ID is active
         active_flow_links = self._links_to_receiver[is_active_flow_link]
@@ -576,7 +576,7 @@ class FlowDirectorSteepest(_FlowDirectorToOne):
         flow_link_direction_at_node = self._flow_link_direction[
             self._grid.links_at_node
         ]
-        flow_to_bad = self._grid.links_at_node == self._grid.BAD_INDEX_VALUE
+        flow_to_bad = self._grid.links_at_node == self._grid.BAD_INDEX
         flow_link_direction_at_node[flow_to_bad] = 0
 
         return flow_link_direction_at_node

--- a/landlab/components/flow_director/flow_director_to_many.py
+++ b/landlab/components/flow_director/flow_director_to_many.py
@@ -8,7 +8,6 @@ grid fields are set up correctly.
 """
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
 from landlab.components.flow_director.flow_director import _FlowDirector
 
 
@@ -121,11 +120,11 @@ class _FlowDirectorToMany(_FlowDirector):
         self.initialize_output_fields(values_per_element=self._max_receivers)
         self._receivers = grid.at_node["flow__receiver_node"]
         if np.all(self._receivers == 0):
-            self._receivers.fill(BAD_INDEX_VALUE)
+            self._receivers.fill(self._grid.BAD_INDEX_VALUE)
 
         self._receiver_links = grid.at_node["flow__link_to_receiver_node"]
         if np.all(self._receiver_links == 0):
-            self._receiver_links.fill(BAD_INDEX_VALUE)
+            self._receiver_links.fill(self._grid.BAD_INDEX_VALUE)
 
         self._proportions = grid.at_node["flow__receiver_proportions"]
         self._steepest_slope = grid.at_node["topographic__steepest_slope"]

--- a/landlab/components/flow_director/flow_director_to_many.py
+++ b/landlab/components/flow_director/flow_director_to_many.py
@@ -120,11 +120,11 @@ class _FlowDirectorToMany(_FlowDirector):
         self.initialize_output_fields(values_per_element=self._max_receivers)
         self._receivers = grid.at_node["flow__receiver_node"]
         if np.all(self._receivers == 0):
-            self._receivers.fill(self._grid.BAD_INDEX_VALUE)
+            self._receivers.fill(self._grid.BAD_INDEX)
 
         self._receiver_links = grid.at_node["flow__link_to_receiver_node"]
         if np.all(self._receiver_links == 0):
-            self._receiver_links.fill(self._grid.BAD_INDEX_VALUE)
+            self._receiver_links.fill(self._grid.BAD_INDEX)
 
         self._proportions = grid.at_node["flow__receiver_proportions"]
         self._steepest_slope = grid.at_node["topographic__steepest_slope"]

--- a/landlab/components/flow_director/flow_director_to_one.py
+++ b/landlab/components/flow_director/flow_director_to_one.py
@@ -8,7 +8,6 @@ grid fields are set up correctly.
 """
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
 from landlab.components.flow_director.flow_director import _FlowDirector
 
 
@@ -128,11 +127,11 @@ class _FlowDirectorToOne(_FlowDirector):
 
         self._links_to_receiver = grid.at_node["flow__link_to_receiver_node"]
         if np.all(self._links_to_receiver == 0):
-            self._links_to_receiver.fill(BAD_INDEX_VALUE)
+            self._links_to_receiver.fill(self._grid.BAD_INDEX_VALUE)
 
         self._receiver = grid.at_node["flow__receiver_node"]
         if np.all(self._receiver == 0):
-            self._receiver.fill(BAD_INDEX_VALUE)
+            self._receiver.fill(self._grid.BAD_INDEX_VALUE)
 
     def run_one_step(self):
         """run_one_step is not implemented for this component."""

--- a/landlab/components/flow_director/flow_director_to_one.py
+++ b/landlab/components/flow_director/flow_director_to_one.py
@@ -127,11 +127,11 @@ class _FlowDirectorToOne(_FlowDirector):
 
         self._links_to_receiver = grid.at_node["flow__link_to_receiver_node"]
         if np.all(self._links_to_receiver == 0):
-            self._links_to_receiver.fill(self._grid.BAD_INDEX_VALUE)
+            self._links_to_receiver.fill(self._grid.BAD_INDEX)
 
         self._receiver = grid.at_node["flow__receiver_node"]
         if np.all(self._receiver == 0):
-            self._receiver.fill(self._grid.BAD_INDEX_VALUE)
+            self._receiver.fill(self._grid.BAD_INDEX)
 
     def run_one_step(self):
         """run_one_step is not implemented for this component."""

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -6,8 +6,7 @@
 
 import numpy as np
 
-from landlab import Component
-from landlab.grid.base import INACTIVE_LINK
+from landlab import Component, LinkStatus
 from landlab.grid.mappers import (
     map_max_of_node_links_to_node,
     map_mean_of_link_nodes_to_link,
@@ -472,7 +471,7 @@ class GroundwaterDupuitPercolator(Component):
             self._hydr_grad * np.cos(np.arctan(abs(self._base_grad)))
             + np.sin(np.arctan(self._base_grad))
         )
-        self._vel[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+        self._vel[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
         # Aquifer thickness at links (upwind)
         hlink = map_value_at_max_node_to_link(
@@ -542,7 +541,7 @@ class GroundwaterDupuitPercolator(Component):
                 self._hydr_grad * np.cos(np.arctan(abs(self._base_grad)))
                 + np.sin(np.arctan(self._base_grad))
             )
-            self._vel[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+            self._vel[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
             # Aquifer thickness at links (upwind)
             hlink = map_value_at_max_node_to_link(

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -16,12 +16,7 @@ from collections import deque
 
 import numpy as np
 
-from landlab import (
-    BAD_INDEX_VALUE,
-    Component,
-    NodeStatus,
-    RasterModelGrid,
-)
+from landlab import Component, NodeStatus, RasterModelGrid
 from landlab.components import FlowAccumulator
 from landlab.utils import StablePriorityQueue
 from landlab.utils.return_array import return_array_at_node

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -18,10 +18,8 @@ import numpy as np
 
 from landlab import (
     BAD_INDEX_VALUE,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
     Component,
+    NodeStatus,
     RasterModelGrid,
 )
 from landlab.components import FlowAccumulator
@@ -360,8 +358,8 @@ class LakeMapperBarnes(Component):
         # of outlet!!
         self._edges = np.where(
             np.logical_or(
-                self._grid.status_at_node == FIXED_VALUE_BOUNDARY,
-                self._grid.status_at_node == FIXED_GRADIENT_BOUNDARY,
+                self._grid.status_at_node == NodeStatus.FIXED_VALUE,
+                self._grid.status_at_node == NodeStatus.FIXED_GRADIENT,
             )
         )[0]
         if self._edges.size == 0:
@@ -992,7 +990,7 @@ class LakeMapperBarnes(Component):
         --------
         >>> import numpy as np
         >>> from collections import deque
-        >>> from landlab import RasterModelGrid
+        >>> from landlab import NodeStatus, RasterModelGrid
         >>> from landlab.components import (
         ...     LakeMapperBarnes,
         ...     FlowDirectorSteepest,
@@ -1042,7 +1040,7 @@ class LakeMapperBarnes(Component):
 
         Note flow doesn't make it to the outlets:
 
-        >>> outlets = np.where(mg.status_at_node == mg.BC_NODE_IS_FIXED_VALUE)
+        >>> outlets = np.where(mg.status_at_node == NodeStatus.FIXED_VALUE)
         >>> drainage_area[outlets].sum() == mg.cell_area_at_node[
         ...     mg.core_nodes].sum()
         False
@@ -1101,7 +1099,7 @@ class LakeMapperBarnes(Component):
         # (0), lake margin (1), and closed (2). This lets us work the
         # perimeter too. Open each lake as needed.
         # close the known boundary nodes:
-        closedq[self._grid.status_at_node != CORE_NODE] = 2
+        closedq[self._grid.status_at_node != NodeStatus.CORE] = 2
 
         # now the actual loop. Work forward lake by lake to avoid unnecessary
         # processing (nodes outside lakes are already correct, by definition).
@@ -1115,7 +1113,7 @@ class LakeMapperBarnes(Component):
             # it's possible the outlet used to drain *into* the lake,
             # so it needs separate consideration. Likewise, the gradients
             # of the perimeter nodes are likely to be wrong.
-            if self._grid.status_at_node[outlet] != CORE_NODE:
+            if self._grid.status_at_node[outlet] != NodeStatus.CORE:
                 # don't do anything if the outlet happens to be a boundary
                 pass
             else:
@@ -1167,7 +1165,7 @@ class LakeMapperBarnes(Component):
                                 continue
                             elif n == -1:
                                 continue
-                            elif self._grid.status_at_node[n] != CORE_NODE:
+                            elif self._grid.status_at_node[n] != NodeStatus.CORE:
                                 closedq[n] = 2
                                 continue
                             else:

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -26,7 +26,6 @@ from landlab.components import FlowAccumulator
 from landlab.utils import StablePriorityQueue
 from landlab.utils.return_array import return_array_at_node
 
-LOCAL_BAD_INDEX_VALUE = BAD_INDEX_VALUE
 LARGE_ELEV = 9999999999.0
 
 # TODO: Needs to have rerouting functionality...
@@ -670,7 +669,7 @@ class LakeMapperBarnes(Component):
         True
         """
         lakemappings = dict()
-        outlet_ID = BAD_INDEX_VALUE
+        outlet_ID = self._grid.BAD_INDEX_VALUE
         while True:
             try:
                 c = heapq.heappop(pitq)
@@ -868,7 +867,7 @@ class LakeMapperBarnes(Component):
         ValueError was raised: Pit is overfilled due to creation of two outlets as the minimum gradient gets applied. Suppress this Error with the ignore_overfill flag at component instantiation.
         """
         lakemappings = dict()
-        outlet_ID = BAD_INDEX_VALUE
+        outlet_ID = self._grid.BAD_INDEX_VALUE
         while True:
             try:
                 topopen = openq.peek_at_task()
@@ -1833,7 +1832,7 @@ class LakeMapperBarnes(Component):
     def lake_map(self):
         """Return an array of ints, where each node within a lake is labelled
         with its outlet node ID. The outlet nodes are NOT part of the lakes.
-        Nodes not in a lake are labelled with LOCAL_BAD_INDEX_VALUE (default
+        Nodes not in a lake are labelled with BAD_INDEX_VALUE (default
         -1).
 
         Examples
@@ -1897,7 +1896,7 @@ class LakeMapperBarnes(Component):
         if self._runcount > self._lastcountforlakemap:
             # things have changed since last call to lake_map
             self._lake_map = np.full(
-                self._grid.number_of_nodes, LOCAL_BAD_INDEX_VALUE, dtype=int
+                self._grid.number_of_nodes, self._grid.BAD_INDEX_VALUE, dtype=int
             )
             for (outlet, lakenodes) in self.lake_dict.items():
                 self._lake_map[lakenodes] = outlet
@@ -1942,7 +1941,7 @@ class LakeMapperBarnes(Component):
         >>> np.all(np.equal(lmb.lake_at_node, lake_at_node))
         True
         """
-        return self.lake_map != LOCAL_BAD_INDEX_VALUE
+        return self.lake_map != self._grid.BAD_INDEX_VALUE
 
     @property
     def lake_depths(self):

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -664,7 +664,7 @@ class LakeMapperBarnes(Component):
         True
         """
         lakemappings = dict()
-        outlet_ID = self._grid.BAD_INDEX_VALUE
+        outlet_ID = self._grid.BAD_INDEX
         while True:
             try:
                 c = heapq.heappop(pitq)
@@ -862,7 +862,7 @@ class LakeMapperBarnes(Component):
         ValueError was raised: Pit is overfilled due to creation of two outlets as the minimum gradient gets applied. Suppress this Error with the ignore_overfill flag at component instantiation.
         """
         lakemappings = dict()
-        outlet_ID = self._grid.BAD_INDEX_VALUE
+        outlet_ID = self._grid.BAD_INDEX
         while True:
             try:
                 topopen = openq.peek_at_task()
@@ -1891,7 +1891,7 @@ class LakeMapperBarnes(Component):
         if self._runcount > self._lastcountforlakemap:
             # things have changed since last call to lake_map
             self._lake_map = np.full(
-                self._grid.number_of_nodes, self._grid.BAD_INDEX_VALUE, dtype=int
+                self._grid.number_of_nodes, self._grid.BAD_INDEX, dtype=int
             )
             for (outlet, lakenodes) in self.lake_dict.items():
                 self._lake_map[lakenodes] = outlet
@@ -1936,7 +1936,7 @@ class LakeMapperBarnes(Component):
         >>> np.all(np.equal(lmb.lake_at_node, lake_at_node))
         True
         """
-        return self.lake_map != self._grid.BAD_INDEX_VALUE
+        return self.lake_map != self._grid.BAD_INDEX
 
     @property
     def lake_depths(self):

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -856,14 +856,12 @@ def find_active_neighbors_for_fixed_links(grid):
     Examples
     --------
     >>> from landlab.grid.structured_quad.links import neighbors_at_link
-    >>> from landlab import RasterModelGrid
+    >>> from landlab import NodeStatus, RasterModelGrid
     >>> from landlab.components.overland_flow.generate_overland_flow_deAlmeida import find_active_neighbors_for_fixed_links
 
-    >>> from landlab import RasterModelGrid, FIXED_GRADIENT_BOUNDARY
-
     >>> grid = RasterModelGrid((4, 5))
-    >>> grid.status_at_node[:5] = FIXED_GRADIENT_BOUNDARY
-    >>> grid.status_at_node[::5] = FIXED_GRADIENT_BOUNDARY
+    >>> grid.status_at_node[:5] = NodeStatus.FIXED_GRADIENT
+    >>> grid.status_at_node[::5] = NodeStatus.FIXED_GRADIENT
     >>> grid.status_at_node # doctest: +NORMALIZE_WHITESPACE
     array([2, 2, 2, 2, 2,
            2, 0, 0, 0, 1,

--- a/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
+++ b/landlab/components/potentiality_flowrouting/route_flow_by_boundary.py
@@ -12,7 +12,7 @@ Created on Fri Feb 20 09:32:27 2015
 
 import numpy as np
 
-from landlab import FIXED_LINK, INACTIVE_LINK, Component, RasterModelGrid
+from landlab import Component, LinkStatus, RasterModelGrid
 
 
 class PotentialityFlowRouter(Component):
@@ -222,7 +222,7 @@ class PotentialityFlowRouter(Component):
 
             upwind_K = grid.map_value_at_max_node_to_link(z, self._K)
             self._discharges_at_link[:] = upwind_K * g
-            self._discharges_at_link[grid.status_at_link == INACTIVE_LINK] = 0.0
+            self._discharges_at_link[grid.status_at_link == LinkStatus.INACTIVE] = 0.0
         else:
             # grad on diags:
             gwd = np.empty(grid.number_of_d8, dtype=float)
@@ -259,7 +259,7 @@ class PotentialityFlowRouter(Component):
             )
             self._discharges_at_link[: grid.number_of_links] = upwind_K * g
             self._discharges_at_link[grid.number_of_links :] = upwind_diag_K * gd
-            self._discharges_at_link[grid.status_at_d8 == FIXED_LINK] = 0.0
+            self._discharges_at_link[grid.status_at_d8 == LinkStatus.FIXED] = 0.0
 
         np.multiply(self._K, outgoing_sum, out=self._Qw)
         # there is no sensible way to save discharges at links, if we route

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from landlab import Component, FieldError, RasterModelGrid
 from landlab.components import DepressionFinderAndRouter, FlowAccumulator
-from landlab.grid.base import BAD_INDEX_VALUE
 
 # TODO: this should probably follow Barnes et al., 2014 for max efficiency
 
@@ -31,7 +30,6 @@ class SinkFiller(Component):
     Examples
     --------
     >>> from landlab import RasterModelGrid
-    >>> from landlab import BAD_INDEX_VALUE as XX
     >>> from landlab.components import FlowAccumulator, SinkFiller
     >>> import numpy as np
     >>> lake1 = np.array([34, 35, 36, 44, 45, 46, 54, 55, 56, 65, 74])
@@ -258,7 +256,7 @@ class SinkFiller(Component):
         else:
             all_poss = np.unique(self._grid.active_adjacent_nodes_at_node[lake_nodes])
         lake_ext_edge = np.setdiff1d(all_poss, lake_nodes)
-        return lake_ext_edge[lake_ext_edge != BAD_INDEX_VALUE]
+        return lake_ext_edge[lake_ext_edge != self._grid.BAD_INDEX_VALUE]
 
     def _get_lake_int_margin(self, lake_nodes, lake_ext_edge):
         """Returns the nodes forming the internal margin of the lake, honoring
@@ -272,7 +270,7 @@ class SinkFiller(Component):
         else:
             all_poss_int = np.unique(self._grid.active_adjacent_nodes_at_node[lee])
         lake_int_edge = np.intersect1d(all_poss_int, lake_nodes)
-        return lake_int_edge[lake_int_edge != BAD_INDEX_VALUE]
+        return lake_int_edge[lake_int_edge != self._grid.BAD_INDEX_VALUE]
 
     def _apply_slope_current_lake(self, apply_slope, outlet_node, lake_code, sublake):
         """Wraps the _add_slopes method to allow handling of conditions where
@@ -311,7 +309,7 @@ class SinkFiller(Component):
             )
         else:
             edge_neighbors = self._grid.active_adjacent_nodes_at_node[ext_edge].copy()
-        edge_neighbors[edge_neighbors == BAD_INDEX_VALUE] = -1
+        edge_neighbors[edge_neighbors == self._grid.BAD_INDEX_VALUE] = -1
         # ^value irrelevant
         old_neighbor_elevs = old_elevs[edge_neighbors]
         new_neighbor_elevs = new_elevs[edge_neighbors]

--- a/landlab/components/sink_fill/fill_sinks.py
+++ b/landlab/components/sink_fill/fill_sinks.py
@@ -256,7 +256,7 @@ class SinkFiller(Component):
         else:
             all_poss = np.unique(self._grid.active_adjacent_nodes_at_node[lake_nodes])
         lake_ext_edge = np.setdiff1d(all_poss, lake_nodes)
-        return lake_ext_edge[lake_ext_edge != self._grid.BAD_INDEX_VALUE]
+        return lake_ext_edge[lake_ext_edge != self._grid.BAD_INDEX]
 
     def _get_lake_int_margin(self, lake_nodes, lake_ext_edge):
         """Returns the nodes forming the internal margin of the lake, honoring
@@ -270,7 +270,7 @@ class SinkFiller(Component):
         else:
             all_poss_int = np.unique(self._grid.active_adjacent_nodes_at_node[lee])
         lake_int_edge = np.intersect1d(all_poss_int, lake_nodes)
-        return lake_int_edge[lake_int_edge != self._grid.BAD_INDEX_VALUE]
+        return lake_int_edge[lake_int_edge != self._grid.BAD_INDEX]
 
     def _apply_slope_current_lake(self, apply_slope, outlet_node, lake_code, sublake):
         """Wraps the _add_slopes method to allow handling of conditions where
@@ -309,7 +309,7 @@ class SinkFiller(Component):
             )
         else:
             edge_neighbors = self._grid.active_adjacent_nodes_at_node[ext_edge].copy()
-        edge_neighbors[edge_neighbors == self._grid.BAD_INDEX_VALUE] = -1
+        edge_neighbors[edge_neighbors == self._grid.BAD_INDEX] = -1
         # ^value irrelevant
         old_neighbor_elevs = old_elevs[edge_neighbors]
         new_neighbor_elevs = new_elevs[edge_neighbors]

--- a/landlab/components/sink_fill/sink_fill_barnes.py
+++ b/landlab/components/sink_fill/sink_fill_barnes.py
@@ -9,11 +9,8 @@ Fill sinks in a landscape to the brim, following the Barnes et al.
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
 from landlab.components import LakeMapperBarnes
 from landlab.utils.return_array import return_array_at_node
-
-LOCAL_BAD_INDEX_VALUE = BAD_INDEX_VALUE
 
 
 class SinkFillerBarnes(LakeMapperBarnes):
@@ -263,7 +260,7 @@ class SinkFillerBarnes(LakeMapperBarnes):
         outlet node ID.
 
         Nodes not in a filled area are labelled with
-        LOCAL_BAD_INDEX_VALUE (default -1).
+        BAD_INDEX_VALUE (default -1).
         """
         return super(SinkFillerBarnes, self).lake_map
 

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -8,7 +8,7 @@
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE as UNDEFINED_INDEX, Component, RasterModelGrid
+from landlab import Component, RasterModelGrid
 from landlab.utils.return_array import return_array_at_node
 
 from ..depression_finder.lake_mapper import _FLOODED
@@ -272,7 +272,8 @@ class FastscapeEroder(Component):
         z = self._grid.at_node["topographic__elevation"]
 
         defined_flow_receivers = np.not_equal(
-            self._grid.at_node["flow__link_to_receiver_node"], UNDEFINED_INDEX
+            self._grid.at_node["flow__link_to_receiver_node"],
+            self._grid.BAD_INDEX_VALUE,
         )
 
         if isinstance(self._grid, RasterModelGrid):

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -273,7 +273,7 @@ class FastscapeEroder(Component):
 
         defined_flow_receivers = np.not_equal(
             self._grid.at_node["flow__link_to_receiver_node"],
-            self._grid.BAD_INDEX_VALUE,
+            self._grid.BAD_INDEX,
         )
 
         if isinstance(self._grid, RasterModelGrid):

--- a/landlab/components/stream_power/sed_flux_dep_incision.py
+++ b/landlab/components/stream_power/sed_flux_dep_incision.py
@@ -4,7 +4,6 @@ import numpy as np
 import scipy.constants
 
 from landlab import Component, MissingKeyError
-from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.utils.decorators import make_return_array_immutable
 
 
@@ -701,7 +700,9 @@ class SedDepEroder(Component):
         steepest_link = "flow__link_to_receiver_node"
         link_length = np.empty(grid.number_of_nodes, dtype=float)
         link_length.fill(np.nan)
-        draining_nodes = np.not_equal(grid.at_node[steepest_link], BAD_INDEX_VALUE)
+        draining_nodes = np.not_equal(
+            grid.at_node[steepest_link], self._grid.BAD_INDEX_VALUE
+        )
         core_draining_nodes = np.intersect1d(
             np.where(draining_nodes)[0], grid.core_nodes, assume_unique=True
         )

--- a/landlab/components/stream_power/sed_flux_dep_incision.py
+++ b/landlab/components/stream_power/sed_flux_dep_incision.py
@@ -701,7 +701,7 @@ class SedDepEroder(Component):
         link_length = np.empty(grid.number_of_nodes, dtype=float)
         link_length.fill(np.nan)
         draining_nodes = np.not_equal(
-            grid.at_node[steepest_link], self._grid.BAD_INDEX_VALUE
+            grid.at_node[steepest_link], self._grid.BAD_INDEX
         )
         core_draining_nodes = np.intersect1d(
             np.where(draining_nodes)[0], grid.core_nodes, assume_unique=True

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE as UNDEFINED_INDEX, Component, MissingKeyError
+from landlab import Component, MissingKeyError
 from landlab.utils.return_array import return_array_at_node
 
 from ..depression_finder.lake_mapper import _FLOODED
@@ -347,7 +347,8 @@ class StreamPowerEroder(Component):
         upstream_order_IDs = self._grid["node"]["flow__upstream_node_order"]
 
         defined_flow_receivers = np.not_equal(
-            self._grid["node"]["flow__link_to_receiver_node"], UNDEFINED_INDEX
+            self._grid["node"]["flow__link_to_receiver_node"],
+            self._grid.BAD_INDEX_VALUE,
         )
 
         try:

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -348,7 +348,7 @@ class StreamPowerEroder(Component):
 
         defined_flow_receivers = np.not_equal(
             self._grid["node"]["flow__link_to_receiver_node"],
-            self._grid.BAD_INDEX_VALUE,
+            self._grid.BAD_INDEX,
         )
 
         try:

--- a/landlab/components/stream_power/stream_power_smooth_threshold.py
+++ b/landlab/components/stream_power/stream_power_smooth_threshold.py
@@ -18,13 +18,9 @@ Created on Sat Nov 26 08:36:49 2016
 
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE
-
 from ..depression_finder.lake_mapper import _FLOODED
 from .cfuncs import smooth_stream_power_eroder_solver
 from .fastscape_stream_power import FastscapeEroder
-
-UNDEFINED_INDEX = BAD_INDEX_VALUE
 
 
 class StreamPowerSmoothThresholdEroder(FastscapeEroder):
@@ -265,7 +261,8 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
         # Get an array of flow-link length for each node that has a defined
         # receiver (i.e., that drains to another node).
         defined_flow_receivers = np.not_equal(
-            self._grid["node"]["flow__link_to_receiver_node"], UNDEFINED_INDEX
+            self._grid["node"]["flow__link_to_receiver_node"],
+            self._grid.BAD_INDEX_VALUE,
         )
         defined_flow_receivers[flow_receivers == node_id] = False
 

--- a/landlab/components/stream_power/stream_power_smooth_threshold.py
+++ b/landlab/components/stream_power/stream_power_smooth_threshold.py
@@ -262,7 +262,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
         # receiver (i.e., that drains to another node).
         defined_flow_receivers = np.not_equal(
             self._grid["node"]["flow__link_to_receiver_node"],
-            self._grid.BAD_INDEX_VALUE,
+            self._grid.BAD_INDEX,
         )
         defined_flow_receivers[flow_receivers == node_id] = False
 

--- a/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
+++ b/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
@@ -10,7 +10,7 @@
 
 import numpy as np
 
-from landlab import INACTIVE_LINK, Component
+from landlab import Component, LinkStatus
 
 
 class TaylorNonLinearDiffuser(Component):
@@ -246,7 +246,7 @@ class TaylorNonLinearDiffuser(Component):
 
             # Calculate gradients
             self._slope[:] = self._grid.calc_grad_at_link(self._elev)
-            self._slope[self._grid.status_at_link == INACTIVE_LINK] = 0.0
+            self._slope[self._grid.status_at_link == LinkStatus.INACTIVE] = 0.0
 
             # Test for time stepping courant condition
             courant_slope_term = 0.0

--- a/landlab/grid/__init__.py
+++ b/landlab/grid/__init__.py
@@ -1,13 +1,14 @@
-from .base import (
+from .base import BAD_INDEX_VALUE, ModelGrid
+from .linkstatus import (
     ACTIVE_LINK,
-    BAD_INDEX_VALUE,
+    FIXED_LINK,
+    INACTIVE_LINK,
+)
+from .nodestatus import (
     CORE_NODE,
     FIXED_GRADIENT_BOUNDARY,
-    FIXED_LINK,
     FIXED_VALUE_BOUNDARY,
-    INACTIVE_LINK,
     LOOPED_BOUNDARY,
-    ModelGrid,
 )
 from .create import create_grid
 from .hex import HexModelGrid

--- a/landlab/grid/__init__.py
+++ b/landlab/grid/__init__.py
@@ -1,18 +1,14 @@
-from .base import BAD_INDEX_VALUE, ModelGrid
-from .linkstatus import (
-    ACTIVE_LINK,
-    FIXED_LINK,
-    INACTIVE_LINK,
-)
+from .base import ModelGrid
+from .create import create_grid
+from .hex import HexModelGrid
+from .linkstatus import ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK
+from .network import NetworkModelGrid
 from .nodestatus import (
     CORE_NODE,
     FIXED_GRADIENT_BOUNDARY,
     FIXED_VALUE_BOUNDARY,
     LOOPED_BOUNDARY,
 )
-from .create import create_grid
-from .hex import HexModelGrid
-from .network import NetworkModelGrid
 from .radial import RadialModelGrid
 from .raster import RasterModelGrid
 from .voronoi import VoronoiDelaunayGrid

--- a/landlab/grid/__init__.py
+++ b/landlab/grid/__init__.py
@@ -1,14 +1,7 @@
 from .base import ModelGrid
 from .create import create_grid
 from .hex import HexModelGrid
-from .linkstatus import ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK
 from .network import NetworkModelGrid
-from .nodestatus import (
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-    LOOPED_BOUNDARY,
-)
 from .radial import RadialModelGrid
 from .raster import RasterModelGrid
 from .voronoi import VoronoiDelaunayGrid
@@ -20,12 +13,5 @@ __all__ = [
     "RasterModelGrid",
     "VoronoiDelaunayGrid",
     "NetworkModelGrid",
-    "FIXED_VALUE_BOUNDARY",
-    "FIXED_GRADIENT_BOUNDARY",
-    "LOOPED_BOUNDARY",
-    "ACTIVE_LINK",
-    "FIXED_LINK",
-    "INACTIVE_LINK",
-    "CORE_NODE",
     "create_grid",
 ]

--- a/landlab/grid/__init__.py
+++ b/landlab/grid/__init__.py
@@ -24,7 +24,6 @@ __all__ = [
     "RasterModelGrid",
     "VoronoiDelaunayGrid",
     "NetworkModelGrid",
-    "BAD_INDEX_VALUE",
     "FIXED_VALUE_BOUNDARY",
     "FIXED_GRADIENT_BOUNDARY",
     "LOOPED_BOUNDARY",

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -23,7 +23,6 @@ from .decorators import override_array_setitem_and_reset, return_readonly_id_arr
 from .linkstatus import LinkStatus, set_status_at_link
 from .nodestatus import NodeStatus
 
-
 #: Indicates an index is, in some way, *bad*.
 BAD_INDEX_VALUE = -1
 # DEJH thinks the user should be able to override this value if they want

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -303,7 +303,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         Units of coordinates
     """
 
-    # Bad index value
+    #: Indicates a node is *bad index*.
     BAD_INDEX_VALUE = BAD_INDEX_VALUE
 
     #: Indicates a node is *core*.
@@ -1519,7 +1519,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         Examples
         --------
         >>> import numpy as np
-        >>> from landlab import RasterModelGrid, BAD_INDEX_VALUE
+        >>> from landlab import RasterModelGrid
 
         >>> rmg = RasterModelGrid((3, 4))
         >>> rmg.at_link['grad'] = np.array([-1., -2., -1.,
@@ -1527,7 +1527,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         ...                                 -1., -2., -1.,
         ...                                 -1., -2., -3., -4.,
         ...                                 -1., -2., -1.])
-        >>> rmg.downwind_links_at_node('grad', bad_index=BAD_INDEX_VALUE)
+        >>> rmg.downwind_links_at_node('grad', bad_index=rmg.BAD_INDEX_VALUE)
         array([[ 0,  3],
                [ 1,  4],
                [ 2,  5],

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -275,7 +275,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         Values at faces.
     at_grid: dict-like
         Global values
-    BAD_INDEX_VALUE : int
+    BAD_INDEX : int
         Indicates a grid element is undefined.
     BC_NODE_IS_CORE : int
         Indicates a node is *core*.
@@ -303,7 +303,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
     """
 
     #: Indicates a node is *bad index*.
-    BAD_INDEX_VALUE = BAD_INDEX_VALUE
+    BAD_INDEX = BAD_INDEX_VALUE
 
     #: Indicates a node is *core*.
     BC_NODE_IS_CORE = NodeStatus.CORE
@@ -765,7 +765,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         ]
         # resolve any corner nodes
         neighbor_nodes = self.adjacent_nodes_at_node[fix_nodes]  # BAD_INDEX_VALUEs
-        neighbor_nodes[neighbor_nodes == BAD_INDEX_VALUE] = -1
+        neighbor_nodes[neighbor_nodes == self.BAD_INDEX] = -1
         fixed_grad_neighbor = np.logical_and(
             (self.status_at_node[neighbor_nodes] == NodeStatus.FIXED_GRADIENT),
             boundary_exists,
@@ -1526,7 +1526,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         ...                                 -1., -2., -1.,
         ...                                 -1., -2., -3., -4.,
         ...                                 -1., -2., -1.])
-        >>> rmg.downwind_links_at_node('grad', bad_index=rmg.BAD_INDEX_VALUE)
+        >>> rmg.downwind_links_at_node('grad', bad_index=rmg.BAD_INDEX)
         array([[ 0,  3],
                [ 1,  4],
                [ 2,  5],
@@ -2721,7 +2721,7 @@ class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
         """
         status_of_neighbor = self._node_status[self.adjacent_nodes_at_node]
         neighbor_not_core = status_of_neighbor != NodeStatus.CORE
-        bad_neighbor = self.adjacent_nodes_at_node == BAD_INDEX_VALUE
+        bad_neighbor = self.adjacent_nodes_at_node == self.BAD_INDEX
         neighbor_not_core[bad_neighbor] = False
         return np.any(neighbor_not_core, axis=1)
 

--- a/landlab/grid/diagonals.py
+++ b/landlab/grid/diagonals.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from ..utils.decorators import cache_result_in_object, make_return_array_immutable
 from .decorators import return_readonly_id_array
-from .linkstatus import ACTIVE_LINK, set_status_at_link
+from .linkstatus import LinkStatus, set_status_at_link
 
 
 def create_nodes_at_diagonal(shape, out=None):
@@ -154,7 +154,7 @@ class DiagonalsMixIn(object):
         diagonal is directed away from the node the direction is -1, if the
         diagonal is directed toward the node its direction is 1. Each
         node is assumed to have exactly four diagonals attached to it.
-        However, perimeter nodes will have few diagonals (corner ndoes
+        However, perimeter nodes will have fewer diagonals (corner nodes
         will only have one diagonal and edge nodes two). In such cases,
         placeholders of 0 are used.
 
@@ -407,7 +407,7 @@ class DiagonalsMixIn(object):
 
         Examples
         --------
-        >>> from landlab import RasterModelGrid
+        >>> from landlab import LinkStatus, NodeStatus, RasterModelGrid
         >>> grid = RasterModelGrid((4, 3))
 
         An inactive link (or diagonal) is one that joins two
@@ -418,8 +418,8 @@ class DiagonalsMixIn(object):
                1, 0, 1,
                1, 0, 1,
                1, 1, 1], dtype=uint8)
-        >>> grid.BC_NODE_IS_CORE, grid.BC_NODE_IS_FIXED_VALUE
-        (0, 1)
+        >>> NodeStatus.CORE, NodeStatus.FIXED_VALUE
+        (<NodeStatus.CORE: 0>, <NodeStatus.FIXED_VALUE: 1>)
 
         Diagonals that connect two boundary nodes are inactive.
 
@@ -427,13 +427,13 @@ class DiagonalsMixIn(object):
         array([0, 4, 4, 0,
                0, 0, 0, 0,
                4, 0, 0, 4], dtype=uint8)
-        >>> grid.BC_LINK_IS_ACTIVE, grid.BC_LINK_IS_INACTIVE
-        (0, 4)
+        >>> LinkStatus.ACTIVE, LinkStatus.INACTIVE
+        (<LinkStatus.ACTIVE: 0>, <LinkStatus.INACTIVE: 4>)
 
         By setting a node to closed that wasn't before, a new link
-        become inactive.
+        becomes inactive.
 
-        >>> grid.status_at_node[5] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[5] = NodeStatus.CLOSED
         >>> grid.status_at_diagonal
         array([0, 4, 4, 0,
                0, 0, 0, 4,
@@ -451,14 +451,14 @@ class DiagonalsMixIn(object):
     @cache_result_in_object()
     @return_readonly_id_array
     def active_diagonals(self):
-        return np.where(self.status_at_diagonal == ACTIVE_LINK)[0]
+        return np.where(self.status_at_diagonal == LinkStatus.ACTIVE)[0]
 
     @property
     @cache_result_in_object()
     @make_return_array_immutable
     def active_diagonal_dirs_at_node(self):
         return np.choose(
-            self.diagonal_status_at_node == ACTIVE_LINK, (0, self.diagonal_dirs_at_node)
+            self.diagonal_status_at_node == LinkStatus.ACTIVE, (0, self.diagonal_dirs_at_node)
         )
 
     @property
@@ -473,12 +473,12 @@ class DiagonalsMixIn(object):
     @cache_result_in_object()
     @return_readonly_id_array
     def active_d8(self):
-        return np.where(self.status_at_d8 == ACTIVE_LINK)[0]
+        return np.where(self.status_at_d8 == LinkStatus.ACTIVE)[0]
 
     @property
     @cache_result_in_object()
     @make_return_array_immutable
     def active_d8_dirs_at_node(self):
         return np.choose(
-            self.d8_status_at_node == ACTIVE_LINK, (0, self.d8_dirs_at_node)
+            self.d8_status_at_node == LinkStatus.ACTIVE, (0, self.d8_dirs_at_node)
         )

--- a/landlab/grid/diagonals.py
+++ b/landlab/grid/diagonals.py
@@ -458,7 +458,8 @@ class DiagonalsMixIn(object):
     @make_return_array_immutable
     def active_diagonal_dirs_at_node(self):
         return np.choose(
-            self.diagonal_status_at_node == LinkStatus.ACTIVE, (0, self.diagonal_dirs_at_node)
+            self.diagonal_status_at_node == LinkStatus.ACTIVE,
+            (0, self.diagonal_dirs_at_node),
         )
 
     @property

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -428,13 +428,13 @@ class HexModelGrid(DualHexGraph, ModelGrid):
         value.  Can return the outlet id as a one element numpy array if
         return_outlet_id is set to True.
 
-        All nodes with nodata_value are set to BC_NODE_IS_CLOSED
+        All nodes with nodata_value are set to `NodeStatus.CLOSED`
         (grid.status_at_node == 4). All nodes with data values are set to
-        CORE_NODES (grid.status_at_node == 0), with the exception that the
-        outlet node is set to a FIXED_VALUE_BOUNDARY (grid.status_at_node == 1).
+        `NodeStatus.CORE` (grid.status_at_node == 0), with the exception that the
+        outlet node is set to a `NodeStatus.FIXED_VALUE` (grid.status_at_node == 1).
 
         Note that the outer ring (perimeter) of the grid is set to
-        BC_NODE_IS_CLOSED, even if there are nodes that have values. The only
+        `NodeStatus.CLOSED`, even if there are nodes that have values. The only
         exception to this would be if the outlet node is on the perimeter, which
         is acceptable.
 

--- a/landlab/grid/linkstatus.py
+++ b/landlab/grid/linkstatus.py
@@ -1,12 +1,18 @@
 #! /usr/bin/env python
+from enum import IntEnum, unique
+
 import numpy as np
 
-from .nodestatus import (
-    CLOSED_BOUNDARY,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-)
+from .nodestatus import NodeStatus
+
+
+@unique
+class LinkStatus(IntEnum):
+    """Define the link types"""
+    ACTIVE = 0
+    FIXED = 2
+    INACTIVE = 4
+
 
 # Define the link types
 #: Indicates a link is *active*, and can carry flux
@@ -39,22 +45,25 @@ def is_fixed_link(node_status_at_link):
     Examples
     --------
     >>> from landlab.grid.linkstatus import is_fixed_link
-    >>> from landlab import CORE_NODE, FIXED_GRADIENT_BOUNDARY
-    >>> is_fixed_link([CORE_NODE, FIXED_GRADIENT_BOUNDARY])
+    >>> from landlab import NodeStatus
+    >>> is_fixed_link([NodeStatus.CORE, NodeStatus.FIXED_GRADIENT])
     array([ True], dtype=bool)
 
-    >>> from landlab import FIXED_VALUE_BOUNDARY
-    >>> is_fixed_link([CORE_NODE, FIXED_VALUE_BOUNDARY])
+    >>> is_fixed_link([NodeStatus.CORE, NodeStatus.FIXED_VALUE])
     array([False], dtype=bool)
 
-    >>> is_fixed_link([[FIXED_GRADIENT_BOUNDARY, CORE_NODE],
-    ...                [CORE_NODE, CORE_NODE]])
+    >>> is_fixed_link(
+    ...     [
+    ...         [NodeStatus.FIXED_GRADIENT, NodeStatus.CORE],
+    ...         [NodeStatus.CORE, NodeStatus.CORE]
+    ...     ]
+    ... )
     array([ True, False], dtype=bool)
     """
     node_status_at_link = np.asarray(node_status_at_link).reshape((-1, 2))
 
-    is_core_node = node_status_at_link == CORE_NODE
-    is_fixed_gradient_node = node_status_at_link == FIXED_GRADIENT_BOUNDARY
+    is_core_node = node_status_at_link == NodeStatus.CORE
+    is_fixed_gradient_node = node_status_at_link == NodeStatus.FIXED_GRADIENT
 
     return (is_core_node[:, 0] & is_fixed_gradient_node[:, 1]) | (
         is_fixed_gradient_node[:, 0] & is_core_node[:, 1]
@@ -80,24 +89,23 @@ def is_inactive_link(node_status_at_link):
     Examples
     --------
     >>> from landlab.grid.linkstatus import is_inactive_link
-    >>> from landlab import CORE_NODE, FIXED_GRADIENT_BOUNDARY
-    >>> is_inactive_link([CORE_NODE, CLOSED_BOUNDARY])
+    >>> from landlab import NodeStatus
+    >>> is_inactive_link([NodeStatus.CORE, NodeStatus.CLOSED])
     array([ True], dtype=bool)
 
-    >>> from landlab import FIXED_VALUE_BOUNDARY
-    >>> is_inactive_link([FIXED_GRADIENT_BOUNDARY, FIXED_VALUE_BOUNDARY])
+    >>> is_inactive_link([NodeStatus.FIXED_GRADIENT, NodeStatus.FIXED_VALUE])
     array([ True], dtype=bool)
 
-    >>> is_inactive_link([[FIXED_GRADIENT_BOUNDARY, CLOSED_BOUNDARY],
-    ...                   [CORE_NODE, CORE_NODE]])
+    >>> is_inactive_link([[NodeStatus.FIXED_GRADIENT, NodeStatus.CLOSED],
+    ...                   [NodeStatus.CORE, NodeStatus.CORE]])
     array([ True, False], dtype=bool)
     """
     node_status_at_link = np.asarray(node_status_at_link).reshape((-1, 2))
 
-    is_core = node_status_at_link == CORE_NODE
-    is_fixed_value = node_status_at_link == FIXED_VALUE_BOUNDARY
-    is_fixed_gradient = node_status_at_link == FIXED_GRADIENT_BOUNDARY
-    is_closed = node_status_at_link == CLOSED_BOUNDARY
+    is_core = node_status_at_link == NodeStatus.CORE
+    is_fixed_value = node_status_at_link == NodeStatus.FIXED_VALUE
+    is_fixed_gradient = node_status_at_link == NodeStatus.FIXED_GRADIENT
+    is_closed = node_status_at_link == NodeStatus.CLOSED
     is_boundary_node = is_fixed_value | is_fixed_gradient | is_closed
 
     return (
@@ -126,22 +134,25 @@ def is_active_link(node_status_at_link):
     Examples
     --------
     >>> from landlab.grid.linkstatus import is_active_link
-    >>> from landlab import CORE_NODE, FIXED_GRADIENT_BOUNDARY
-    >>> is_active_link([CORE_NODE, FIXED_GRADIENT_BOUNDARY])
+    >>> from landlab import NodeStatus
+    >>> is_active_link([NodeStatus.CORE, NodeStatus.FIXED_GRADIENT])
     array([False], dtype=bool)
 
-    >>> from landlab import FIXED_VALUE_BOUNDARY
-    >>> is_active_link([CORE_NODE, FIXED_VALUE_BOUNDARY])
+    >>> is_active_link([NodeStatus.CORE, NodeStatus.FIXED_VALUE])
     array([ True], dtype=bool)
 
-    >>> is_active_link([[FIXED_GRADIENT_BOUNDARY, CORE_NODE],
-    ...                 [CORE_NODE, CORE_NODE]])
+    >>> is_active_link(
+    ...     [
+    ...         [NodeStatus.FIXED_GRADIENT, NodeStatus.CORE],
+    ...         [NodeStatus.CORE, NodeStatus.CORE]
+    ...     ]
+    ... )
     array([False, True], dtype=bool)
     """
     node_status_at_link = np.asarray(node_status_at_link).reshape((-1, 2))
 
-    is_core_node = node_status_at_link == CORE_NODE
-    is_fixed_value_node = node_status_at_link == FIXED_VALUE_BOUNDARY
+    is_core_node = node_status_at_link == NodeStatus.CORE
+    is_fixed_value_node = node_status_at_link == NodeStatus.FIXED_VALUE
     return (
         (is_core_node[:, 0] & is_core_node[:, 1])
         | (is_core_node[:, 0] & is_fixed_value_node[:, 1])
@@ -164,8 +175,8 @@ def set_status_at_link(node_status_at_link, out=None):
         == 1
     )
 
-    out[_is_inactive_link] = INACTIVE_LINK
-    out[_is_active_link] = ACTIVE_LINK
-    out[_is_fixed_link] = FIXED_LINK
+    out[_is_inactive_link] = LinkStatus.INACTIVE
+    out[_is_active_link] = LinkStatus.ACTIVE
+    out[_is_fixed_link] = LinkStatus.FIXED
 
     return out

--- a/landlab/grid/linkstatus.py
+++ b/landlab/grid/linkstatus.py
@@ -9,6 +9,7 @@ from .nodestatus import NodeStatus
 @unique
 class LinkStatus(IntEnum):
     """Define the link types"""
+
     ACTIVE = 0
     FIXED = 2
     INACTIVE = 4

--- a/landlab/grid/linkstatus.py
+++ b/landlab/grid/linkstatus.py
@@ -22,9 +22,6 @@ FIXED_LINK = 2
 #: Indicates a link is *inactive*, and cannot carry flux
 INACTIVE_LINK = 4
 
-LINK_STATUS_FLAGS_LIST = [ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK]
-LINK_STATUS_FLAGS = set(LINK_STATUS_FLAGS_LIST)
-
 
 def is_fixed_link(node_status_at_link):
     """Find links that are fixed.

--- a/landlab/grid/linkstatus.py
+++ b/landlab/grid/linkstatus.py
@@ -10,18 +10,12 @@ from .nodestatus import NodeStatus
 class LinkStatus(IntEnum):
     """Define the link types"""
 
+    #: Indicate a link is *active*, and can carry flux
     ACTIVE = 0
+    #: Indicate a link has a fixed (gradient) value, & behaves as a boundary
     FIXED = 2
+    #: Indicate a link is *inactive*, and cannot carry flux
     INACTIVE = 4
-
-
-# Define the link types
-#: Indicates a link is *active*, and can carry flux
-ACTIVE_LINK = 0
-#: Indicates a link has a fixed (gradient) value, & behaves as a boundary
-FIXED_LINK = 2
-#: Indicates a link is *inactive*, and cannot carry flux
-INACTIVE_LINK = 4
 
 
 def is_fixed_link(node_status_at_link):

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -1362,7 +1362,7 @@ def map_link_vector_sum_to_patch(grid, var_name, ignore_inactive_links=True, out
     >>> np.allclose(ycomp[(6, 9, 10),] / np.sqrt(3.0), [0.0, 0.0, -1.0])
     True
 
-    These are the patches with *INACTIVE_LINK* on all three sides:
+    These are the patches with *LinksStatus.INACTIVE* on all three sides:
 
     >>> absent_patches = np.array([0, 1, 2, 4, 8, 11, 12, 15, 16, 17, 18])
     >>> np.allclose(xcomp[absent_patches], 0.0)

--- a/landlab/grid/network.py
+++ b/landlab/grid/network.py
@@ -10,14 +10,8 @@ from ..field import GraphFields
 from ..graph import NetworkGraph
 from ..utils.decorators import cache_result_in_object
 from .decorators import override_array_setitem_and_reset, return_readonly_id_array
-from .linkstatus import ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK, set_status_at_link
-from .nodestatus import (
-    CLOSED_BOUNDARY,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-    LOOPED_BOUNDARY,
-)
+from .linkstatus import LinkStatus, set_status_at_link
+from .nodestatus import NodeStatus
 
 
 class NetworkModelGrid(NetworkGraph, GraphFields):
@@ -51,22 +45,22 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
     """
 
     #: Indicates a node is *core*.
-    BC_NODE_IS_CORE = CORE_NODE
+    BC_NODE_IS_CORE = NodeStatus.CORE
     #: Indicates a boundary node has a fixed value.
-    BC_NODE_IS_FIXED_VALUE = FIXED_VALUE_BOUNDARY
+    BC_NODE_IS_FIXED_VALUE = NodeStatus.FIXED_VALUE
     #: Indicates a boundary node has a fixed gradient.
-    BC_NODE_IS_FIXED_GRADIENT = FIXED_GRADIENT_BOUNDARY
+    BC_NODE_IS_FIXED_GRADIENT = NodeStatus.FIXED_GRADIENT
     #: Indicates a boundary node is wrap-around.
-    BC_NODE_IS_LOOPED = LOOPED_BOUNDARY
+    BC_NODE_IS_LOOPED = NodeStatus.LOOPED
     #: Indicates a boundary node is closed
-    BC_NODE_IS_CLOSED = CLOSED_BOUNDARY
+    BC_NODE_IS_CLOSED = NodeStatus.CLOSED
 
     #: Indicates a link is *active*, and can carry flux
-    BC_LINK_IS_ACTIVE = ACTIVE_LINK
+    BC_LINK_IS_ACTIVE = LinkStatus.ACTIVE
     #: Indicates a link has a fixed gradient value, and behaves as a boundary
-    BC_LINK_IS_FIXED = FIXED_LINK
+    BC_LINK_IS_FIXED = LinkStatus.FIXED
     #: Indicates a link is *inactive*, and cannot carry flux
-    BC_LINK_IS_INACTIVE = INACTIVE_LINK
+    BC_LINK_IS_INACTIVE = LinkStatus.INACTIVE
 
     #: Grid elements on which fields can be placed.
     VALID_LOCATIONS = ("node", "link", "grid")
@@ -324,7 +318,6 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
         Examples
         --------
         >>> from landlab import NetworkModelGrid
-        >>> from landlab import FIXED_LINK
 
         >>> y_of_node = (0, 1, 2, 2)
         >>> x_of_node = (0, 0, -1, 1)
@@ -335,7 +328,7 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
 
         LLCATS: NINF BC SUBSET
         """
-        return np.where(self.status_at_link == ACTIVE_LINK)[0]
+        return np.where(self.status_at_link == LinkStatus.ACTIVE)[0]
 
     @property
     @cache_result_in_object()

--- a/landlab/grid/network.py
+++ b/landlab/grid/network.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from landlab.utils.decorators import make_return_array_immutable
-
+from .base import BAD_INDEX_VALUE
 from ..core import load_params
 from ..core.utils import add_module_functions_to_class
 from ..field import GraphFields
@@ -43,6 +43,8 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
            [2, 1],
            [1, 3]])
     """
+    #: Indicates a node is *bad index*.
+    BAD_INDEX_VALUE = BAD_INDEX_VALUE
 
     #: Indicates a node is *core*.
     BC_NODE_IS_CORE = NodeStatus.CORE

--- a/landlab/grid/network.py
+++ b/landlab/grid/network.py
@@ -3,12 +3,13 @@
 import numpy as np
 
 from landlab.utils.decorators import make_return_array_immutable
-from .base import BAD_INDEX_VALUE
+
 from ..core import load_params
 from ..core.utils import add_module_functions_to_class
 from ..field import GraphFields
 from ..graph import NetworkGraph
 from ..utils.decorators import cache_result_in_object
+from .base import BAD_INDEX_VALUE
 from .decorators import override_array_setitem_and_reset, return_readonly_id_array
 from .linkstatus import LinkStatus, set_status_at_link
 from .nodestatus import NodeStatus
@@ -43,6 +44,7 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
            [2, 1],
            [1, 3]])
     """
+
     #: Indicates a node is *bad index*.
     BAD_INDEX_VALUE = BAD_INDEX_VALUE
 

--- a/landlab/grid/network.py
+++ b/landlab/grid/network.py
@@ -46,7 +46,7 @@ class NetworkModelGrid(NetworkGraph, GraphFields):
     """
 
     #: Indicates a node is *bad index*.
-    BAD_INDEX_VALUE = BAD_INDEX_VALUE
+    BAD_INDEX = BAD_INDEX_VALUE
 
     #: Indicates a node is *core*.
     BC_NODE_IS_CORE = NodeStatus.CORE

--- a/landlab/grid/nodestatus.py
+++ b/landlab/grid/nodestatus.py
@@ -5,6 +5,7 @@ from enum import IntEnum, unique
 @unique
 class NodeStatus(IntEnum):
     """Define the boundary-type codes"""
+
     CORE = 0
     FIXED_VALUE = 1
     FIXED_GRADIENT = 2

--- a/landlab/grid/nodestatus.py
+++ b/landlab/grid/nodestatus.py
@@ -1,4 +1,16 @@
 #! /usr/bin/env python
+from enum import IntEnum, unique
+
+
+@unique
+class NodeStatus(IntEnum):
+    """Define the boundary-type codes"""
+    CORE = 0
+    FIXED_VALUE = 1
+    FIXED_GRADIENT = 2
+    LOOPED = 3
+    CLOSED = 4
+
 
 # Define the boundary-type codes
 

--- a/landlab/grid/nodestatus.py
+++ b/landlab/grid/nodestatus.py
@@ -6,34 +6,13 @@ from enum import IntEnum, unique
 class NodeStatus(IntEnum):
     """Define the boundary-type codes"""
 
+    #: Indicate a node is *core*.
     CORE = 0
+    #: Indicate a boundary node is has a fixed values.
     FIXED_VALUE = 1
+    #: Indicate a boundary node is has a fixed gradient.
     FIXED_GRADIENT = 2
+    #: Indicate a boundary node is wrap-around.
     LOOPED = 3
+    #: Indicate a boundary node is closed
     CLOSED = 4
-
-
-# Define the boundary-type codes
-
-#: Indicates a node is *core*.
-CORE_NODE = 0
-
-#: Indicates a boundary node is has a fixed values.
-FIXED_VALUE_BOUNDARY = 1
-
-#: Indicates a boundary node is has a fixed gradient.
-FIXED_GRADIENT_BOUNDARY = 2
-
-#: Indicates a boundary node is wrap-around.
-LOOPED_BOUNDARY = 3
-
-#: Indicates a boundary node is closed
-CLOSED_BOUNDARY = 4
-
-BOUNDARY_STATUS_FLAGS_LIST = [
-    FIXED_VALUE_BOUNDARY,
-    FIXED_GRADIENT_BOUNDARY,
-    LOOPED_BOUNDARY,
-    CLOSED_BOUNDARY,
-]
-BOUNDARY_STATUS_FLAGS = set(BOUNDARY_STATUS_FLAGS_LIST)

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -2095,7 +2095,9 @@ class RasterModelGrid(
         if outlet_id is None:
             # verify that there is one and only one node with the status
             # BC_NODE_IS_FIXED_VALUE.
-            possible_outlets = np.where(self.status_at_node == NodeStatus.FIXED_VALUE)[0]
+            possible_outlets = np.where(self.status_at_node == NodeStatus.FIXED_VALUE)[
+                0
+            ]
 
             if len(possible_outlets) > 1:
                 raise ValueError(

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -1522,7 +1522,6 @@ def calc_slope_at_patch(
            [ 1.24904577,  1.24904577,  1.24904577,  1.24904577],
            [ 1.37340077,  1.37340077,  1.37340077,  1.37340077]])
 
-    >>> from landlab import FIXED_VALUE_BOUNDARY
     >>> z = mg.node_x.copy()
     >>> mg.set_closed_boundaries_at_grid_edges(True, True, True, True)
     >>> mg.status_at_node[11] = mg.BC_NODE_IS_CLOSED

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from landlab.core.utils import make_optional_arg_into_id_array, radians_to_degrees
 from landlab.grid import gradients
-from landlab.grid.base import BAD_INDEX_VALUE
 from landlab.utils.decorators import use_field_name_or_array
 
 
@@ -294,17 +293,17 @@ def calc_grad_across_cell_faces(grid, node_values, *args, **kwds):
     LLCATS: FINF GRAD
     """
     padded_node_values = np.empty(node_values.size + 1, dtype=float)
-    padded_node_values[-1] = BAD_INDEX_VALUE
+    padded_node_values[-1] = grid.BAD_INDEX_VALUE
     padded_node_values[:-1] = node_values
     cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
     node_ids = grid.node_at_cell[cell_ids]
 
     neighbors = grid.active_adjacent_nodes_at_node[node_ids]
-    if BAD_INDEX_VALUE != -1:
-        neighbors = np.where(neighbors == BAD_INDEX_VALUE, -1, neighbors)
+    if grid.BAD_INDEX_VALUE != -1:
+        neighbors = np.where(neighbors == grid.BAD_INDEX_VALUE, -1, neighbors)
     values_at_neighbors = padded_node_values[neighbors]
     masked_neighbor_values = np.ma.array(
-        values_at_neighbors, mask=neighbors == BAD_INDEX_VALUE
+        values_at_neighbors, mask=neighbors == grid.BAD_INDEX_VALUE
     )
     values_at_nodes = node_values[node_ids].reshape(len(node_ids), 1)
 
@@ -476,14 +475,14 @@ def calc_grad_along_node_links(grid, node_values, *args, **kwds):
     LLCATS: NINF LINF GRAD
     """
     padded_node_values = np.empty(node_values.size + 1, dtype=float)
-    padded_node_values[-1] = BAD_INDEX_VALUE
+    padded_node_values[-1] = grid.BAD_INDEX_VALUE
     padded_node_values[:-1] = node_values
     node_ids = make_optional_arg_into_id_array(grid.number_of_nodes, *args)
 
     neighbors = grid.active_adjacent_nodes_at_node[node_ids]
     values_at_neighbors = padded_node_values[neighbors]
     masked_neighbor_values = np.ma.array(
-        values_at_neighbors, mask=values_at_neighbors == BAD_INDEX_VALUE
+        values_at_neighbors, mask=values_at_neighbors == grid.BAD_INDEX_VALUE
     )
     values_at_nodes = node_values[node_ids].reshape(len(node_ids), 1)
 
@@ -1843,7 +1842,7 @@ def calc_slope_at_node(
         orthos = grid.adjacent_nodes_at_node.copy()
         # these have closed node neighbors...
         for dirs in (diags, orthos):
-            dirs[dirs == BAD_INDEX_VALUE] = -1  # indexing to work
+            dirs[dirs == grid.BAD_INDEX_VALUE] = -1  # indexing to work
         # now make an array like patches_at_node to store the interim calcs
         patch_slopes_x = np.ma.zeros(patches_at_node.shape, dtype=float)
         patch_slopes_y = np.ma.zeros(patches_at_node.shape, dtype=float)

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -293,17 +293,17 @@ def calc_grad_across_cell_faces(grid, node_values, *args, **kwds):
     LLCATS: FINF GRAD
     """
     padded_node_values = np.empty(node_values.size + 1, dtype=float)
-    padded_node_values[-1] = grid.BAD_INDEX_VALUE
+    padded_node_values[-1] = grid.BAD_INDEX
     padded_node_values[:-1] = node_values
     cell_ids = make_optional_arg_into_id_array(grid.number_of_cells, *args)
     node_ids = grid.node_at_cell[cell_ids]
 
     neighbors = grid.active_adjacent_nodes_at_node[node_ids]
-    if grid.BAD_INDEX_VALUE != -1:
-        neighbors = np.where(neighbors == grid.BAD_INDEX_VALUE, -1, neighbors)
+    if grid.BAD_INDEX != -1:
+        neighbors = np.where(neighbors == grid.BAD_INDEX, -1, neighbors)
     values_at_neighbors = padded_node_values[neighbors]
     masked_neighbor_values = np.ma.array(
-        values_at_neighbors, mask=neighbors == grid.BAD_INDEX_VALUE
+        values_at_neighbors, mask=neighbors == grid.BAD_INDEX
     )
     values_at_nodes = node_values[node_ids].reshape(len(node_ids), 1)
 
@@ -475,14 +475,14 @@ def calc_grad_along_node_links(grid, node_values, *args, **kwds):
     LLCATS: NINF LINF GRAD
     """
     padded_node_values = np.empty(node_values.size + 1, dtype=float)
-    padded_node_values[-1] = grid.BAD_INDEX_VALUE
+    padded_node_values[-1] = grid.BAD_INDEX
     padded_node_values[:-1] = node_values
     node_ids = make_optional_arg_into_id_array(grid.number_of_nodes, *args)
 
     neighbors = grid.active_adjacent_nodes_at_node[node_ids]
     values_at_neighbors = padded_node_values[neighbors]
     masked_neighbor_values = np.ma.array(
-        values_at_neighbors, mask=values_at_neighbors == grid.BAD_INDEX_VALUE
+        values_at_neighbors, mask=values_at_neighbors == grid.BAD_INDEX
     )
     values_at_nodes = node_values[node_ids].reshape(len(node_ids), 1)
 
@@ -1842,7 +1842,7 @@ def calc_slope_at_node(
         orthos = grid.adjacent_nodes_at_node.copy()
         # these have closed node neighbors...
         for dirs in (diags, orthos):
-            dirs[dirs == grid.BAD_INDEX_VALUE] = -1  # indexing to work
+            dirs[dirs == grid.BAD_INDEX] = -1  # indexing to work
         # now make an array like patches_at_node to store the interim calcs
         patch_slopes_x = np.ma.zeros(patches_at_node.shape, dtype=float)
         patch_slopes_y = np.ma.zeros(patches_at_node.shape, dtype=float)

--- a/landlab/grid/raster_set_status.py
+++ b/landlab/grid/raster_set_status.py
@@ -30,7 +30,6 @@ def set_status_at_node_on_edges(grid, right=None, top=None, left=None, bottom=No
            1, 0, 0, 4,
            1, 1, 1, 4], dtype=uint8)
 
-    >>> from landlab import FIXED_GRADIENT_BOUNDARY
     >>> grid = RasterModelGrid((3, 4))
 
     The status of a corner is set along with its clockwise edge. That is,

--- a/landlab/grid/structured_quad/cells.py
+++ b/landlab/grid/structured_quad/cells.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from landlab.grid.base import BAD_INDEX_VALUE
-
+from ..base import BAD_INDEX_VALUE
 from . import nodes
 
 

--- a/landlab/grid/structured_quad/links.py
+++ b/landlab/grid/structured_quad/links.py
@@ -683,8 +683,14 @@ def is_active_link(shape, node_status):
     status_at_link_end = node_status.flat[node_id_at_link_end(shape)]
 
     return (
-        ((status_at_link_start == NodeStatus.CORE) & (status_at_link_end == NodeStatus.CORE))
-        | ((status_at_link_end == NodeStatus.CORE) & (status_at_link_start == NodeStatus.CORE))
+        (
+            (status_at_link_start == NodeStatus.CORE)
+            & (status_at_link_end == NodeStatus.CORE)
+        )
+        | (
+            (status_at_link_end == NodeStatus.CORE)
+            & (status_at_link_start == NodeStatus.CORE)
+        )
         | (
             (status_at_link_end == NodeStatus.CORE)
             & (status_at_link_start == NodeStatus.FIXED_VALUE)

--- a/landlab/grid/structured_quad/links.py
+++ b/landlab/grid/structured_quad/links.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ...core.utils import as_id_array
-from ..base import CORE_NODE, FIXED_GRADIENT_BOUNDARY, FIXED_VALUE_BOUNDARY
+from ..nodestatus import NodeStatus
 from ..unstructured.links import LinkGrid
 from . import nodes
 
@@ -683,15 +683,15 @@ def is_active_link(shape, node_status):
     status_at_link_end = node_status.flat[node_id_at_link_end(shape)]
 
     return (
-        ((status_at_link_start == CORE_NODE) & (status_at_link_end == CORE_NODE))
-        | ((status_at_link_end == CORE_NODE) & (status_at_link_start == CORE_NODE))
+        ((status_at_link_start == NodeStatus.CORE) & (status_at_link_end == NodeStatus.CORE))
+        | ((status_at_link_end == NodeStatus.CORE) & (status_at_link_start == NodeStatus.CORE))
         | (
-            (status_at_link_end == CORE_NODE)
-            & (status_at_link_start == FIXED_VALUE_BOUNDARY)
+            (status_at_link_end == NodeStatus.CORE)
+            & (status_at_link_start == NodeStatus.FIXED_VALUE)
         )
         | (
-            (status_at_link_end == FIXED_VALUE_BOUNDARY)
-            & (status_at_link_start == CORE_NODE)
+            (status_at_link_end == NodeStatus.FIXED_VALUE)
+            & (status_at_link_start == NodeStatus.CORE)
         )
     )
 
@@ -748,7 +748,7 @@ def is_fixed_link(shape, node_status):
 
     Examples
     --------
-    >>> from landlab import RasterModelGrid
+    >>> from landlab import NodeStatus, RasterModelGrid
     >>> from landlab.grid.structured_quad.links import is_fixed_link
     >>> import numpy as np
 
@@ -758,7 +758,7 @@ def is_fixed_link(shape, node_status):
     >>> rmg.at_node['topographic__elevation'] = z
     >>> rmg.at_link['topographic__slope'] = s
 
-    >>> rmg.status_at_node[rmg.perimeter_nodes] = rmg.BC_NODE_IS_FIXED_GRADIENT
+    >>> rmg.status_at_node[rmg.perimeter_nodes] = NodeStatus.FIXED_GRADIENT
     >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
     array([2, 2, 2, 2, 2,
            2, 0, 0, 0, 2,
@@ -781,11 +781,11 @@ def is_fixed_link(shape, node_status):
     status_at_link_end = node_status.flat[node_id_at_link_end(shape)]
 
     return (
-        (status_at_link_start == CORE_NODE)
-        & (status_at_link_end == FIXED_GRADIENT_BOUNDARY)
+        (status_at_link_start == NodeStatus.CORE)
+        & (status_at_link_end == NodeStatus.FIXED_GRADIENT)
     ) | (
-        (status_at_link_end == CORE_NODE)
-        & (status_at_link_start == FIXED_GRADIENT_BOUNDARY)
+        (status_at_link_end == NodeStatus.CORE)
+        & (status_at_link_start == NodeStatus.FIXED_GRADIENT)
     )
 
 
@@ -807,7 +807,7 @@ def fixed_link_ids(shape, node_status):
     Examples
     --------
 
-    >>> from landlab import RasterModelGrid
+    >>> from landlab import NodeStatus, RasterModelGrid
     >>> from landlab.grid.structured_quad.links import fixed_link_ids
     >>> import numpy as np
     >>> rmg = RasterModelGrid((4, 5))
@@ -815,7 +815,7 @@ def fixed_link_ids(shape, node_status):
     >>> s = np.arange(0, rmg.number_of_links)
     >>> rmg.at_node['topographic__elevation'] = z
     >>> rmg.at_link['topographic__slope'] = s
-    >>> rmg.status_at_node[rmg.perimeter_nodes] = rmg.BC_NODE_IS_FIXED_GRADIENT
+    >>> rmg.status_at_node[rmg.perimeter_nodes] = NodeStatus.FIXED_GRADIENT
     >>> rmg.status_at_node # doctest: +NORMALIZE_WHITESPACE
     array([2, 2, 2, 2, 2,
            2, 0, 0, 0, 2,
@@ -866,16 +866,16 @@ def horizontal_active_link_ids(shape, active_ids, bad_index_value=-1):
 
     .. note::
 
-        ``*`` indicates the nodes that are set to `BC_NODE_IS_CLOSED`
+        ``*`` indicates the nodes that are set to `NodeStatus.CLOSED`
 
-        ``o`` indicates the nodes that are set to `BC_NODE_IS_CORE`
+        ``o`` indicates the nodes that are set to `NodeStatus.CORE`
 
-        ``I`` indicates the links that are set to `BC_LINK_IS_INACTIVE`
+        ``I`` indicates the links that are set to `LinkStatus.INACTIVE`
 
         ``V`` indicates vertical active ids, which are ignored by this
         function.
 
-        Numeric values correspond to the horizontal `BC_LINK_IS_ACTIVE`  ID.
+        Numeric values correspond to the horizontal `LinkStatus.ACTIVE`  ID.
 
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.structured_quad.links import (active_link_ids,
@@ -944,20 +944,20 @@ def horizontal_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
 
     .. note::
 
-        ``*`` indicates the nodes that are set to `FIXED_VALUE_BOUNDARY`
+        ``*`` indicates the nodes that are set to `NodeStatus.FIXED_VALUE`
 
-        ``o`` indicates the nodes that are set to `CORE_NODE`
+        ``o`` indicates the nodes that are set to `NodeStatus.CORE`
 
-        ``I`` indicates the links that are set to `INACTIVE_LINK`
+        ``I`` indicates the links that are set to `LinkStatus.INACTIVE`
 
         ``V`` indicates vertical ids, which are ignored by this function
 
-        ``H`` indicates horizontal `ACTIVE_LINK` ids, which are ignored by
+        ``H`` indicates horizontal `LinkStatus.ACTIVE` ids, which are ignored by
         this function
 
-        Numeric values correspond to the horizontal `FIXED_LINK` ID.
+        Numeric values correspond to the horizontal `LinkStatus.FIXED` ID.
 
-    >>> from landlab import RasterModelGrid
+    >>> from landlab import NodeStatus, RasterModelGrid
     >>> from landlab.grid.structured_quad.links import (fixed_link_ids,
     ...     horizontal_fixed_link_ids)
     >>> import numpy
@@ -968,7 +968,7 @@ def horizontal_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
     >>> rmg.at_link['topographic__slope'] = numpy.arange(
     ...     0, rmg.number_of_links)
 
-    >>> rmg.status_at_node[rmg.perimeter_nodes] = rmg.BC_NODE_IS_FIXED_GRADIENT
+    >>> rmg.status_at_node[rmg.perimeter_nodes] = NodeStatus.FIXED_GRADIENT
     >>> status = rmg.status_at_node
     >>> status # doctest: +NORMALIZE_WHITESPACE
     array([2, 2, 2, 2, 2,
@@ -1181,16 +1181,16 @@ def vertical_active_link_ids(shape, active_ids, bad_index_value=-1):
 
     .. note::
 
-        ``*`` indicates the nodes that are set to `BC_NODE_IS_CLOSED`
+        ``*`` indicates the nodes that are set to `NodeStatus.CLOSED`
 
-        ``o`` indicates the nodes that are set to `BC_NODE_IS_CORE`
+        ``o`` indicates the nodes that are set to `NodeStatus.CORE`
 
-        ``I`` indicates the links that are set to `BC_LINK_IS_INACTIVE`
+        ``I`` indicates the links that are set to `LinkStatus.INACTIVE`
 
         ``H`` indicates horizontal active ids, which are ignored by this
         function
 
-        Numeric values correspond to the vertical `BC_LINK_IS_ACTIVE` IDs.
+        Numeric values correspond to the vertical `LinkStatus.ACTIVE` IDs.
 
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.structured_quad.links import (active_link_ids,
@@ -1266,11 +1266,11 @@ def vertical_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
     .. note::
 
         ``*`` indicates the nodes that are set to
-        `FIXED_GRADIENT_BOUNDARY`
+        `NodeStatus.FIXED_GRADIENT`
 
-        ``o`` indicates the nodes that are set to `CORE_NODE`
+        ``o`` indicates the nodes that are set to `NodeStatus.CORE`
 
-        ``I`` indicates the links that are set to `INACTIVE_LINK`
+        ``I`` indicates the links that are set to `LinkStatus.INACTIVE`
 
         ``H`` indicates horizontal active and fixed links, which are ignored by
         this function.
@@ -1278,9 +1278,9 @@ def vertical_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
         ``V`` indicates vertical active ids, which are ignored by this
         function.
 
-        Numeric values correspond to the vertical `FIXED_LINK` IDs.
+        Numeric values correspond to the vertical `LinkStatus.FIXED` IDs.
 
-    >>> from landlab import RasterModelGrid
+    >>> from landlab import NodeStatus, RasterModelGrid
     >>> from landlab.grid.structured_quad.links import (fixed_link_ids,
     ...     vertical_fixed_link_ids)
     >>> import numpy
@@ -1290,7 +1290,7 @@ def vertical_fixed_link_ids(shape, fixed_ids, bad_index_value=-1):
     ...     0, rmg.number_of_nodes)
     >>> rmg.at_link['topographic__slope'] = numpy.arange(
     ...     0, rmg.number_of_links)
-    >>> rmg.status_at_node[rmg.perimeter_nodes] = rmg.BC_NODE_IS_FIXED_GRADIENT
+    >>> rmg.status_at_node[rmg.perimeter_nodes] = NodeStatus.FIXED_GRADIENT
 
     >>> status = rmg.status_at_node
     >>> status # doctest: +NORMALIZE_WHITESPACE
@@ -1520,7 +1520,7 @@ def horizontal_north_link_neighbor(shape, horizontal_ids, bad_index_value=-1):
 
         ``*`` indicates nodes
 
-        Numeric values correspond to the horizontal `ACTIVE_LINK` IDs.
+        Numeric values correspond to the horizontal `LinkStatus.ACTIVE` IDs.
 
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.structured_quad.links import *
@@ -1602,7 +1602,7 @@ def horizontal_east_link_neighbor(shape, horizontal_ids, bad_index_value=-1):
 
         ``*`` indicates nodes
 
-        Numeric values correspond to the horizontal `ACTIVE_LINK` IDs.
+        Numeric values correspond to the horizontal `LinkStatus.ACTIVE` IDs.
 
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.structured_quad.links import *
@@ -1778,7 +1778,7 @@ def d4_horizontal_active_link_neighbors(shape, horizontal_ids, bad_index_value=-
 
         ``*`` indicates nodes
 
-        Numeric values correspond to the horizontal `ACTIVE_LINK` IDs.
+        Numeric values correspond to the horizontal `LinkStatus.ACTIVE` IDs.
 
     >>> from landlab import RasterModelGrid
     >>> from landlab.grid.structured_quad.links import *

--- a/landlab/grid/structured_quad/nodes.py
+++ b/landlab/grid/structured_quad/nodes.py
@@ -2,7 +2,7 @@ import itertools
 
 import numpy as np
 
-from ..base import CLOSED_BOUNDARY, CORE_NODE
+from ..nodestatus import NodeStatus
 
 
 def number_of_nodes(shape):
@@ -271,7 +271,7 @@ def perimeter(shape):
     return np.fromiter(perimeter_iter(shape), dtype=np.int)
 
 
-def status_with_perimeter_as_boundary(shape, node_status=CLOSED_BOUNDARY):
+def status_with_perimeter_as_boundary(shape, node_status=NodeStatus.CLOSED):
     """Node status for a grid whose boundary is along its perimeter.
 
     Parameters
@@ -299,7 +299,7 @@ def status_with_perimeter_as_boundary(shape, node_status=CLOSED_BOUNDARY):
            [-1, -1, -1, -1]])
     """
     status = np.empty(shape, dtype=int)
-    status.fill(CORE_NODE)
+    status.fill(NodeStatus.CORE)
     status.flat[perimeter(shape)] = node_status
 
     return status

--- a/landlab/grid/structured_quad/structured.py
+++ b/landlab/grid/structured_quad/structured.py
@@ -20,7 +20,7 @@ array([ 0,  4, 15, 19])
 """
 import numpy as np
 
-from ..base import FIXED_VALUE_BOUNDARY
+from ..nodestatus import NodeStatus
 from ..unstructured.base import BaseGrid
 from . import cells as quad_cells, faces as quad_faces, links as quad_links, nodes
 from .cells import StructuredQuadCellGrid
@@ -66,7 +66,7 @@ class StructuredQuadGrid(BaseGrid):
 
         if node_status is None:
             self._status = nodes.status_with_perimeter_as_boundary(
-                self.shape, node_status=FIXED_VALUE_BOUNDARY
+                self.shape, node_status=NodeStatus.FIXED_VALUE
             )
         else:
             self._status = node_status

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -46,8 +46,12 @@ def link_is_active(status_at_link_ends):
     (status_at_link_start, status_at_link_end) = _split_link_ends(status_at_link_ends)
 
     return (
-        (status_at_link_start == NodeStatus.CORE) & ~(status_at_link_end == NodeStatus.CLOSED)
-    ) | ((status_at_link_end == NodeStatus.CORE) & ~(status_at_link_start == NodeStatus.CLOSED))
+        (status_at_link_start == NodeStatus.CORE)
+        & ~(status_at_link_end == NodeStatus.CLOSED)
+    ) | (
+        (status_at_link_end == NodeStatus.CORE)
+        & ~(status_at_link_start == NodeStatus.CLOSED)
+    )
 
 
 def find_active_links(node_status, node_at_link_ends):

--- a/landlab/grid/unstructured/links.py
+++ b/landlab/grid/unstructured/links.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from ...core.utils import as_id_array
 from ...utils.jaggedarray import JaggedArray
-from .status import CLOSED_BOUNDARY, CORE_NODE
+from ..nodestatus import NodeStatus
 
 
 def _split_link_ends(link_ends):
@@ -46,8 +46,8 @@ def link_is_active(status_at_link_ends):
     (status_at_link_start, status_at_link_end) = _split_link_ends(status_at_link_ends)
 
     return (
-        (status_at_link_start == CORE_NODE) & ~(status_at_link_end == CLOSED_BOUNDARY)
-    ) | ((status_at_link_end == CORE_NODE) & ~(status_at_link_start == CLOSED_BOUNDARY))
+        (status_at_link_start == NodeStatus.CORE) & ~(status_at_link_end == NodeStatus.CLOSED)
+    ) | ((status_at_link_end == NodeStatus.CORE) & ~(status_at_link_start == NodeStatus.CLOSED))
 
 
 def find_active_links(node_status, node_at_link_ends):

--- a/landlab/grid/unstructured/status.py
+++ b/landlab/grid/unstructured/status.py
@@ -46,7 +46,8 @@ class StatusGrid(object):
     def open_boundary_nodes(self):
         """Node id of all open boundary nodes."""
         (open_boundary_node_ids,) = np.where(
-            (self.node_status != NodeStatus.CLOSED) & (self.node_status != NodeStatus.CORE)
+            (self.node_status != NodeStatus.CLOSED)
+            & (self.node_status != NodeStatus.CORE)
         )
         return open_boundary_node_ids
 

--- a/landlab/grid/unstructured/status.py
+++ b/landlab/grid/unstructured/status.py
@@ -1,11 +1,6 @@
 import numpy as np
 
-from ..nodestatus import (
-    CLOSED_BOUNDARY,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-)
+from ..nodestatus import NodeStatus
 
 
 class StatusGrid(object):
@@ -18,11 +13,11 @@ class StatusGrid(object):
 
         Return an array of the status of a grid's nodes. The node status can
         be one of the following:
-        - ``CORE_NODE``
-        - ``FIXED_VALUE_BOUNDARY``
-        - ``FIXED_GRADIENT_BOUNDARY``
-        - ``LOOPED_BOUNDARY``
-        - ``CLOSED_BOUNDARY``
+        - ``NodeStatus.CORE``
+        - ``NodeStatus.FIXED_VALUE``
+        - ``NodeStatus.FIXED_GRADIENT``
+        - ``NodeStatus.LOOPED``
+        - ``NodeStatus.CLOSED``
         """
         return self._node_status
 
@@ -35,41 +30,41 @@ class StatusGrid(object):
 
         core_nodes will return just core nodes.
         """
-        (active_node_ids,) = np.where(self.node_status != CLOSED_BOUNDARY)
+        (active_node_ids,) = np.where(self.node_status != NodeStatus.CLOSED)
         return active_node_ids
 
     def core_nodes(self):
         """Node IDs of all core nodes."""
-        (core_node_ids,) = np.where(self.node_status == CORE_NODE)
+        (core_node_ids,) = np.where(self.node_status == NodeStatus.CORE)
         return core_node_ids
 
     def boundary_nodes(self):
         """Node IDs of all boundary nodes."""
-        (boundary_node_ids,) = np.where(self.node_status != CORE_NODE)
+        (boundary_node_ids,) = np.where(self.node_status != NodeStatus.CORE)
         return boundary_node_ids
 
     def open_boundary_nodes(self):
         """Node id of all open boundary nodes."""
         (open_boundary_node_ids,) = np.where(
-            (self.node_status != CLOSED_BOUNDARY) & (self.node_status != CORE_NODE)
+            (self.node_status != NodeStatus.CLOSED) & (self.node_status != NodeStatus.CORE)
         )
         return open_boundary_node_ids
 
     def closed_boundary_nodes(self):
         """Node id of all closed boundary nodes."""
-        (closed_boundary_node_ids,) = np.where(self.node_status == CLOSED_BOUNDARY)
+        (closed_boundary_node_ids,) = np.where(self.node_status == NodeStatus.CLOSED)
         return closed_boundary_node_ids
 
     def fixed_gradient_boundary_nodes(self):
         """Node id of all fixed gradient boundary nodes."""
         (fixed_gradient_boundary_node_ids,) = np.where(
-            self.node_status == FIXED_GRADIENT_BOUNDARY
+            self.node_status == NodeStatus.FIXED_GRADIENT
         )
         return fixed_gradient_boundary_node_ids
 
     def fixed_value_boundary_nodes(self):
         """Node id of all fixed value boundary nodes."""
         (fixed_value_boundary_node_ids,) = np.where(
-            self.node_status == FIXED_VALUE_BOUNDARY
+            self.node_status == NodeStatus.FIXED_VALUE
         )
         return fixed_value_boundary_node_ids

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -327,7 +327,7 @@ def _imshow_grid_values(
         patches = []
 
         for corners in grid.corners_at_cell:
-            valid_corners = corners[corners != grid.BAD_INDEX_VALUE]
+            valid_corners = corners[corners != grid.BAD_INDEX]
             closed_loop_corners = np.concatenate([valid_corners, [valid_corners[0]]])
 
             x = grid.x_of_corner[closed_loop_corners]

--- a/landlab/utils/distance_to_divide.py
+++ b/landlab/utils/distance_to_divide.py
@@ -2,7 +2,7 @@
 """Functions to calculate flow distance from divide."""
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE, FieldError, RasterModelGrid
+from landlab import FieldError, RasterModelGrid
 
 
 def calculate_distance_to_divide(
@@ -212,7 +212,7 @@ def calculate_distance_to_divide(
 
         else:
             # non-existant links are coded with -1
-            useable_receivers = np.where(reciever != BAD_INDEX_VALUE)[0]
+            useable_receivers = np.where(reciever != grid.BAD_INDEX_VALUE)[0]
 
             for idx in range(len(useable_receivers)):
                 r = reciever[useable_receivers][idx]

--- a/landlab/utils/distance_to_divide.py
+++ b/landlab/utils/distance_to_divide.py
@@ -212,7 +212,7 @@ def calculate_distance_to_divide(
 
         else:
             # non-existant links are coded with -1
-            useable_receivers = np.where(reciever != grid.BAD_INDEX_VALUE)[0]
+            useable_receivers = np.where(reciever != grid.BAD_INDEX)[0]
 
             for idx in range(len(useable_receivers)):
                 r = reciever[useable_receivers][idx]

--- a/landlab/utils/flow__distance.py
+++ b/landlab/utils/flow__distance.py
@@ -2,7 +2,7 @@
 """Functions to calculate flow distance."""
 import numpy as np
 
-from landlab import BAD_INDEX_VALUE, FieldError, RasterModelGrid
+from landlab import FieldError, RasterModelGrid
 
 
 def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
@@ -181,7 +181,7 @@ def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
 
             else:
                 # non-existant links are coded with -1
-                useable_receivers = np.where(reciever != BAD_INDEX_VALUE)[0]
+                useable_receivers = np.where(reciever != grid.BAD_INDEX_VALUE)[0]
 
                 # we will have the stream flow to the downstream node with the
                 # shortest distance to the outlet.

--- a/landlab/utils/flow__distance.py
+++ b/landlab/utils/flow__distance.py
@@ -181,7 +181,7 @@ def calculate_flow__distance(grid, add_to_grid=False, clobber=False):
 
             else:
                 # non-existant links are coded with -1
-                useable_receivers = np.where(reciever != grid.BAD_INDEX_VALUE)[0]
+                useable_receivers = np.where(reciever != grid.BAD_INDEX)[0]
 
                 # we will have the stream flow to the downstream node with the
                 # shortest distance to the outlet.

--- a/landlab/utils/structured_grid.py
+++ b/landlab/utils/structured_grid.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from ..core.utils import as_id_array
 from ..grid.base import BAD_INDEX_VALUE
-from ..grid.nodestatus import CLOSED_BOUNDARY, CORE_NODE, FIXED_VALUE_BOUNDARY
+from ..grid.nodestatus import NodeStatus
 
 
 def node_count(shape):
@@ -476,7 +476,7 @@ def face_at_link(shape, actives=None, inactive_link_index=BAD_INDEX_VALUE):
     return link_faces
 
 
-def status_at_node(shape, boundary_status=FIXED_VALUE_BOUNDARY):
+def status_at_node(shape, boundary_status=NodeStatus.FIXED_VALUE):
     """Array of the statuses of nodes.
 
     The statuses of the nodes in a structured grid with dimensions,
@@ -485,7 +485,7 @@ def status_at_node(shape, boundary_status=FIXED_VALUE_BOUNDARY):
     """
     status = np.empty(np.prod(shape), dtype=np.int8)
 
-    status[interior_nodes(shape)] = CORE_NODE
+    status[interior_nodes(shape)] = NodeStatus.CORE
     status[perimeter_nodes(shape)] = boundary_status
 
     return status
@@ -497,7 +497,7 @@ def active_links(shape, node_status_array=None, link_nodes=None):
     Return the link IDs for links that are *active* in a structured grid of
     quadrilaterals. Use the *node_status_array* keyword to specify the status
     for each of the grid's nodes. If not given, each of the perimeter nodes is
-    assumed to be `FIXED_VALUE_BOUNDARY`.
+    assumed to be `NodeStatus.FIXED_VALUE`.
 
     Use the *link_nodes* keyword to provide, as a tuple of arrays, that give
     the *from-node* and the *to-node* for each for each link in the grid.
@@ -512,19 +512,19 @@ def active_links(shape, node_status_array=None, link_nodes=None):
 
     Examples
     --------
-    Because, by default, the perimeter nodes are `FIXED_VALUE_BOUNDARY` nodes,
+    Because, by default, the perimeter nodes are `NodeStatus.FIXED_VALUE` nodes,
     only links attached to the interior nodes are *active*.
 
     >>> from landlab.utils.structured_grid import active_links
-    >>> from landlab.grid.nodestatus import CLOSED_BOUNDARY, CORE_NODE
+    >>> from landlab.grid.nodestatus import NodeStatus
     >>> active_links((3, 4))
     array([ 1,  2,  5,  6, 11, 12, 13])
 
-    If all the perimeter nodes `CLOSED_BOUNDARY` nodes, the only active link
+    If all the perimeter nodes `NodeStatus.CLOSED` nodes, the only active link
     is between the two core nodes.
 
-    >>> node_status = np.ones(3 * 4) * CLOSED_BOUNDARY
-    >>> node_status[5:7] = CORE_NODE
+    >>> node_status = np.ones(3 * 4) * NodeStatus.CLOSED
+    >>> node_status[5:7] = NodeStatus.CORE
     >>> active_links((3, 4), node_status_array=node_status)
     array([12])
 
@@ -547,8 +547,8 @@ def active_links(shape, node_status_array=None, link_nodes=None):
     to_node_status = node_status_array[link_to_node]
 
     active_links_ = (
-        (from_node_status == CORE_NODE) & ~(to_node_status == CLOSED_BOUNDARY)
-    ) | ((to_node_status == CORE_NODE) & ~(from_node_status == CLOSED_BOUNDARY))
+        (from_node_status == NodeStatus.CORE) & ~(to_node_status == NodeStatus.CLOSED)
+    ) | ((to_node_status == NodeStatus.CORE) & ~(from_node_status == NodeStatus.CLOSED))
 
     (active_links_,) = np.where(active_links_)
 
@@ -1254,7 +1254,7 @@ def setup_active_outlink_matrix2(shape, node_status=None, return_count=True):
 
     Use the *node_status_array* keyword to specify the status for each of the
     grid's nodes. If not given, each of the perimeter nodes is assumed to be
-    `FIXED_VALUE_BOUNDARY`.
+    `NodeStatus.FIXED_VALUE`.
 
     Parameters
     ----------
@@ -1306,7 +1306,7 @@ def setup_active_inlink_matrix(shape, node_status=None, return_count=True):
 
     Use the *node_status_array* keyword to specify the status for each of
     the grid's nodes. If not given, each of the perimeter nodes is assumed
-    to be `FIXED_VALUE_BOUNDARY`.
+    to be `NodeStatus.FIXED_VALUE`.
 
     Parameters
     ----------
@@ -1358,7 +1358,7 @@ def setup_active_inlink_matrix2(shape, node_status=None, return_count=True):
 
     Use the *node_status_array* keyword to specify the status for each of the
     grid's nodes. If not given, each of the perimeter nodes is assumed to be
-    `FIXED_VALUE_BOUNDARY`.
+    `NodeStatus.FIXED_VALUE`.
 
     Parameters
     ----------

--- a/landlab/values/synthetic.py
+++ b/landlab/values/synthetic.py
@@ -80,7 +80,6 @@ from landlab.grid.linkstatus import LinkStatus
 from landlab.grid.network import NetworkModelGrid
 from landlab.grid.nodestatus import NodeStatus
 
-
 _STATUS = defaultdict(
     dict,
     {

--- a/landlab/values/synthetic.py
+++ b/landlab/values/synthetic.py
@@ -16,8 +16,7 @@ nodes, this could be acomplished as follows:
 Examples
 --------
 >>> import numpy as np
->>> from landlab import RasterModelGrid
->>> from landlab import CORE_NODE
+>>> from landlab import NodeStatus, RasterModelGrid
 >>> from landlab.values import random, plane
 >>> np.random.seed(42)
 
@@ -50,9 +49,9 @@ array([ 0.,  1.,  2.,  3.,  2.,  1.,  0.,
 
 Next add uniformly distributed noise.
 
->>> noise = random(mg, 'topographic__elevation',
-...                where=CORE_NODE,
-...                distribution='uniform')
+>>> noise = random(
+...     mg, "topographic__elevation", where=NodeStatus.CORE, distribution='uniform'
+... )
 >>> np.round(mg.at_node['topographic__elevation'], decimals=3)
 array([ 0.   ,  1.   ,  2.   ,  3.   ,  2.   ,  1.   ,  0.   ,
         1.   ,  2.375,  3.951,  4.732,  3.599,  2.156,  1.   ,
@@ -77,30 +76,25 @@ from collections import defaultdict
 
 import numpy as np
 
-from landlab.grid.linkstatus import ACTIVE_LINK, FIXED_LINK, INACTIVE_LINK
+from landlab.grid.linkstatus import LinkStatus
 from landlab.grid.network import NetworkModelGrid
-from landlab.grid.nodestatus import (
-    CLOSED_BOUNDARY,
-    CORE_NODE,
-    FIXED_GRADIENT_BOUNDARY,
-    FIXED_VALUE_BOUNDARY,
-    LOOPED_BOUNDARY,
-)
+from landlab.grid.nodestatus import NodeStatus
+
 
 _STATUS = defaultdict(
     dict,
     {
         "link": {
-            "ACTIVE_LINK": ACTIVE_LINK,
-            "FIXED_LINK": FIXED_LINK,
-            "INACTIVE_LINK": INACTIVE_LINK,
+            "ACTIVE_LINK": LinkStatus.ACTIVE,
+            "FIXED_LINK": LinkStatus.FIXED,
+            "INACTIVE_LINK": LinkStatus.INACTIVE,
         },
         "node": {
-            "CLOSED_BOUNDARY": CLOSED_BOUNDARY,
-            "CORE_NODE": CORE_NODE,
-            "FIXED_GRADIENT_BOUNDARY": FIXED_GRADIENT_BOUNDARY,
-            "FIXED_VALUE_BOUNDARY": FIXED_VALUE_BOUNDARY,
-            "LOOPED_BOUNDARY": LOOPED_BOUNDARY,
+            "CLOSED_BOUNDARY": NodeStatus.CLOSED,
+            "CORE_NODE": NodeStatus.CORE,
+            "FIXED_GRADIENT_BOUNDARY": NodeStatus.FIXED_GRADIENT,
+            "FIXED_VALUE_BOUNDARY": NodeStatus.FIXED_VALUE,
+            "LOOPED_BOUNDARY": NodeStatus.LOOPED,
         },
     },
 )
@@ -182,7 +176,7 @@ def random(grid, name, at="node", where=None, distribution="uniform", **kwargs):
     where : optional
         The keyword ``where`` indicates where synthetic values
         should be placed. It is either (1) a single value or list
-        of values indicating a grid-element status (e.g. CORE_NODE),
+        of values indicating a grid-element status (e.g. `NodeStatus.CORE`),
         or (2) a (number-of-grid-element,) sized boolean array.
     distribution : str, optional
         Name of the distribution provided by the np.random
@@ -203,13 +197,15 @@ def random(grid, name, at="node", where=None, distribution="uniform", **kwargs):
     >>> from landlab.values import random
     >>> np.random.seed(42)
     >>> mg = RasterModelGrid((4, 4))
-    >>> values = random(mg,
-    ...                 'soil__depth',
-    ...                 'node',
-    ...                 where='CORE_NODE',
-    ...                 distribution='uniform',
-    ...                 high=3.,
-    ...                 low=2.)
+    >>> values = random(
+    ...     mg,
+    ...     "soil__depth",
+    ...     "node",
+    ...     where="CORE_NODE",
+    ...     distribution="uniform",
+    ...     high=3.0,
+    ...     low=2.0,
+    ... )
     >>> mg.at_node['soil__depth']
     array([ 0.        ,  0.        ,  0.        ,  0.        ,
             0.        ,  2.37454012,  2.95071431,  0.        ,
@@ -245,7 +241,7 @@ def plane(
     where : optional
         The keyword ``where`` indicates where synthetic values
         should be placed. It is either (1) a single value or list
-        of values indicating a grid-element status (e.g. CORE_NODE),
+        of values indicating a grid-element status (e.g. `NodeStatus.CORE`),
         or (2) a (number-of-grid-element,) sized boolean array.
     point : tuple, optional
         A tuple defining a point the plane goes through in the
@@ -340,7 +336,7 @@ def constant(grid, name, at="node", where=None, value=0.0, dtype=None):
     where : optional
         The keyword ``where`` indicates where synthetic values
         should be placed. It is either (1) a single value or list
-        of values indicating a grid-element status (e.g. CORE_NODE),
+        of values indicating a grid-element status (e.g. `NodeStatus.CORE`),
         or (2) a (number-of-grid-element,) sized boolean array.
     value : float, optional
         Constant value to add to the grid. Default is 0.
@@ -359,7 +355,7 @@ def constant(grid, name, at="node", where=None, value=0.0, dtype=None):
     >>> from landlab.values import constant
     >>> mg = RasterModelGrid((4, 4))
     >>> values = constant(
-    ...     mg, 'some_flux', 'link', where='ACTIVE_LINK', value=10.0
+    ...     mg, "some_flux", "link", where="ACTIVE_LINK", value=10.0
     ... )
     >>> mg.at_link['some_flux']
     array([  0.,   0.,   0.,   0.,  10.,  10.,   0.,  10.,  10.,  10.,   0.,
@@ -410,7 +406,7 @@ def sine(
     where : optional
         The keyword ``where`` indicates where synthetic values
         should be placed. It is either (1) a single value or list
-        of values indicating a grid-element status (e.g. CORE_NODE),
+        of values indicating a grid-element status (e.g. `NodeStatus.CORE`),
         or (2) a (number-of-grid-element,) sized boolean array.
     amplitude : p
     wavelength :
@@ -427,7 +423,6 @@ def sine(
     --------
     >>> from numpy.testing import assert_array_almost_equal
     >>> from landlab import RasterModelGrid
-    >>> from landlab import ACTIVE_LINK
     >>> from landlab.values import sine
     >>> mg = RasterModelGrid((5, 5))
     >>> values = sine(mg,

--- a/tests/components/depression_finder/conftest.py
+++ b/tests/components/depression_finder/conftest.py
@@ -1,8 +1,10 @@
 import numpy as np
 import pytest
 
-from landlab import BAD_INDEX_VALUE as XX, RasterModelGrid
+from landlab import RasterModelGrid
 from landlab.components import DepressionFinderAndRouter, FlowAccumulator
+
+XX = RasterModelGrid.BAD_INDEX_VALUE
 
 
 @pytest.fixture

--- a/tests/components/depression_finder/conftest.py
+++ b/tests/components/depression_finder/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from landlab import RasterModelGrid
 from landlab.components import DepressionFinderAndRouter, FlowAccumulator
 
-XX = RasterModelGrid.BAD_INDEX_VALUE
+XX = RasterModelGrid.BAD_INDEX
 
 
 @pytest.fixture

--- a/tests/components/depression_finder/test_lake_mapper.py
+++ b/tests/components/depression_finder/test_lake_mapper.py
@@ -12,13 +12,15 @@ from numpy import pi, sin
 from numpy.testing import assert_array_equal
 from pytest import approx
 
-from landlab import BAD_INDEX_VALUE as XX, RasterModelGrid
+from landlab import RasterModelGrid
 from landlab.components import DepressionFinderAndRouter, FlowAccumulator
 
 NUM_GRID_ROWS = 8
 NUM_GRID_COLS = 8
 PERIOD_X = 8.0
 PERIOD_Y = 4.0
+
+XX = RasterModelGrid.BAD_INDEX_VALUE
 
 
 def test_route_to_multiple_error_raised():

--- a/tests/components/depression_finder/test_lake_mapper.py
+++ b/tests/components/depression_finder/test_lake_mapper.py
@@ -20,7 +20,7 @@ NUM_GRID_COLS = 8
 PERIOD_X = 8.0
 PERIOD_Y = 4.0
 
-XX = RasterModelGrid.BAD_INDEX_VALUE
+XX = RasterModelGrid.BAD_INDEX
 
 
 def test_route_to_multiple_error_raised():

--- a/tests/components/flow_accum/conftest.py
+++ b/tests/components/flow_accum/conftest.py
@@ -4,7 +4,8 @@ import numpy as np
 import pytest
 
 from landlab import RasterModelGrid
-from landlab.grid.base import BAD_INDEX_VALUE as XX
+
+XX = RasterModelGrid.BAD_INDEX_VALUE
 
 
 @pytest.fixture

--- a/tests/components/flow_accum/conftest.py
+++ b/tests/components/flow_accum/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 from landlab import RasterModelGrid
 
-XX = RasterModelGrid.BAD_INDEX_VALUE
+XX = RasterModelGrid.BAD_INDEX
 
 
 @pytest.fixture

--- a/tests/components/sink_fill/test_sink_filler.py
+++ b/tests/components/sink_fill/test_sink_filler.py
@@ -10,8 +10,10 @@ import numpy as np  # for use of np.round
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
-from landlab import BAD_INDEX_VALUE as XX, FieldError, RasterModelGrid
+from landlab import FieldError, RasterModelGrid
 from landlab.components import FlowAccumulator, SinkFiller, SinkFillerBarnes
+
+XX = RasterModelGrid.BAD_INDEX_VALUE
 
 
 def test_route_to_multiple_error_raised_init():

--- a/tests/components/sink_fill/test_sink_filler.py
+++ b/tests/components/sink_fill/test_sink_filler.py
@@ -13,7 +13,7 @@ from numpy.testing import assert_array_almost_equal, assert_array_equal
 from landlab import FieldError, RasterModelGrid
 from landlab.components import FlowAccumulator, SinkFiller, SinkFillerBarnes
 
-XX = RasterModelGrid.BAD_INDEX_VALUE
+XX = RasterModelGrid.BAD_INDEX
 
 
 def test_route_to_multiple_error_raised_init():

--- a/tests/grid/structured_quad/test_links.py
+++ b/tests/grid/structured_quad/test_links.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
-from landlab.grid.base import CLOSED_BOUNDARY, CORE_NODE
+from landlab.grid.nodestatus import NodeStatus
 from landlab.grid.structured_quad.links import active_link_ids
 from landlab.grid.structured_quad.nodes import status_with_perimeter_as_boundary
 from landlab.testing.tools import assert_array_is_int
@@ -10,8 +10,8 @@ from landlab.testing.tools import assert_array_is_int
 
 def test_active_links_ids():
     status = np.empty((4, 5), dtype=int)
-    status.fill(CLOSED_BOUNDARY)
-    status[1, 2] = status[1, 3] = status[2, 2] = status[2, 3] = CORE_NODE
+    status.fill(NodeStatus.CLOSED)
+    status[1, 2] = status[1, 3] = status[2, 2] = status[2, 3] = NodeStatus.CORE
 
     link_ids = active_link_ids((4, 5), status)
     assert_array_equal(link_ids, [11, 15, 16, 20])

--- a/tests/grid/structured_quad/test_nodes.py
+++ b/tests/grid/structured_quad/test_nodes.py
@@ -1,6 +1,6 @@
 from numpy.testing import assert_array_equal
 
-from landlab.grid.base import CLOSED_BOUNDARY, CORE_NODE, FIXED_VALUE_BOUNDARY
+from landlab.grid.nodestatus import NodeStatus
 from landlab.grid.structured_quad import nodes
 from landlab.testing.tools import assert_array_is_int
 
@@ -13,7 +13,7 @@ def test_perimeter_nodes():
 
 def test_perimeter_status_default():
     node_status = nodes.status_with_perimeter_as_boundary((4, 5))
-    F, C = CLOSED_BOUNDARY, CORE_NODE
+    F, C = NodeStatus.CLOSED, NodeStatus.CORE
     assert_array_equal(
         node_status,
         [[F, F, F, F, F], [F, C, C, C, F], [F, C, C, C, F], [F, F, F, F, F]],
@@ -23,9 +23,9 @@ def test_perimeter_status_default():
 
 def test_perimeter_status_status_as_scalar():
     node_status = nodes.status_with_perimeter_as_boundary(
-        (4, 5), node_status=CLOSED_BOUNDARY
+        (4, 5), node_status=NodeStatus.CLOSED
     )
-    B, C = CLOSED_BOUNDARY, CORE_NODE
+    B, C = NodeStatus.CLOSED, NodeStatus.CORE
     assert_array_equal(
         node_status,
         [[B, B, B, B, B], [B, C, C, C, B], [B, C, C, C, B], [B, B, B, B, B]],
@@ -34,7 +34,7 @@ def test_perimeter_status_status_as_scalar():
 
 
 def test_perimeter_status_status_as_array():
-    F, B, C = FIXED_VALUE_BOUNDARY, CLOSED_BOUNDARY, CORE_NODE
+    F, B, C = NodeStatus.FIXED_VALUE, NodeStatus.CLOSED, NodeStatus.CORE
     status = [F, F, F, F, F, F, B, F, B, B, B, B, B, B]
     node_status = nodes.status_with_perimeter_as_boundary((4, 5), node_status=status)
     assert_array_equal(

--- a/tests/grid/test_raster_grid/test_bc_updates.py
+++ b/tests/grid/test_raster_grid/test_bc_updates.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from landlab import RasterModelGrid
+from landlab import LinkStatus, RasterModelGrid
 
 
 def test_issue_428_a():
@@ -38,14 +38,14 @@ def test_issue_428_b():
 def test_link_update_with_nodes_closed():
     rmg = RasterModelGrid((4, 5))
     rmg.status_at_node[rmg.nodes_at_bottom_edge] = rmg.BC_NODE_IS_CLOSED
-    inactive_array = np.array([rmg.BC_LINK_IS_INACTIVE] * 5)
+    inactive_array = np.array([LinkStatus.INACTIVE] * 5)
     assert_array_equal(rmg.status_at_link[4:9], inactive_array)
 
 
 def test_link_update_with_nodes_fixed_grad():
     rmg = RasterModelGrid((4, 5))
     rmg.status_at_node[rmg.nodes_at_bottom_edge] = rmg.BC_NODE_IS_FIXED_GRADIENT
-    fixed_array = np.array([rmg.BC_LINK_IS_FIXED] * 3)
+    fixed_array = np.array([LinkStatus.FIXED] * 3)
     assert_array_equal(rmg.status_at_link[5:8], fixed_array)
 
 

--- a/tests/grid/test_raster_grid/test_fixed_link_boundary.py
+++ b/tests/grid/test_raster_grid/test_fixed_link_boundary.py
@@ -1,12 +1,12 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from landlab import RasterModelGrid
-from landlab.grid.nodestatus import (
-    CLOSED_BOUNDARY as CB,
-    FIXED_GRADIENT_BOUNDARY as FG,
-    FIXED_VALUE_BOUNDARY as FV,
-)
+from landlab import NodeStatus, RasterModelGrid
+
+
+FG = NodeStatus.FIXED_GRADIENT
+CB = NodeStatus.CLOSED
+FV = NodeStatus.FIXED_VALUE
 
 
 def test_fixed_link_boundaries_at_grid_edges():

--- a/tests/grid/test_raster_grid/test_fixed_link_boundary.py
+++ b/tests/grid/test_raster_grid/test_fixed_link_boundary.py
@@ -3,7 +3,6 @@ from numpy.testing import assert_array_equal
 
 from landlab import NodeStatus, RasterModelGrid
 
-
 FG = NodeStatus.FIXED_GRADIENT
 CB = NodeStatus.CLOSED
 FV = NodeStatus.FIXED_VALUE

--- a/tests/grid/test_raster_grid/test_init.py
+++ b/tests/grid/test_raster_grid/test_init.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
 
-from landlab import BAD_INDEX_VALUE as X, RasterModelGrid
+from landlab import RasterModelGrid
+
+X = RasterModelGrid.BAD_INDEX_VALUE
 
 
 def test_init_new_style():

--- a/tests/grid/test_raster_grid/test_init.py
+++ b/tests/grid/test_raster_grid/test_init.py
@@ -3,7 +3,7 @@ import pytest
 
 from landlab import RasterModelGrid
 
-X = RasterModelGrid.BAD_INDEX_VALUE
+X = RasterModelGrid.BAD_INDEX
 
 
 def test_init_new_style():

--- a/tests/grid/test_raster_grid/test_is_boundary.py
+++ b/tests/grid/test_raster_grid/test_is_boundary.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from landlab import FIXED_GRADIENT_BOUNDARY, RasterModelGrid
+from landlab import NodeStatus, RasterModelGrid
 
 
 def test_id_as_int():
@@ -53,7 +53,7 @@ def test_id_as_list():
 
 def test_boundary_flag():
     rmg = RasterModelGrid((4, 5))
-    rmg.status_at_node[0] = FIXED_GRADIENT_BOUNDARY
+    rmg.status_at_node[0] = NodeStatus.FIXED_GRADIENT
     assert_array_equal(
         rmg.node_is_boundary(np.arange(20)),
         np.array(
@@ -84,7 +84,7 @@ def test_boundary_flag():
     )
 
     assert_array_equal(
-        rmg.node_is_boundary(np.arange(20), boundary_flag=FIXED_GRADIENT_BOUNDARY),
+        rmg.node_is_boundary(np.arange(20), boundary_flag=NodeStatus.FIXED_GRADIENT),
         np.array(
             [
                 True,

--- a/tests/grid/test_raster_grid/test_neighbor_nodes.py
+++ b/tests/grid/test_raster_grid/test_neighbor_nodes.py
@@ -3,7 +3,8 @@ import pytest
 from numpy.testing import assert_array_equal
 
 from landlab import RasterModelGrid
-from landlab.grid.base import BAD_INDEX_VALUE as X
+
+X = RasterModelGrid.BAD_INDEX_VALUE
 
 
 def test_all_active_neighbors():

--- a/tests/grid/test_raster_grid/test_neighbor_nodes.py
+++ b/tests/grid/test_raster_grid/test_neighbor_nodes.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_equal
 
 from landlab import RasterModelGrid
 
-X = RasterModelGrid.BAD_INDEX_VALUE
+X = RasterModelGrid.BAD_INDEX
 
 
 def test_all_active_neighbors():

--- a/tests/grid/test_raster_grid/test_status_at_node.py
+++ b/tests/grid/test_raster_grid/test_status_at_node.py
@@ -3,7 +3,6 @@ from numpy.testing import assert_array_equal
 
 from landlab import NodeStatus, RasterModelGrid
 
-
 CB = NodeStatus.CLOSED
 FV = NodeStatus.FIXED_VALUE
 

--- a/tests/grid/test_raster_grid/test_status_at_node.py
+++ b/tests/grid/test_raster_grid/test_status_at_node.py
@@ -1,8 +1,11 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from landlab import RasterModelGrid
-from landlab.grid.nodestatus import CLOSED_BOUNDARY as CB, FIXED_VALUE_BOUNDARY as FV
+from landlab import NodeStatus, RasterModelGrid
+
+
+CB = NodeStatus.CLOSED
+FV = NodeStatus.FIXED_VALUE
 
 
 def test_get_status():

--- a/tests/io/netcdf/test_write_netcdf.py
+++ b/tests/io/netcdf/test_write_netcdf.py
@@ -260,9 +260,7 @@ def test_netcdf_write_at_cells(tmpdir):
     """Test write_netcdf using with cell fields"""
     field = RasterModelGrid((4, 3))
     field.add_field(
-        "topographic__elevation",
-        np.arange(field.number_of_cells),
-        at="cell",
+        "topographic__elevation", np.arange(field.number_of_cells), at="cell"
     )
     field.add_field("uplift_rate", np.arange(field.number_of_cells), at="cell")
 

--- a/tests/utils/test_structured_grid.py
+++ b/tests/utils/test_structured_grid.py
@@ -4,6 +4,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 import landlab.utils.structured_grid as sgrid
+from landlab.grid.nodestatus import NodeStatus
 
 
 def test_node_x_2d():
@@ -244,7 +245,7 @@ def test_4_by_5():
 
 def test_with_status_at_node():
     status = sgrid.status_at_node((4, 5))
-    status[6] = sgrid.CLOSED_BOUNDARY
+    status[6] = NodeStatus.CLOSED
     active_links = sgrid.active_links((4, 5), node_status_array=status)
 
     assert_array_equal(


### PR DESCRIPTION
This pull request removes uses of the old node and link status flag constants. The old constants are still there, though, and can be used in the same way as before for backward compatibility. I've removed uses of the following constants,
* `CORE_NODE`
* `FIXED_VALUE_BOUNDARY`
* `FIXED_GRADIENT_BOUNDARY`
* `LOOPED_BOUNDARY`
* `CLOSED_BOUNDARY`
* `ACTIVE_LINK`
* `INACTIVE_LINK`
* `FIXED_LINK`

In doing all of this, I realized that sometimes it is desirable to want to use these constants without importing a *ModelGrid* (and then using e.g. `ModelGrid.BC_*`). For these use cases, I introduced two new *enum* classes, `NodeStatus` and `LinkStatus` (*enums* only became available in Python 3.4ish). These mirror those constants bound to `ModelGrid`,
* `NodeStatus.CORE` -> `ModelGrid.BC_NODE_IS_CORE`
* `NodeStatus.FIXED_VALUE` -> `ModelGrid.BC_NODE_IS_FIXED_VALUE`
* `NodeStatus.FIXED_GRADIENT` -> `ModelGrid.BC_NODE_IS_FIXED_GRADIENT`
* `NodeStatus.LOOPED` -> `ModelGrid.BC_NODE_IS_LOOPED`
* `NodeStatus.CLOSED` -> `ModelGrid.BC_NODE_IS_CLOSED`
* `LinkStatus.ACTIVE` -> `ModelGrid.BC_LINK_IS_ACTIVE`
* `LinkStatus.INACTIVE` -> `ModelGrid.BC_LINK_IS_INACTIVE`
* `LinkStatus.FIXED` -> `ModelGrid.BC_LINK_IS_FIXED`

Truthfully, I think I like these two new *enum* classes better. I also think they may fit in better when we address the problem of different components having different sets of boundary conditions as I think the solution will be to create a new class(es) to hold just boundary conditions.