### PR TITLE
Fix bmi get_var_units

### DIFF
--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -413,7 +413,7 @@ def wrap_as_bmi(cls):
 
         def get_var_units(self, name):
             """Get the unit used by a variable."""
-            return self.var_units[name]
+            return self._info[name]["units"]
 
         def get_value_ref(self, name):
             """Get a reference to a variable's data."""

--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -195,6 +195,8 @@ def wrap_as_bmi(cls):
     >>> flexure = BmiFlexure()
     >>> sorted(flexure.get_input_var_names())
     ['boundary_condition_flag', 'lithosphere__overlying_pressure_increment']
+    >>> flexure.get_var_units("lithosphere__overlying_pressure_increment")
+    'Pa'
 
     >>> config = \"\"\"
     ... flexure:


### PR DESCRIPTION
This pull request fixes the `get_var_units` method of the bmi wrapper to use the new component metadata (i.e. `_info[name]["units"]` rather then `_var_units`)