### PR TITLE
Add Python 3.8 builds to AppVeyor and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 - osx
 env:
   matrix:
+  - CONDA_ENV=3.8
   - CONDA_ENV=3.7
   - CONDA_ENV=3.6
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,14 @@ jobs:
     stage: deploy
     if: tag =~ v.*$
     os: osx
-    env: CONDA_ENV=3.7
+    env: CONDA_ENV=3.8
     script:
     - pip install twine wheel
     - python setup.py bdist_wheel
     - twine upload -u landlab -p$PYPI_PASS dist/*landlab*
+  - <<: *deploy
+    os: osx
+    env: CONDA_ENV=3.7
   - <<: *deploy
     os: osx
     env: CONDA_ENV=3.6

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
-      CONDA_INSTALL_LOCN: C:\\Miniconda38-x64
+      CONDA_INSTALL_LOCN: C:\\Python38
       CONDA_PY: 3.8
 
     - TARGET_ARCH: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,26 +30,26 @@ init:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "pip install twine -r requirements-testing.txt -r requirements-notebooks.txt"
-  - "python -VV"
+  - "%WITH_COMPILER% pip install twine -r requirements-testing.txt -r requirements-notebooks.txt"
+  - "%WITH_COMPILER% python -VV"
 
 build: false
 
 test_script:
   - "%WITH_COMPILER% pip install numpy"
-  - "pip install netcdf4==1.5.2"
-  - "pip install -e ."
-  - "pytest -vvv"
+  - "%WITH_COMPILER% pip install netcdf4==1.5.2"
+  - "%WITH_COMPILER% pip install -e ."
+  - "%WITH_COMPILER% pytest -vvv"
 
 after_test:
-  - "python setup.py bdist_wheel"
+  - "%WITH_COMPILER% python setup.py bdist_wheel"
 
 artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.
   - path: 'dist\*'
 
 deploy_script:
-  - cmd: "python .ci/appveyor/pypi_upload.py"
+  - cmd: "%WITH_COMPILER% python .ci/appveyor/pypi_upload.py"
 
 notifications:
   - provider: Slack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,11 @@ environment:
 
     - TARGET_ARCH: x64
       CONDA_NPY: 111
+      CONDA_INSTALL_LOCN: C:\\Miniconda38-x64
+      CONDA_PY: 3.8
+
+    - TARGET_ARCH: x64
+      CONDA_NPY: 111
       CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
       CONDA_PY: 3.7
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,13 +36,13 @@ install:
 build: false
 
 test_script:
-  - "%WITH_COMPILER% pip install numpy"
-  - "%WITH_COMPILER% pip install netcdf4==1.5.2"
-  - "%WITH_COMPILER% pip install -e ."
+  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install numpy'
+  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install netcdf4==1.5.2'
+  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install -e .'
   - cmd: '%PYTHON%\Scripts\pytest -vvv'
 
 after_test:
-  - cmd: "%PYTHON%\Scripts\python setup.py bdist_wheel"
+  - cmd: '%PYTHON%\Scripts\python setup.py bdist_wheel'
 
 artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,13 +35,8 @@ init:
   - "ECHO %APPVEYOR_REPO_BRANCH%"
 
 install:
-  - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-  - cmd: conda update --yes --quiet conda
-  - cmd: set PYTHONUNBUFFERED=1
-  - cmd: conda config --set always_yes yes
   - cmd: pip install twine -r requirements-testing.txt -r requirements-notebooks.txt
-  - cmd: conda info
-  - cmd: conda list
+  - cmd: python -VV
 
 build: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 platform:
   - x64
 
-os: Previous Visual Studio 2015
+# os: Previous Visual Studio 2015
 # os: Visual Studio 2013
 
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,9 +36,9 @@ install:
 build: false
 
 test_script:
-  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install numpy"
-  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install netcdf4==1.5.2"
-  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install -e ."
+  - "%WITH_COMPILER% pip install numpy"
+  - "%WITH_COMPILER% pip install netcdf4==1.5.2"
+  - "%WITH_COMPILER% pip install -e ."
   - cmd: '%PYTHON%\Scripts\pytest -vvv'
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ init:
 
 install:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - "%WITH_COMPILER% pip install twine -r requirements-testing.txt -r requirements-notebooks.txt"
+  - "%WITH_COMPILER% pip install twine wheel -r requirements-testing.txt -r requirements-notebooks.txt"
   - "%WITH_COMPILER% python -VV"
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,19 +10,13 @@ environment:
   matrix:
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_INSTALL_LOCN: C:\\Python38
-      CONDA_PY: 3.8
+      PYTHON: C:\\Python38-x64
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_INSTALL_LOCN: C:\\Miniconda37-x64
-      CONDA_PY: 3.7
+      PYTHON: C:\\Python37-x64
 
     - TARGET_ARCH: x64
-      CONDA_NPY: 111
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-      CONDA_PY: 3.6
+      PYTHON: C:\\Python36-x64
 
 platform:
   - x64
@@ -31,30 +25,31 @@ os: Previous Visual Studio 2015
 # os: Visual Studio 2013
 
 init:
-  - "ECHO %CONDA_INSTALL_LOCN% %CONDA_PY% %HOME% %PLATFORM%"
+  - "ECHO %PYTHON% %HOME% %PLATFORM%"
   - "ECHO %APPVEYOR_REPO_BRANCH%"
 
 install:
-  - cmd: pip install twine -r requirements-testing.txt -r requirements-notebooks.txt
-  - cmd: python -VV
+  - set Path=%PYTHON%\Scripts;%Path%
+  - cmd: '%PYTHON%\Scripts\pip install twine -r requirements-testing.txt -r requirements-notebooks.txt'
+  - cmd: '%PYTHON%\Scripts\python -VV'
 
 build: false
 
 test_script:
-  - "%WITH_COMPILER% pip install numpy"
-  - "%WITH_COMPILER% pip install netcdf4==1.5.2"
-  - "%WITH_COMPILER% pip install -e ."
-  - pytest -vvv
+  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install numpy"
+  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install netcdf4==1.5.2"
+  - "%WITH_COMPILER% %PYTHON%\Scripts\pip install -e ."
+  - cmd: '%PYTHON%\Scripts\pytest -vvv'
 
 after_test:
-  - cmd: python setup.py bdist_wheel
+  - cmd: "%PYTHON%\Scripts\python setup.py bdist_wheel"
 
 artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.
   - path: 'dist\*'
 
 deploy_script:
-  - cmd: python .ci/appveyor/pypi_upload.py
+  - cmd: '%PYTHON%\Scripts\python .ci/appveyor/pypi_upload.py'
 
 notifications:
   - provider: Slack

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,13 +10,13 @@ environment:
   matrix:
 
     - TARGET_ARCH: x64
-      PYTHON: C:\\Python38-x64
+      PYTHON: "C:\\Python38-x64"
 
     - TARGET_ARCH: x64
-      PYTHON: C:\\Python37-x64
+      PYTHON: "C:\\Python37-x64"
 
     - TARGET_ARCH: x64
-      PYTHON: C:\\Python36-x64
+      PYTHON: "C:\\Python36-x64"
 
 platform:
   - x64
@@ -29,27 +29,27 @@ init:
   - "ECHO %APPVEYOR_REPO_BRANCH%"
 
 install:
-  - set Path=%PYTHON%\Scripts;%Path%
-  - cmd: '%PYTHON%\Scripts\pip install twine -r requirements-testing.txt -r requirements-notebooks.txt'
-  - cmd: '%PYTHON%\Scripts\python -VV'
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "pip install twine -r requirements-testing.txt -r requirements-notebooks.txt"
+  - "python -VV"
 
 build: false
 
 test_script:
-  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install numpy'
-  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install netcdf4==1.5.2'
-  - '%WITH_COMPILER% %PYTHON%\Scripts\pip install -e .'
-  - cmd: '%PYTHON%\Scripts\pytest -vvv'
+  - "%WITH_COMPILER% pip install numpy"
+  - "pip install netcdf4==1.5.2"
+  - "pip install -e ."
+  - "pytest -vvv"
 
 after_test:
-  - cmd: '%PYTHON%\Scripts\python setup.py bdist_wheel'
+  - "python setup.py bdist_wheel"
 
 artifacts:
   # Archive the generated conda package in the ci.appveyor.com build report.
   - path: 'dist\*'
 
 deploy_script:
-  - cmd: '%PYTHON%\Scripts\python .ci/appveyor/pypi_upload.py'
+  - cmd: "python .ci/appveyor/pypi_upload.py"
 
 notifications:
   - provider: Slack


### PR DESCRIPTION
This pull request addresses issue #1109 as described by @kbarnhart. That is, we don't build/test/deploy (to PyPI) with Python 3.8. 