### PR TITLE
remove gitignore image types for joss dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,9 +67,11 @@ test-results.xml
 
 *.pdf
 !docs/**/*.pdf
+!joss/**/*.pdf
 
 *.png
 !docs/**/*.png
+!joss/**/*.png
 
 *.aux
 


### PR DESCRIPTION
JOSS submissions may include figures set to be ignored. This PR removes figure file types from gitignore.