### PR TITLE
Fix pip update instructions

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -74,7 +74,7 @@ In a terminal type:
 
 .. code-block:: bash
 
-  $ pip update landlab
+  $ pip install --upgrade --pre landlab
 
 Uninstall
 `````````


### PR DESCRIPTION
The pip update instructions were wrong (and didn't include the --pre channel). I realized this because of @rclavera's comment over on #1118 . This PR fixes it. I tested as best I could (made a new conda environment).

@mcflugen OK with you if we make a new release so we can have 3.8 builds? I think it would be v2.0.0b4