### PR TITLE
Improve clarity of dropping Py27 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,22 @@ to
 `install a prepackaged binary <https://landlab.readthedocs.io/en/latest/install/index.html>`_.
 We distribute through both conda-forge and pip.
 
+Landlab 2.0
+```````````
+
+In late December 2019 Landlab switched to version 2.0-beta. Landlab will be
+in 2.0-beta until the Landlab 2.0 publication is finalized. Landlab dropped
+support of Python 2.7 with this transition.
+
+Supported Python Versions
+`````````````````````````
+
+Landlab supports Python versions >= 3.6. Landlab distributes pre-packaged
+binaries through `conda-forge <https://anaconda.org/conda-forge/landlab>`_
+and `PyPI <https://pypi.org/project/landlab/>`_ for versions 3.6 and 3.7
+(3.8 coming soon). Note that on  PyPI, the ``--pre`` flag is necessary while
+Landlab v2.0 is in beta release.
+
 Conda Environment with Pre-packaged Binary Distribution
 ```````````````````````````````````````````````````````
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,12 +49,17 @@ Landlab 2.0
 -----------
 
 In late December 2019 Landlab switched to version 2.0-beta. Landlab will be
-in 2.0-beta until the Landlab 2.0 publication is finalized.
+in 2.0-beta until the Landlab 2.0 publication is finalized. Landlab dropped
+support of Python 2.7 with this transition. 
 
 Supported Python Versions
 -------------------------
 
-Python 3.6, 3.7, and 3.8
+Landlab supports Python versions >= 3.6. Landlab distributes pre-packaged
+binaries through `conda-forge <https://anaconda.org/conda-forge/landlab>`_
+and `PyPI <https://pypi.org/project/landlab/>`_ for versions 3.6 and 3.7
+(3.8 coming soon). Note that on  PyPI, the ``--pre`` flag is necessary while
+Landlab v2.0 is in beta release.
 
 Documentation Outline
 ---------------------

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
     url="https://github.com/landlab",
     description="Plugin-based component modeling tool.",
     long_description=open("README.rst").read(),
+    python_requires=">=3.6",
     setup_requires=["cython", "numpy"],
     install_requires=open("requirements.txt", "r").read().splitlines(),
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         "Programming Language :: Cython",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Physics",
     ],


### PR DESCRIPTION
Addresses comments raised in #1125.

@mcflugen might you take a look.  I'm not sure if there are additional things we need to test in adding `python_requires`. 