### PR TITLE
StreamPowerSmoothThresholdEroder indexing bug

### DIFF
--- a/landlab/components/stream_power/stream_power_smooth_threshold.py
+++ b/landlab/components/stream_power/stream_power_smooth_threshold.py
@@ -331,7 +331,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
                 * self._A_to_the_m[defined_flow_receivers]
             ) / (self._thresholds[defined_flow_receivers] * flow_link_lengths)
 
-            self._delta[defined_flow_receivers][self._thresholds == 0.0] = 0.0
+            self._delta[defined_flow_receivers][self._thresholds[defined_flow_receivers] == 0.0] = 0.0
         else:
             self._gamma[defined_flow_receivers] = dt * self._thresholds
             if self._thresholds == 0:


### PR DESCRIPTION
@gregtucker I found this while updating terrainbento to LL2. 

self._thresholds is an at-node array, so it needs to be indexed here. 