### PR TITLE
feat: add setters for erodibility for some stream power like components

### DIFF
--- a/landlab/components/erosion_deposition/erosion_deposition.py
+++ b/landlab/components/erosion_deposition/erosion_deposition.py
@@ -314,7 +314,7 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
         # E/D specific inits.
 
         # K's and critical values can be floats, grid fields, or arrays
-        self._K = return_array_at_node(grid, K)
+        self.K = K
         self._sp_crit = return_array_at_node(grid, sp_crit)
 
         # Handle option for solver
@@ -327,6 +327,15 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
             raise ValueError(
                 "Parameter 'solver' must be one of: " + "'basic', 'adaptive'"
             )
+
+    @property
+    def K(self):
+        """Erodibility (units depend on m_sp)."""
+        return self._K
+
+    @K.setter
+    def K(self, new_val):
+        self._K = return_array_at_node(self._grid, new_val)
 
     def _calc_erosion_rates(self):
         """Calculate erosion rates."""

--- a/landlab/components/erosion_deposition/erosion_deposition.py
+++ b/landlab/components/erosion_deposition/erosion_deposition.py
@@ -314,6 +314,7 @@ class ErosionDeposition(_GeneralizedErosionDeposition):
         # E/D specific inits.
 
         # K's and critical values can be floats, grid fields, or arrays
+        # use setter for K defined below
         self.K = K
         self._sp_crit = return_array_at_node(grid, sp_crit)
 

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -321,6 +321,7 @@ class Space(_GeneralizedErosionDeposition):
         self._Er = np.zeros(grid.number_of_nodes)
 
         # K's and critical values can be floats, grid fields, or arrays
+        # use setters defined below
         self.K_sed = K_sed
         self.K_br = K_br
 

--- a/landlab/components/space/space.py
+++ b/landlab/components/space/space.py
@@ -321,8 +321,8 @@ class Space(_GeneralizedErosionDeposition):
         self._Er = np.zeros(grid.number_of_nodes)
 
         # K's and critical values can be floats, grid fields, or arrays
-        self._K_sed = return_array_at_node(grid, K_sed)
-        self._K_br = return_array_at_node(grid, K_br)
+        self.K_sed = K_sed
+        self.K_br = K_br
 
         self._sp_crit_sed = return_array_at_node(grid, sp_crit_sed)
         self._sp_crit_br = return_array_at_node(grid, sp_crit_br)
@@ -338,6 +338,24 @@ class Space(_GeneralizedErosionDeposition):
             raise ValueError(
                 "Parameter 'solver' must be one of: " + "'basic', 'adaptive'"
             )
+
+    @property
+    def K_br(self):
+        """Erodibility of bedrock(units depend on m_sp)."""
+        return self._K_br
+
+    @K_br.setter
+    def K_br(self, new_val):
+        self._K_br = return_array_at_node(self._grid, new_val)
+
+    @property
+    def K_sed(self):
+        """Erodibility of sediment(units depend on m_sp)."""
+        return self._K_sed
+
+    @K_sed.setter
+    def K_sed(self, new_val):
+        self._K_sed = return_array_at_node(self._grid, new_val)
 
     def _calc_erosion_rates(self):
         """Calculate erosion rates."""

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -247,7 +247,9 @@ class FastscapeEroder(Component):
 
         self._erode_flooded_nodes = erode_flooded_nodes
 
+        # use setter for K defined below
         self.K = K_sp
+
         self._m = float(m_sp)
         self._n = float(n_sp)
 

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -247,7 +247,7 @@ class FastscapeEroder(Component):
 
         self._erode_flooded_nodes = erode_flooded_nodes
 
-        self._K = return_array_at_node(grid, K_sp)
+        self.K = K_sp
         self._m = float(m_sp)
         self._n = float(n_sp)
 
@@ -261,6 +261,15 @@ class FastscapeEroder(Component):
         # make storage variables
         self._A_to_the_m = grid.zeros(at="node")
         self._alpha = grid.empty(at="node")
+
+    @property
+    def K(self):
+        """Erodibility (units depend on m_sp)."""
+        return self._K
+
+    @K.setter
+    def K(self, new_val):
+        self._K = return_array_at_node(self._grid, new_val)
 
     def run_one_step(self, dt):
         """Erode for a single time step.

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -262,7 +262,7 @@ class StreamPowerEroder(Component):
 
         self._A = return_array_at_node(grid, discharge_field)
         self._elevs = return_array_at_node(grid, "topographic__elevation")
-        self._K_unit_time = return_array_at_node(grid, K_sp)
+        self.K = return_array_at_node(grid, K_sp)
         self._sp_crit = return_array_at_node(grid, threshold_sp)
 
         assert np.all(self._sp_crit >= 0.0)
@@ -338,6 +338,15 @@ class StreamPowerEroder(Component):
         self._stream_power_erosion = self._grid.zeros(centering="node")
         self._alpha = self._grid.zeros("node")
 
+    @property
+    def K(self):
+        """Erodibility (units depend on m_sp)."""
+        return self._K
+
+    @K.setter
+    def K(self, new_val):
+        self._K = return_array_at_node(self._grid, new_val)
+
     def run_one_step(self, dt):
         """A simple, explicit implementation of a stream power algorithm.
 
@@ -377,7 +386,7 @@ class StreamPowerEroder(Component):
         # Operate the main function:
         if self._use_W:
             self._alpha[defined_flow_receivers] = (
-                self._K_unit_time[defined_flow_receivers]
+                self._K[defined_flow_receivers]
                 * dt
                 * self._A[defined_flow_receivers] ** self._m
                 / self._W[defined_flow_receivers]
@@ -386,7 +395,7 @@ class StreamPowerEroder(Component):
 
         else:
             self._alpha[defined_flow_receivers] = (
-                self._K_unit_time[defined_flow_receivers]
+                self._K[defined_flow_receivers]
                 * dt
                 * self._A[defined_flow_receivers] ** self._m
                 / (flow_link_lengths ** self._n)

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -262,8 +262,10 @@ class StreamPowerEroder(Component):
 
         self._A = return_array_at_node(grid, discharge_field)
         self._elevs = return_array_at_node(grid, "topographic__elevation")
-        self.K = return_array_at_node(grid, K_sp)
         self._sp_crit = return_array_at_node(grid, threshold_sp)
+
+        # use setter for K defined below
+        self.K = K_sp
 
         assert np.all(self._sp_crit >= 0.0)
 

--- a/landlab/components/stream_power/stream_power_smooth_threshold.py
+++ b/landlab/components/stream_power/stream_power_smooth_threshold.py
@@ -179,7 +179,7 @@ class StreamPowerSmoothThresholdEroder(FastscapeEroder):
                 raise NotImplementedError(msg)
 
         if not erode_flooded_nodes:
-            if "flood_status_code" not in self._grid.at_node:
+            if "flood_status_code" not in grid.at_node:
                 msg = (
                     "In order to not erode flooded nodes another component "
                     "must create the field *flood_status_code*. You want to "


### PR DESCRIPTION
This PR adds setters for the fluvial erodibility coefficient in 
- FastscapeStreamPower (and by extension StreamPowerSmoothThresholdEroder)
- StreamPowerEroder
- ErosionDeposition
- Space

These are necessary to support updating terrainbento to be compliant with LL2. 