### PR TITLE
Add Python 3.8 to Linux builds to send to PyPI

### DIFF
--- a/.ci/travis/build_wheels.sh
+++ b/.ci/travis/build_wheels.sh
@@ -4,6 +4,7 @@ set -e -x
 PYBIN=" \
   /opt/python/cp36-cp36m/bin \
   /opt/python/cp37-cp37m/bin \
+  /opt/python/cp38-cp38/bin \
 "
 
 for bindir in $PYBIN; do


### PR DESCRIPTION
This pull request attempts to fix #1139. I believe the only issue was that`.ci/travis/build_wheels.sh` specified only Python 3.6 and 3.7. With this pull request I've added `/opt/python/cp38-cp38/bin` to the list of Python versions to build.

I didn't add something like build everything that matches `/opt/python/*/bin` because the Docker image we're using includes Python 2.7, 3.4, and 3.5 (in addition to 3.6, 3.7, and 3.8).