### PR TITLE
Add layer reducer

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,9 +54,10 @@ source_suffix = '.rst'
 
 # Regex for links that we know work in browser, but do not work in sphinx/CI (BE VERY CAREFUL ADDING LINKS TO THIS LIST)
 linkcheck_ignore = [
-    r'https://pubs.geoscienceworld.org/gsa/geology.*', # Added by KRB Dec 2019, at this point two links match this pattern
-    r'https://dx.doi.org/10.1130/*', # added by KRB Jan 2019. Four links match this pattern
-    ]
+    r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
+    r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
+    r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7",  # Added by EWHH Feb 2020
+]
 
 # The master toctree document.
 master_doc = 'index'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,6 +12,7 @@
 # serve to show the default.
 
 import os
+import re
 import sys
 from datetime import date
 
@@ -56,7 +57,7 @@ source_suffix = '.rst'
 linkcheck_ignore = [
     r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
     r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
-    r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7",  # Added by EWHH Feb 2020
+    re.escape(r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"),  # Added by EWHH Feb 2020
 ]
 
 # The master toctree document.

--- a/landlab/layers/eventlayers.py
+++ b/landlab/layers/eventlayers.py
@@ -876,9 +876,14 @@ class EventLayers:
         array([[ 1.5,  1.5,  1.5],
                [ 1. ,  2. ,  0.5]])
 
+        Combine all of the layers into a single layer.
+
         >>> layers.reduce()
         >>> layers.dz
         array([[ 2.5,  3.5,  2. ]])
+
+        Add two additional layers to the top. The bottom-most layer is row
+        0, and the two new layers are rows 1 and 2.
 
         >>> layers.add([1., 2., .5])
         >>> layers.add([1., 2., .5])
@@ -886,6 +891,9 @@ class EventLayers:
         array([[ 2.5,  3.5,  2. ],
                [ 1. ,  2. ,  0.5],
                [ 1. ,  2. ,  0.5]])
+
+        Combine the two new layers (layers 1 and 2) into a single layer.
+
         >>> layers.reduce(1, 3)
         >>> layers.dz
         array([[ 2.5,  3.5,  2. ],
@@ -898,6 +906,9 @@ class EventLayers:
                [ 2. ,  4. ,  1. ],
                [ 1. ,  2. ,  0.5],
                [ 1. ,  2. ,  0.5]])
+
+        Combine the middle two layers.
+
         >>> layers.reduce(1, 3)
         >>> layers.dz
         array([[ 2.5,  3.5,  2. ],
@@ -909,18 +920,25 @@ class EventLayers:
                [ 3. ,  6. ,  1.5],
                [ 1. ,  2. ,  0.5],
                [ 1. ,  1. ,  1. ]])
+
+        Combine every two layers (layers 0 and 1 and combined, and layers
+        1 and 2 are combined).
+
         >>> layers.reduce(0, 4, 2)
         >>> layers.dz
         array([[ 5.5,  9.5,  3.5],
                [ 2. ,  3. ,  1.5]])
 
+        When layers are combined, thicknesses are summed but layer attributes
+        can be combined in other ways (e.g. max, or mean)
+
         >>> layers = EventLayers(3)
         >>> layers.add([1, 1, 1], age=0.)
         >>> layers.add([1, 2, 5], age=1.)
         >>> layers.add([2, 2, 2], age=2.)
-        >>> layers.reduce(age=np.sum)
+        >>> layers.reduce(age=np.max)
         >>> layers["age"]
-        array([[ 3.,  3.,  3.]])
+        array([[ 2.,  2.,  2.]])
 
         >>> layers.add([2, 2, 2], age=3.)
         >>> layers.add([2, 2, 2], age=4.)

--- a/landlab/layers/eventlayers.py
+++ b/landlab/layers/eventlayers.py
@@ -944,7 +944,7 @@ class EventLayers:
         >>> layers.add([2, 2, 2], age=4.)
         >>> layers.reduce(1, 3, age=np.mean)
         >>> layers["age"]
-        array([[ 3. ,  3. ,  3. ],
+        array([[ 2. ,  2. ,  2. ],
                [ 3.5,  3.5,  3.5]])
         """
         _valid_keywords_or_raise(kwds, required=self.tracking, optional=self._attrs)

--- a/landlab/layers/eventlayers.py
+++ b/landlab/layers/eventlayers.py
@@ -218,6 +218,7 @@ class _BlockSlice:
     """Slices that divide a matrix into equally sized blocks."""
 
     def __init__(self, *args):
+        """_BlockSlice([start], stop, [step])"""
         if len(args) > 3:
             raise TypeError(
                 "_BlockSlice expected at most 3 arguments, got {0}".format(len(args))
@@ -260,16 +261,34 @@ class _BlockSlice:
         return self._step
 
     def indices(self, n_rows):
-        """
+        """Row indices to blocks within a matrix.
+
+        Parameters
+        ----------
+        n_rows : int
+            The number of rows in the matrix.
+
+        Returns
+        -------
+        (start, stop, step)
+            Tuple of (int* that gives the row of the first block, row of the
+            last block, and the number of rows in each block.
+
         Examples
         --------
         >>> from landlab.layers.eventlayers import _BlockSlice
+
+        The default is one single block that encomapses all the rows.
+
         >>> _BlockSlice().indices(4)
         (0, 4, 4)
+
         >>> _BlockSlice(3).indices(4)
         (0, 3, 3)
+
         >>> _BlockSlice(1, 3).indices(4)
         (1, 3, 2)
+
         >>> _BlockSlice(1, 7, 2).indices(8)
         (1, 7, 2)
         """
@@ -445,7 +464,7 @@ def _allocate_layers_for(array, number_of_layers, number_of_stacks):
     )
 
 
-class EventLayersMixIn(object):
+class EventLayersMixIn:
 
     """MixIn that adds a EventLayers attribute to a ModelGrid."""
 
@@ -460,7 +479,7 @@ class EventLayersMixIn(object):
             return self._event_layers
 
 
-class EventLayers(object):
+class EventLayers:
 
     """Track EventLayers where each event is its own layer.
 
@@ -961,9 +980,36 @@ class EventLayers(object):
 
     @property
     def surface_index(self):
+        """Index to the top non-empty layer.
+
+        Examples
+        --------
+        >>> from landlab.layers.eventlayers import EventLayers
+
+        Create an empty layer stack with 5 stacks.
+
+        >>> layers = EventLayers(3)
+        >>> layers.surface_index
+        array([0, 0, 0])
+
+        Add a layer with a uniform thickness.
+
+        >>> for _ in range(5): layers.add(1.0)
+        >>> layers.surface_index
+        array([4, 4, 4])
+
+        Add a layer with varying thickness. Negative thickness
+        removes thickness from underlying layers, zero thickness adds a
+        layer but doesn't change the surface index.
+
+        >>> layers.add([-1.0, 0.0, 1.0])
+        >>> layers.surface_index
+        array([3, 4, 5])
+        """
         return self._surface_index
 
     def get_surface_values(self, name):
+        """Values of a field on the surface layer."""
         return self._attrs[name][self.surface_index, np.arange(self._number_of_stacks)]
 
     def _add_empty_layer(self):

--- a/landlab/layers/eventlayers.py
+++ b/landlab/layers/eventlayers.py
@@ -184,36 +184,6 @@ def _reduce_matrix(array, step, reducer):
     )
 
 
-def _reduce_matrix_rows(array, *args, reducer=np.sum):
-    """Combine rows of a portion of a 2D matrix.
-    """
-    start, stop = 0, len(array)
-    if len(args) == 1:
-        stop = args[0]
-    elif len(args) == 2:
-        start, stop = args
-    elif len(args) == 3:
-        start, stop, step = args
-    if start == stop:
-        return len(array)
-
-    start, stop, _ = slice(start, stop).indices(len(array))
-
-    if len(args) < 3:
-        step = stop - start
-
-    if step == 1:
-        return len(array)
-
-    middle = _reduce_matrix(array[start:stop, :], step, reducer)
-    top = array[stop:, :]
-
-    array[start : start + len(middle), :] = middle
-    array[start + len(middle) : start + len(middle) + len(top)] = top
-
-    return start + len(middle) + len(top)
-
-
 class _BlockSlice:
     """Slices that divide a matrix into equally sized blocks."""
 

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -3,7 +3,6 @@ import pathlib
 import subprocess
 import tempfile
 
-import nbformat
 import pytest
 import yaml
 
@@ -17,6 +16,8 @@ def _notebook_run(path):
     """Execute a notebook via nbconvert and collect output.
        :returns (parsed nb object, execution errors)
     """
+    import nbformat
+
     _, notebook = os.path.split(path)
     base, ext = os.path.splitext(notebook)
 

--- a/tests/layers/test_event_layers.py
+++ b/tests/layers/test_event_layers.py
@@ -4,6 +4,7 @@ from numpy.testing import assert_array_equal
 
 from landlab import RasterModelGrid
 from landlab.layers import EventLayers
+from landlab.layers.eventlayers import _BlockSlice, _valid_keywords_or_raise
 
 
 def test_EventLayersMixIn():
@@ -78,3 +79,224 @@ def test_adding_untracked_layer():
     layers.add([0.0, 0.0, 1.0], type=3.0, size="sand")
     with pytest.raises(ValueError):
         layers.add([1.0], type=3.0, size="sand", spam="eggs")
+
+
+def test_reduce_with_no_args():
+    layers = EventLayers(3)
+
+    layers.add(1.5)
+    layers.reduce()
+    assert_array_equal(layers.dz, [[1.5, 1.5, 1.5]])
+
+    layers.add(2.5)
+    layers.reduce()
+    assert_array_equal(layers.dz, [[4.0, 4.0, 4.0]])
+
+
+def test_reduce_with_start():
+    layers = EventLayers(3)
+
+    layers.add([3.0, 4.0, 5.0])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([1.0, 2.0, 0.5])
+    layers.reduce(1, 3)
+
+    assert_array_equal(layers.dz, [[3.0, 4.0, 5.0], [2.0, 4.0, 1.0]])
+
+
+def test_reduce_with_start_and_stop():
+    layers = EventLayers(3)
+
+    layers.add([3.0, 4.0, 5.0])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([2.0, 5.0, 6.0])
+
+    layers.reduce(1, 3)
+    assert_array_equal(layers.dz, [[3.0, 4.0, 5.0], [2.0, 4.0, 1.0], [2.0, 5.0, 6.0]])
+
+
+def test_reduce_with_start_and_stop_and_step():
+    layers = EventLayers(3)
+
+    layers.add([3.0, 4.0, 5.0])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([2.0, 5.0, 6.0])
+
+    layers.reduce(1, 3, 2)
+    assert_array_equal(layers.dz, [[3.0, 4.0, 5.0], [2.0, 4.0, 1.0], [2.0, 5.0, 6.0]])
+
+
+def test_reduce_with_stop_equals_start():
+    layers = EventLayers(3)
+
+    layers.add([3.0, 4.0, 5.0])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([2.0, 5.0, 6.0])
+
+    layers.reduce(1, 1)
+    assert_array_equal(
+        layers.dz, [[3.0, 4.0, 5.0], [1.0, 2.0, 0.5], [1.0, 2.0, 0.5], [2.0, 5.0, 6.0]]
+    )
+
+
+def test_reduce_with_stop_less_than_start():
+    layers = EventLayers(3)
+
+    layers.add([3.0, 4.0, 5.0])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([1.0, 2.0, 0.5])
+    layers.add([2.0, 5.0, 6.0])
+
+    with pytest.raises(ValueError):
+        layers.reduce(3, 1)
+
+
+def test_reduce_with_one_layer():
+    layers = EventLayers(3)
+    layers.add(1.0)
+    layers.reduce()
+    assert_array_equal(layers.dz, [[1, 1, 1]])
+
+
+def test_reduce_with_no_layers():
+    layers = EventLayers(3)
+    layers.reduce()
+    assert_array_equal(layers.dz, np.empty((0, 3)))
+
+
+def test_reduce_with_attrs():
+    layers = EventLayers(3)
+    layers.add([1, 1, 1], age=0.0)
+    layers.add([1, 2, 5], age=1.0)
+    layers.add([2, 2, 2], age=2.0)
+    layers.reduce(age=np.sum)
+    assert_array_equal(layers["age"], [[3.0, 3.0, 3.0]])
+
+
+def test_reduce_with_reducer():
+    layers = EventLayers(3)
+    layers.add([2, 2, 2], age=1.0)
+    layers.add([2, 2, 2], age=3.0)
+    layers.add([2, 2, 2], age=4.0)
+    layers.reduce(1, 3, age=np.mean)
+    assert_array_equal(layers["age"], [[1.0, 1.0, 1.0], [3.5, 3.5, 3.5]])
+
+
+def test_reduce_with_start_too_big():
+    layers = EventLayers(3)
+    layers.add(1)
+    layers.reduce(2, 4)
+    assert_array_equal(layers.dz, [[1, 1, 1]])
+
+
+def test_reduce_with_unknown_property():
+    layers = EventLayers(3)
+    for layer in range(4):
+        layers.add(layer)
+    with pytest.raises(TypeError):
+        layers.reduce(1, 3, age=np.mean)
+
+
+def test_reduce_with_missing_property():
+    layers = EventLayers(3)
+    for layer in range(4):
+        layers.add(layer, age=layer)
+    with pytest.raises(TypeError):
+        layers.reduce(1, 3)
+
+
+@pytest.mark.parametrize("args", [(), (4,), (0, 4), (0, 4, 4), (-4, 4, 4), (4, 0, -4)])
+def test_reduce_args(args):
+    layers = EventLayers(3)
+    for layer in range(4):
+        layers.add(layer)
+    layers.reduce(4)
+    assert_array_equal(layers.dz, [[6, 6, 6]])
+
+
+def test_reduce_partial_block():
+    layers = EventLayers(3)
+    for layer in range(6):
+        layers.add(layer)
+    layers.reduce(1, 6, 4)
+    assert_array_equal(layers.dz, [[0, 0, 0], [10, 10, 10], [5, 5, 5]])
+
+
+def test_block_slice_no_args():
+    block = _BlockSlice()
+    assert block.start == 0
+    assert block.stop is None
+    assert block.step is None
+    assert block.indices(4) == (0, 4, 4)
+
+
+def test_block_slice_one_arg():
+    block = _BlockSlice(4)
+    assert block.start == 0
+    assert block.stop == 4
+    assert block.step is None
+    assert block.indices(4) == (0, 4, 4)
+    assert block.indices(3) == (0, 3, 3)
+
+
+def test_block_slice_two_args():
+    block = _BlockSlice(1, 4)
+    assert block.start == 1
+    assert block.stop == 4
+    assert block.step is None
+    assert block.indices(4) == (1, 4, 3)
+    assert block.indices(5) == (1, 4, 3)
+    assert block.indices(3) == (1, 3, 2)
+
+
+def test_block_slice_three_args():
+    block = _BlockSlice(1, 7, 2)
+    assert block.start == 1
+    assert block.stop == 7
+    assert block.step == 2
+    assert block.indices(8) == (1, 7, 2)
+
+    block = _BlockSlice(1, 7, 7)
+    assert block.start == 1
+    assert block.stop == 7
+    assert block.step == 6
+    assert block.indices(8) == (1, 7, 6)
+
+
+@pytest.mark.parametrize("args", [(0, 7, 2), (0, 8, 2), (0, 8, 21)])
+@pytest.mark.parametrize("n_rows", [7, 8])
+def test_block_slice_full_blocks(args, n_rows):
+    start, stop, step = _BlockSlice(*args).indices(n_rows)
+    assert (stop - start) % step == 0
+
+
+def test_block_slice_stop_less_than_start():
+    with pytest.raises(ValueError):
+        _BlockSlice(5, 4)
+
+
+def test_valid_keywords():
+    _valid_keywords_or_raise({"foo": 0}, optional=["foo", "bar"])
+    with pytest.raises(TypeError):
+        _valid_keywords_or_raise({"foo": 0}, required=["foo", "bar"])
+    with pytest.raises(TypeError):
+        _valid_keywords_or_raise(["baz"], optional=["foo", "bar"])
+
+
+@pytest.mark.parametrize("as_type", [list, tuple, set])
+def test_valid_keywords_as_types(as_type):
+    _valid_keywords_or_raise(as_type(["foo"]), optional=as_type(["foo", "bar"]))
+    with pytest.raises(TypeError):
+        _valid_keywords_or_raise(as_type(["foo"]), required=as_type(["foo", "bar"]))
+    with pytest.raises(TypeError):
+        _valid_keywords_or_raise(as_type(["baz"]), optional=as_type(["foo", "bar"]))
+
+
+def test_valid_keywords_empty():
+    _valid_keywords_or_raise([])
+    _valid_keywords_or_raise([], optional=["foo"])
+    with pytest.raises(TypeError):
+        _valid_keywords_or_raise([], required=["foo"])


### PR DESCRIPTION
This pull request adds a new method, *reduce*, to *EventLayers*. The *reduce* method combines blocks of *EventLayers* into single blocks. So, for instance, if there are 200 layers, calling *reduce* could reduce the number of layers to 20 but averaging every 10 layers into a single layer. This can be useful when running a model that generates a large number of layers but only the most recently deposited layers are of importance and deeper layers can be archived to save memory.

As a demonstration of how this could be used, the following is a code snippet from the *Sequence* model,
```python
    if (self.grid.event_layers.number_of_layers - self._n_archived_layers) % 20 == 0:
        self.grid.event_layers.reduce(
            self._n_archived_layers,
            self._n_archived_layers + 10,
            age=np.max,
            percent_sand=np.mean,
            porosity=np.mean,
            t0=np.sum,
            water_depth=np.mean,
        )
        self._n_archived_layers += 1
```
In this example, after 20 new layers have been added layers 10 through 19 (as measured from the surface layer) are average into a single layer and archived. This ensures that there are always 10 layers at the top that are at full resolution. Notice the way that layer attributes are combined can be specified per attribute (e.g. the maximum of *age* is used, while *porosity* is averaged).