### PR TITLE
Fix manylinux builds

### DIFF
--- a/.ci/travis/build_wheels.sh
+++ b/.ci/travis/build_wheels.sh
@@ -14,7 +14,7 @@ done
 
 # Bundle external shared libraries into the wheels
 for whl in /io/wheelhouse/*.whl; do
-    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/
+    auditwheel repair "$whl" --plat $PLAT -w /io/wheelhouse/ || echo "NOT A PLATFORM WHEEL"
 done
 
 ls /io/wheelhouse


### PR DESCRIPTION
This pull request fixes creating *manylinux* builds for landlab on Travis using Docker. It seems the issue was that a new version of the *auditwheel* command now returns an error code (1) if it's given a non-platform wheel to repair. Since we just looped over all wheels in the *wheelhouse* folder, passing each one to *auditwheel*, *auditwheel* would return an error and the script would exit prematurely before creating further *manylinux* distributions.

To fix the problem, I simply allow *auditwheel* to return a non-zero code and continue with the loop.