### PR TITLE
Fix raster_netcdf format details

### DIFF
--- a/landlab/io/netcdf/read.py
+++ b/landlab/io/netcdf/read.py
@@ -236,7 +236,7 @@ def _get_raster_spacing(coords):
 
 
 def read_netcdf(
-    nc_file, grid=None, name=None, just_grid=False, halo=0, nodata_value=-9999.0
+    nc_file, grid=None, name=None, just_grid=False, halo=0, nodata_value=-9999.0,
 ):
     """Create a :class:`~.RasterModelGrid` from a netcdf file.
 
@@ -334,18 +334,25 @@ def read_netcdf(
     else:
         names = set(name)
 
-    dx = np.diff(dataset["x"], axis=1)
-    dy = np.diff(dataset["y"], axis=0)
+    # test if the input is a raster (x and y) are only 1-D instead of 2D.
+    if len(dataset["x"].shape) == 1:
+        y, x = np.meshgrid(dataset["y"], dataset["x"], indexing="ij")
+    else:
+        x = dataset["x"]
+        y = dataset["y"]
+
+    dx = np.diff(x, axis=1)
+    dy = np.diff(y, axis=0)
 
     if np.all(dx == dx[0, 0]) and np.all(dy == dy[0, 0]):
         xy_spacing = (dx[0, 0], dy[0, 0])
     else:
         raise NotRasterGridError()
 
-    shape = dataset["x"].shape
+    shape = x.shape
     xy_of_lower_left = (
-        dataset["x"][0, 0] - halo * xy_spacing[0],
-        dataset["y"][0, 0] - halo * xy_spacing[1],
+        x[0, 0] - halo * xy_spacing[0],
+        y[0, 0] - halo * xy_spacing[1],
     )
 
     if grid is None:

--- a/landlab/io/netcdf/write.py
+++ b/landlab/io/netcdf/write.py
@@ -564,6 +564,7 @@ def write_netcdf(
     names=None,
     at=None,
     time=None,
+    raster=False,
 ):
     """Write landlab fields to netcdf.
 
@@ -588,6 +589,9 @@ def write_netcdf(
         write all fields.
     at : {'node', 'cell'}, optional
         The location where values are defined.
+    raster : bool, optional
+        Indicate whether spatial dimensions are written as full value arrays
+        (default) or just as coordinate dimensions.
 
     Examples
     --------
@@ -684,8 +688,12 @@ def write_netcdf(
             grid.y_of_corner[grid.corners_at_cell].reshape(shape + (4,)),
         )
     else:
-        data["x"] = (("nj", "ni"), grid.x_of_node.reshape(shape))
-        data["y"] = (("nj", "ni"), grid.y_of_node.reshape(shape))
+        if raster:
+            data["x"] = (("ni"), grid.x_of_node.reshape(shape)[0, :])
+            data["y"] = (("nj"), grid.y_of_node.reshape(shape)[:, 0])
+        else:
+            data["x"] = (("nj", "ni"), grid.x_of_node.reshape(shape))
+            data["y"] = (("nj", "ni"), grid.y_of_node.reshape(shape))
 
     if not append:
         if time is not None:
@@ -814,4 +822,5 @@ def write_raster_netcdf(
         names=names,
         at=at,
         time=time,
+        raster=True,
     )

--- a/landlab/io/netcdf/write.py
+++ b/landlab/io/netcdf/write.py
@@ -754,6 +754,8 @@ def write_raster_netcdf(
     some data fields to it.
 
     >>> rmg = RasterModelGrid((4, 3))
+    >>> rmg.shape
+    (4, 3)
     >>> rmg.at_node["topographic__elevation"] = np.arange(12.0)
     >>> rmg.at_node["uplift_rate"] = 2.0 * np.arange(12.0)
 
@@ -782,6 +784,24 @@ def write_raster_netcdf(
     >>> 'topographic__elevation' in fp.variables
     False
     >>> fp.variables['uplift_rate'][:].flatten()
+    array([  0.,   2.,   4.,   6.,   8.,  10.,  12.,  14.,  16.,  18.,  20.,
+            22.])
+    >>> fp.variables['x'][:]
+    array([ 0.,  1.,  2.])
+    >>> fp.variables['y'][:]
+    array([ 0.,  1.,  2.,  3.])
+
+    Read now with read_netcdf
+
+    >>> from landlab.io.netcdf import read_netcdf
+    >>> grid = read_netcdf("test.nc")
+    >>> grid.shape
+    (4, 3)
+    >>> grid.x_of_node
+    array([ 0.,  1.,  2.,  0.,  1.,  2.,  0.,  1.,  2.,  0.,  1.,  2.])
+    >>> grid.y_of_node
+    array([ 0.,  0.,  0.,  1.,  1.,  1.,  2.,  2.,  2.,  3.,  3.,  3.])
+    >>> grid.at_node["uplift_rate"]
     array([  0.,   2.,   4.,   6.,   8.,  10.,  12.,  14.,  16.,  18.,  20.,
             22.])
     """

--- a/landlab/io/netcdf/write.py
+++ b/landlab/io/netcdf/write.py
@@ -727,6 +727,13 @@ def write_raster_netcdf(
     This method is for Raster Grids only and takes advantage of regular x and
     y spacing to save memory.
 
+    Rather that writing x and y of node locations at all (nr x nc) locations,
+    it writes a 1D array each for x and y.
+
+    A more modern version of this might write x and y location as a netcdf
+    coordinate. However, the original version of this function wrote x and y
+    as data variables rather than coordinates.
+
     If the *append* keyword argument in True, append the data to an existing
     file, if it exists. Otherwise, clobber an existing files.
 


### PR DESCRIPTION
The recent pull request #1029 slightly changed the treatment of "raster-netcdfs". These are netcdfs that write "x" and "y" as 1D data variables instead of as 2D variables. #1029 wrote raster netcdfs spatial information as 2D. Why did this happen... the tests in landlab weren't sufficient to distinguish the two types (but the tests in terrainbento are). 

This PR remedies the issue, adds a test, and adds some docs. 

With this terrainbento tests pass too!