### PR TITLE
fix: remove fetched folder.

### DIFF
--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -51,6 +51,12 @@ class ExampleData:
         --------
         >>> data = ExampleData("io/shapefile")
         >>> data.fetch()
+
+        We now remove the created folder because otherwise the test can only
+        pass locally once.
+
+        >>> import shutil
+        >>> shutil.rmtree("methow")
         """
         dstdir, srcdir = pathlib.Path("."), self.base
 


### PR DESCRIPTION
@mcflugen without these extra two lines the tests can only pass once for me. otherwise the folder `methow` persists and the test fails with an error saying (smartly) that the folder is already there. 