### PR TITLE
Add HeightAboveDrainageCalculator component

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -82,6 +82,7 @@ COMPONENTS = [
     gFlex,
     GroundwaterDupuitPercolator,
     HackCalculator,
+    HeightAboveDrainageCalculator,
     KinwaveImplicitOverlandFlow,
     KinwaveOverlandFlowModel,
     LakeMapperBarnes,

--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -20,6 +20,7 @@ from .fracture_grid import FractureGridGenerator
 from .gflex import gFlex
 from .groundwater import GroundwaterDupuitPercolator
 from .hack_calculator import HackCalculator
+from .hand_calculator import HeightAboveDrainage
 from .lake_fill import LakeMapperBarnes
 from .landslides import LandslideProbability
 from .lateral_erosion import LateralEroder

--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -20,7 +20,7 @@ from .fracture_grid import FractureGridGenerator
 from .gflex import gFlex
 from .groundwater import GroundwaterDupuitPercolator
 from .hack_calculator import HackCalculator
-from .hand_calculator import HeightAboveDrainage
+from .hand_calculator import HeightAboveDrainageCalculator
 from .lake_fill import LakeMapperBarnes
 from .landslides import LandslideProbability
 from .lateral_erosion import LateralEroder

--- a/landlab/components/hand_calculator/__init__.py
+++ b/landlab/components/hand_calculator/__init__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+"""
+.. codeauthor:: D Litwin
+
+.. sectionauthor:: D Litwin
+"""
+
+from .hand_calculator import HeightAboveDrainage
+
+__all__ = ["HeightAboveDrainage"]

--- a/landlab/components/hand_calculator/__init__.py
+++ b/landlab/components/hand_calculator/__init__.py
@@ -5,6 +5,6 @@
 .. sectionauthor:: D Litwin
 """
 
-from .hand_calculator import HeightAboveDrainage
+from .hand_calculator import HeightAboveDrainageCalculator
 
-__all__ = ["HeightAboveDrainage"]
+__all__ = ["HeightAboveDrainageCalculator"]

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -10,6 +10,7 @@ import numpy as np
 from landlab import Component
 from landlab.utils import return_array_at_node
 
+
 class HeightAboveDrainageCalculator(Component):
     """
     Calculate the elevation difference between each node and its nearest
@@ -125,7 +126,7 @@ class HeightAboveDrainageCalculator(Component):
         },
     }
 
-    def __init__(self, grid, channel_mask = "channel__mask"):
+    def __init__(self, grid, channel_mask="channel__mask"):
         """
         Parameters
         ----------

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -115,9 +115,7 @@ class HeightAboveDrainage(Component):
 
         # Downstream drainage node
         if "downstream_drainage__node" in grid.at_node:
-            self._downstream_drainage_id = grid.at_node[
-                "downstream_drainage__node"
-            ]
+            self._downstream_drainage_id = grid.at_node["downstream_drainage__node"]
         else:
             self._downstream_drainage_id = grid.add_zeros(
                 "downstream_drainage__node", at="node", dtype=int
@@ -125,31 +123,29 @@ class HeightAboveDrainage(Component):
 
         # height above nearest drainage
         if "height_above_drainage__elevation" in grid.at_node:
-            self._hand = grid.at_node[
-                "height_above_drainage__elevation"
-            ]
+            self._hand = grid.at_node["height_above_drainage__elevation"]
         else:
             self._hand = grid.add_zeros(
                 "height_above_drainage__elevation", at="node", dtype=float
             )
-
 
     @property
     def channel_mask(self):
         return self._channel_mask
 
     @channel_mask.setter
-    def channel_mask(self,new_val):
+    def channel_mask(self, new_val):
         self._channel_mask = new_val
-
 
     def run_one_step(self):
 
-        self_draining_nodes = sum(self._receivers == np.arange(self._grid.number_of_nodes))
+        self_draining_nodes = sum(
+            self._receivers == np.arange(self._grid.number_of_nodes)
+        )
         if self_draining_nodes != len(self._grid.boundary_nodes):
             warn(
-            "Pits detected in the flow directions supplied. "
-            "Pits will be treated as drainage nodes."
+                "Pits detected in the flow directions supplied. "
+                "Pits will be treated as drainage nodes."
             )
 
         self._downstream_drainage_id[:] = 0
@@ -158,7 +154,9 @@ class HeightAboveDrainage(Component):
 
         for i in range(self._grid.number_of_nodes):
 
-            if i == self._receivers[i] or is_drainage_node[i]: #started on a boundary, depression, or in channel
+            if (
+                i == self._receivers[i] or is_drainage_node[i]
+            ):  # started on a boundary, depression, or in channel
                 self._downstream_drainage_id[i] = i
 
             else:
@@ -173,4 +171,4 @@ class HeightAboveDrainage(Component):
                         cur_node = downstream_id
 
         nearest_drainage_elev = self._elev[self._downstream_drainage_id]
-        self._hand[:] = self._elev-nearest_drainage_elev
+        self._hand[:] = self._elev - nearest_drainage_elev

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -33,8 +33,12 @@ class HeightAboveDrainageCalculator(Component):
     >>> mg.set_status_at_node_on_edges(right=mg.BC_NODE_IS_CLOSED, bottom=mg.BC_NODE_IS_FIXED_VALUE, \
                                   left=mg.BC_NODE_IS_CLOSED, top=mg.BC_NODE_IS_CLOSED)
     >>> elev = np.array([[2,1,0,1,2],[3,2,1,2,3],[4,3,2,3,4],[5,4,4,4,5]])
-    >>> elev
     >>> z[:] = elev.reshape(len(z))
+    >>> elev
+    array([[2, 1, 0, 1, 2],
+       [3, 2, 1, 2, 3],
+       [4, 3, 2, 3, 4],
+       [5, 4, 4, 4, 5]])
 
     >>> fa = FlowAccumulator(mg, flow_director="D8")
     >>> fa.run_one_step()
@@ -42,13 +46,19 @@ class HeightAboveDrainageCalculator(Component):
     >>> channel__mask = mg.zeros(at="node")
     >>> channel__mask[[2,7]] = 1
     >>> channel__mask.reshape(elev.shape)
+    array([[ 0.,  0.,  1.,  0.,  0.],
+       [ 0.,  0.,  1.,  0.,  0.],
+       [ 0.,  0.,  0.,  0.,  0.],
+       [ 0.,  0.,  0.,  0.,  0.]])
 
     >>> hd = HeightAboveDrainageCalculator(mg, channel__mask)
     >>> hd.run_one_step()
 
-    >>> mg.at_node["height_above_drainage__elevation"].reshape(elev.shape)
-
-
+    >>> mg.at_node["height_above_drainage__elevation"].reshape(elev.shape)  # doctest: +NORMALIZE_WHITESPACE
+    array([[ 0.,  0.,  0.,  0.,  0.],
+           [ 0.,  2.,  0.,  2.,  0.],
+           [ 0.,  2.,  1.,  2.,  0.],
+           [ 0.,  0.,  0.,  0.,  0.]])
 
     References
     ----------

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -43,7 +43,7 @@ class HeightAboveDrainageCalculator(Component):
     >>> channel__mask[[2,7]] = 1
     >>> channel__mask.reshape(elev.shape)
 
-    >>> hd = HeightAboveDrainage(mg, channel__mask)
+    >>> hd = HeightAboveDrainageCalculator(mg, channel__mask)
     >>> hd.run_one_step()
 
     >>> mg.at_node["height_above_drainage__elevation"].reshape(elev.shape)
@@ -65,7 +65,7 @@ class HeightAboveDrainageCalculator(Component):
 
     """
 
-    _name = "HeightAboveDrainage"
+    _name = "HeightAboveDrainageCalculator"
 
     _unit_agnostic = True
 

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -83,6 +83,14 @@ class HeightAboveDrainageCalculator(Component):
     _unit_agnostic = True
 
     _info = {
+        "channel__mask": {
+            "dtype": np.uint8,
+            "intent": "in",
+            "optional": True,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Logical map of at which grid nodes channels are present",
+        },
         "flow__receiver_node": {
             "dtype": int,
             "intent": "in",

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -127,6 +127,13 @@ class HeightAboveDrainage(Component):
 
         def run_one_step(self):
 
+            self_draining_nodes = sum(self._receivers == np.arange(self._grid.number_of_nodes))
+            if self_draining_nodes != len(self._grid.boundary_nodes):
+                warn(
+                "Pits detected in the flow directions supplied. "
+                "Pits will be treated as drainage nodes."
+                )
+
             self._downstream_drainage_id[:] = 0
             is_drainage_node = self._channel_mask
             is_drainage_node[self._grid.open_boundary_nodes] = 1

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Landlab component to calculate height above nearest drainage."""
+from warnings import warn
+
+import numpy as np
+
+from landlab import Component
+
+
+class HeightAboveDrainage(Component):
+    """
+    References
+    ----------
+    **Required Software Citation(s) Specific to this Component**
+
+    None Listed
+
+    **Additional References**
+
+    Nobre, A. D., Cuartas, L. A., Hodnett, M., Rennó, C. D., Rodrigues, G.,
+    Silveira, A., et al. (2011). Height Above the Nearest Drainage – a
+    hydrologically relevant new terrain model. Journal of Hydrology, 404(1),
+    13–29. https://doi.org/10.1016/j.jhydrol.2011.03.051
+
+    """
+
+    _name = "HeightAboveDrainage"
+
+    _unit_agnostic = True
+
+    _info = {
+        "channel__mask": {
+            "dtype": np.uint8,
+            "intent": "in",
+            "optional": True,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Logical map of at which grid nodes channels are present",
+        },
+        "flow__link_to_receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "ID of link downstream of each node, which carries the discharge",
+        },
+        "flow__receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array of receivers (node that receives flow from current node)",
+        },
+        "flow__upstream_node_order": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array containing downstream-to-upstream ordered list of node IDs",
+        },
+        "topographic__elevation": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Land surface topographic elevation",
+        },
+        "height_above_drainage__elevation": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Elevation above the nearest channel node",
+        },
+        "downstream_drainage__node": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "node array of nearst drainage node ID",
+        },
+    }
+
+    def __init__(self, grid, channel__mask):
+
+        super().__init__(grid)
+
+        if grid.at_node["flow__receiver_node"].size != grid.size("node"):
+            msg = (
+                "A route-to-multiple flow director has been "
+                "run on this grid. The landlab development team has not "
+                "verified that HeightAboveDrainage is compatible with "
+                "route-to-multiple methods. Please open a GitHub Issue "
+                "to start this process."
+            )
+            raise NotImplementedError(msg)
+
+        if channel__mask is None:
+            raise ValueError(
+                "No channel mask supplied. "
+                "A channel mask is needed "
+                "to determine nearest drainage."
+            )
+
+        self._grid = grid
+        self._channel_mask = channel__mask
+        self._elev = grid.at_node["topographic__elevation"]
+        self._receivers = grid.at_node["flow__receiver_node"]
+        self._downstream_drainage_id = grid.at_node["downstream_drainage__node"]
+        self._hand = grid.at_node["height_above_drainage__elevation"]
+
+
+        @property
+        def channel_mask(self):
+            return self._channel_mask
+
+        @channel_mask.setter
+        def channel_mask(self,new_val):
+            self._channel_mask = new_val
+
+
+        def run_one_step(self):
+
+            self._downstream_drainage_id[:] = 0
+            is_drainage_node = self._channel_mask
+            is_drainage_node[self._grid.open_boundary_nodes] = 1
+
+            for i in range(self._grid.number_of_nodes):
+
+                if i == receivers[i] or is_drainage_node[i]: #started on a boundary, depression, or in channel
+                    self._downstream_drainage_id[i] = i
+
+                else:
+                    cur_node = i
+                    reached_drainage = False
+                    while not reached_drainage:
+                        downstream_id = self._receivers[cur_node]
+                        if is_drainage_node[downstream_id]:
+                            self._downstream_drainage_id[i] = downstream_id
+                            reached_drainage = True
+                        else:
+                            cur_node = downstream_id
+
+            nearest_drainage_elev = self._elev[self._downstream_drainage_id]
+            self._hand = self._elev-nearest_drainage_elev

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -83,14 +83,6 @@ class HeightAboveDrainageCalculator(Component):
     _unit_agnostic = True
 
     _info = {
-        "channel__mask": {
-            "dtype": np.uint8,
-            "intent": "in",
-            "optional": True,
-            "units": "-",
-            "mapping": "node",
-            "doc": "Logical map of at which grid nodes channels are present",
-        },
         "flow__receiver_node": {
             "dtype": int,
             "intent": "in",
@@ -126,7 +118,12 @@ class HeightAboveDrainageCalculator(Component):
     }
 
     def __init__(self, grid, channel__mask):
-
+        """
+        Parameters
+        ----------
+        grid : Landlab Model Grid instance, required
+        channel__mask : Logical map of at which grid nodes channels are present, required
+        """
         super().__init__(grid)
 
         if grid.at_node["flow__receiver_node"].size != grid.size("node"):

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -130,8 +130,10 @@ class HeightAboveDrainageCalculator(Component):
         """
         Parameters
         ----------
-        grid : Landlab Model Grid instance, required
-        channel__mask : Logical map of at which grid nodes channels are present, required
+        grid : ModelGrid
+            Landlab ModelGrid object
+        channel_mask : field name, array of uint8
+            Logical map of nodes where drainage is present
         """
         super().__init__(grid)
 
@@ -165,7 +167,7 @@ class HeightAboveDrainageCalculator(Component):
 
     @channel_mask.setter
     def channel_mask(self, new_val):
-        self._channel_mask = new_val
+        self._channel_mask = return_array_at_node(self._grid, new_val)
 
     def run_one_step(self):
 

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -8,7 +8,7 @@ from warnings import warn
 import numpy as np
 
 from landlab import Component
-
+from landlab.utils import return_array_at_node
 
 class HeightAboveDrainageCalculator(Component):
     """
@@ -54,7 +54,7 @@ class HeightAboveDrainageCalculator(Component):
        [ 0.,  0.,  0.,  0.,  0.],
        [ 0.,  0.,  0.,  0.,  0.]])
 
-    >>> hd = HeightAboveDrainageCalculator(mg, channel__mask)
+    >>> hd = HeightAboveDrainageCalculator(mg, channel_mask=channel__mask)
     >>> hd.run_one_step()
 
     >>> mg.at_node["height_above_drainage__elevation"].reshape(elev.shape)  # doctest: +NORMALIZE_WHITESPACE
@@ -125,7 +125,7 @@ class HeightAboveDrainageCalculator(Component):
         },
     }
 
-    def __init__(self, grid, channel__mask):
+    def __init__(self, grid, channel_mask = "channel__mask"):
         """
         Parameters
         ----------
@@ -145,7 +145,7 @@ class HeightAboveDrainageCalculator(Component):
             raise NotImplementedError(msg)
 
         self._grid = grid
-        self._channel_mask = channel__mask
+        self._channel_mask = return_array_at_node(self._grid, channel_mask)
         self._elev = grid.at_node["topographic__elevation"]
         self._receivers = grid.at_node["flow__receiver_node"]
         self._node_order = grid.at_node["flow__upstream_node_order"]

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -86,7 +86,7 @@ class HeightAboveDrainageCalculator(Component):
         "channel__mask": {
             "dtype": np.uint8,
             "intent": "in",
-            "optional": False,
+            "optional": True,
             "units": "-",
             "mapping": "node",
             "doc": "Logical map of at which grid nodes channels are present",

--- a/landlab/components/hand_calculator/hand_calculator.py
+++ b/landlab/components/hand_calculator/hand_calculator.py
@@ -7,17 +7,17 @@ import numpy as np
 from landlab import Component
 
 
-class HeightAboveDrainage(Component):
+class HeightAboveDrainageCalculator(Component):
     """
     Calculate the elevation difference between each node and its nearest
     drainage node in a DEM.
 
     This component implements the method described by Nobre et al (2011). A
     single direction flow director (D8 or steepest descent) must be run prior
-    to HeightAboveDrainage to supply the flow directions. This component does
-    not fill depressions in a DEM, instead it treats them as drainage nodes.
+    to HeightAboveDrainageCalculator to supply the flow directions. This component does
+    not fill depressions in a DEM, but rather it treats them as drainage nodes.
     For best results, please run one of the available pit filling components
-    prior to HeightAboveDrainage.
+    prior to HeightAboveDrainageCalculator.
 
     Examples
     --------
@@ -26,12 +26,12 @@ class HeightAboveDrainage(Component):
     >>> from numpy.testing import assert_equal
 
     >>> from landlab import RasterModelGrid
-    >>> from landlab.components import HeightAboveDrainage, FlowAccumulator
+    >>> from landlab.components import HeightAboveDrainageCalculator, FlowAccumulator
 
-    >>> mg = RasterModelGrid((5, 4))
+    >>> mg = RasterModelGrid((4, 5))
     >>> z = mg.add_zeros("topographic__elevation", at="node")
-    >>> mg.set_status_at_node_on_edges(right=grid.BC_NODE_IS_CLOSED, bottom=grid.BC_NODE_IS_FIXED_VALUE, \
-                                  left=grid.BC_NODE_IS_CLOSED, top=grid.BC_NODE_IS_CLOSED)
+    >>> mg.set_status_at_node_on_edges(right=mg.BC_NODE_IS_CLOSED, bottom=mg.BC_NODE_IS_FIXED_VALUE, \
+                                  left=mg.BC_NODE_IS_CLOSED, top=mg.BC_NODE_IS_CLOSED)
     >>> elev = np.array([[2,1,0,1,2],[3,2,1,2,3],[4,3,2,3,4],[5,4,4,4,5]])
     >>> elev
     >>> z[:] = elev.reshape(len(z))
@@ -103,7 +103,7 @@ class HeightAboveDrainage(Component):
             "doc": "Elevation above the nearest channel node",
         },
         "downstream_drainage__node": {
-            "dtype": float,
+            "dtype": int,
             "intent": "out",
             "optional": False,
             "units": "-",

--- a/tests/components/hand_calculator/test_hand.py
+++ b/tests/components/hand_calculator/test_hand.py
@@ -3,7 +3,7 @@ import pytest
 from numpy.testing import assert_equal
 
 from landlab import FieldError, RasterModelGrid
-from landlab.components import HeightAboveDrainage, FlowAccumulator
+from landlab.components import HeightAboveDrainageCalculator, FlowAccumulator
 
 
 def test_route_to_multiple_error_raised():
@@ -16,7 +16,7 @@ def test_route_to_multiple_error_raised():
     channel__mask = mg.zeros(at="node")
 
     with pytest.raises(NotImplementedError):
-        HeightAboveDrainage(mg, channel__mask)
+        HeightAboveDrainageCalculator(mg, channel__mask)
 
 def test_warn_drainage_pits():
     mg = RasterModelGrid((4, 4))
@@ -29,7 +29,7 @@ def test_warn_drainage_pits():
 
     channel__mask = mg.zeros(at="node")
     channel__mask[[2,6]] = 1
-    hd = HeightAboveDrainage(mg, channel__mask)
+    hd = HeightAboveDrainageCalculator(mg, channel__mask)
 
     with pytest.warns(UserWarning):
         hd.run_one_step()

--- a/tests/components/hand_calculator/test_hand.py
+++ b/tests/components/hand_calculator/test_hand.py
@@ -16,7 +16,7 @@ def test_route_to_multiple_error_raised():
     channel__mask = mg.zeros(at="node")
 
     with pytest.raises(NotImplementedError):
-        HeightAboveDrainageCalculator(mg, channel__mask)
+        HeightAboveDrainageCalculator(mg, channel_mask=channel__mask)
 
 def test_warn_drainage_pits():
     mg = RasterModelGrid((4, 4))
@@ -29,7 +29,7 @@ def test_warn_drainage_pits():
 
     channel__mask = mg.zeros(at="node")
     channel__mask[[2,6]] = 1
-    hd = HeightAboveDrainageCalculator(mg, channel__mask)
+    hd = HeightAboveDrainageCalculator(mg, channel_mask=channel__mask)
 
     with pytest.warns(UserWarning):
         hd.run_one_step()

--- a/tests/components/hand_calculator/test_hand.py
+++ b/tests/components/hand_calculator/test_hand.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from landlab import FieldError, RasterModelGrid
+from landlab.components import HeightAboveDrainage, FlowAccumulator
+
+
+def test_route_to_multiple_error_raised():
+    mg = RasterModelGrid((10, 10))
+    z = mg.add_zeros("topographic__elevation", at="node")
+    z += mg.x_of_node + mg.y_of_node
+    fa = FlowAccumulator(mg, flow_director="MFD")
+    fa.run_one_step()
+
+    channel__mask = mg.zeros(at="node")
+
+    with pytest.raises(NotImplementedError):
+        HeightAboveDrainage(mg, channel__mask)
+
+def test_warn_drainage_pits():
+    mg = RasterModelGrid((4, 4))
+    z = mg.add_zeros("topographic__elevation", at="node")
+    elev = np.array([[2,1,1,2],[3,2,2,3],[4,1,3,4],[5,3,4,4]])
+    z[:] = elev.reshape(len(z))
+
+    fa = FlowAccumulator(mg, flow_director="D8")
+    fa.run_one_step()
+
+    channel__mask = mg.zeros(at="node")
+    channel__mask[[2,6]] = 1
+    hd = HeightAboveDrainage(mg, channel__mask)
+
+    with pytest.warns(UserWarning):
+        hd.run_one_step()

--- a/tests/components/hand_calculator/test_hand.py
+++ b/tests/components/hand_calculator/test_hand.py
@@ -1,8 +1,7 @@
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
-from landlab import FieldError, RasterModelGrid
+from landlab import RasterModelGrid
 from landlab.components import HeightAboveDrainageCalculator, FlowAccumulator
 
 
@@ -18,17 +17,18 @@ def test_route_to_multiple_error_raised():
     with pytest.raises(NotImplementedError):
         HeightAboveDrainageCalculator(mg, channel_mask=channel__mask)
 
+
 def test_warn_drainage_pits():
     mg = RasterModelGrid((4, 4))
     z = mg.add_zeros("topographic__elevation", at="node")
-    elev = np.array([[2,1,1,2],[3,2,2,3],[4,1,3,4],[5,3,4,4]])
+    elev = np.array([[2, 1, 1, 2], [3, 2, 2, 3], [4, 1, 3, 4], [5, 3, 4, 4]])
     z[:] = elev.reshape(len(z))
 
     fa = FlowAccumulator(mg, flow_director="D8")
     fa.run_one_step()
 
     channel__mask = mg.zeros(at="node")
-    channel__mask[[2,6]] = 1
+    channel__mask[[2, 6]] = 1
     hd = HeightAboveDrainageCalculator(mg, channel_mask=channel__mask)
 
     with pytest.warns(UserWarning):


### PR DESCRIPTION
Addressing the need I described in #1204, this PR includes a new component that calculates the height of every node above the nearest drainage node (the union of nodes specified with a channel mask and open boundary nodes). 