### PR TITLE
Add callback function to GroundwaterDupuitPercolator

### DIFF
--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -577,7 +577,7 @@ class GroundwaterDupuitPercolator(Component):
                 "water table above elevation surface. "
                 "Setting water table elevation here to "
                 "elevation surface"
-                )
+            )
             self._wtable[self._wtable > self._elev] = self._elev[
                 self._wtable > self._elev
             ]
@@ -660,7 +660,7 @@ class GroundwaterDupuitPercolator(Component):
                 "water table above elevation surface. "
                 "Setting water table elevation here to "
                 "elevation surface"
-                )
+            )
             self._wtable[self._wtable > self._elev] = self._elev[
                 self._wtable > self._elev
             ]
@@ -726,13 +726,12 @@ class GroundwaterDupuitPercolator(Component):
             self._dhdt[:] = (1 / self._n) * (self._recharge - self._qs - dqdx)
 
             # calculate criteria for timestep
-            c1 = hlink>0
             self._dt_vn = self._vn_coefficient * min(
-                self._n_link[c1] * self._grid.length_of_link[c1] ** 2 / (4 * self._K[c1] * hlink[c1])
+                self._n_link * self._grid.length_of_link ** 2 / (4 * self._K * hlink)
             )
-            c2 = self._vel>0
+
             self._dt_courant = self._courant_coefficient * min(
-                self._grid.length_of_link[c2] / abs(self._vel[c2] / self._n_link[c2])
+                self._grid.length_of_link / abs(self._vel / self._n_link)
             )
             dt_stability = min(self._dt_courant, self._dt_vn)
             substep_dt = min([dt_stability, remaining_time])

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -4,6 +4,7 @@
 @author: G Tucker, D Litwin, K Barnhart
 """
 from warnings import warn
+
 import numpy as np
 
 from landlab import Component, LinkStatus

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -287,7 +287,7 @@ class GroundwaterDupuitPercolator(Component):
         regularization_f=1e-2,
         courant_coefficient=0.5,
         vn_coefficient=0.8,
-        callback_fun=None,
+        callback_fun=lambda *args, **kwargs: None,
     ):
         """
         Parameters
@@ -326,6 +326,14 @@ class GroundwaterDupuitPercolator(Component):
             This parameter is only used with ``run_with_adaptive_time_step_solver``
             and must be greater than zero.
             Default = 0.8
+        callback_fun: function(grid, substep_dt)
+            Optional function that will be executed at the end of each sub-timestep
+            in the run_with_adaptive_time_step_solver method. Intended purpose
+            is to write output not otherwise visible outside of the method call.
+            Arguments:
+                grid: the ModelGrid instance used by GroundwaterDupuitPercolator
+                substep_dt: the length of the current substep determined internally
+                by run_with_adaptive_time_step_solver to meet stability criteria.
         """
         super().__init__(grid)
 
@@ -367,6 +375,7 @@ class GroundwaterDupuitPercolator(Component):
         self.courant_coefficient = courant_coefficient
         self.vn_coefficient = vn_coefficient
 
+        # set callback function
         self._callback_fun = callback_fun
 
     @property

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -327,7 +327,7 @@ class GroundwaterDupuitPercolator(Component):
             This parameter is only used with ``run_with_adaptive_time_step_solver``
             and must be greater than zero.
             Default = 0.8
-        callback_fun: function(grid, substep_dt, **kwargs)
+        callback_fun: function(grid, substep_dt, \*\*kwargs)
             Optional function that will be executed at the end of each sub-timestep
             in the run_with_adaptive_time_step_solver method. Intended purpose
             is to write output not otherwise visible outside of the method call.

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -291,7 +291,7 @@ class GroundwaterDupuitPercolator(Component):
         vn_coefficient=0.8,
         callback_fun=lambda *args, **kwargs: None,
     ):
-        """
+        r"""
         Parameters
         ----------
         grid: ModelGrid

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -76,7 +76,7 @@ class GroundwaterDupuitPercolator(Component):
     >>> elev[:] = 5.0
     >>> gdp = GroundwaterDupuitPercolator(grid)
 
-    Run component forward. Note all time units in the model are in seconds.
+    Run component forward.
 
     >>> dt = 1E4
     >>> for i in range(100):
@@ -107,7 +107,8 @@ class GroundwaterDupuitPercolator(Component):
     >>> gdp = GroundwaterDupuitPercolator(grid, recharge_rate=1E-7)
     >>> fa = FlowAccumulator(grid, runoff_rate='surface_water__specific_discharge')
 
-    Advance timestep
+    Advance timestep. Default units are meters and seconds, though the component
+    is unit agnostic.
 
     >>> dt = 1E3
     >>> for i in range(1000):
@@ -149,7 +150,7 @@ class GroundwaterDupuitPercolator(Component):
     where :math:`n` is the drainable porosity.
 
     An explicit forward in time finite volume method is used to implement a
-    numerical solution. Flow discharge between neighboring nodes is calculated
+    numerical solution. Groundwater flow between neighboring nodes is calculated
     using the saturated thickness at the up-gradient node.
 
     References
@@ -158,7 +159,7 @@ class GroundwaterDupuitPercolator(Component):
 
     Litwin, D. G., Tucker, G.E., Barnhart, K. R., Harman, C. J. (2020).
     GroundwaterDupuitPercolator: A Landlab component for groundwater flow.
-    Journal of Open Source Software, 5(46), 1935, https://doi.org/10.21105/joss.01935
+    Journal of Open Source Software, 5(46), 1935.
 
     **Additional References**
 
@@ -567,7 +568,7 @@ class GroundwaterDupuitPercolator(Component):
 
         Parameters
         ----------
-        dt: float (time in seconds)
+        dt: float
             The imposed timestep.
         """
 
@@ -650,7 +651,7 @@ class GroundwaterDupuitPercolator(Component):
 
         Parameters
         ----------
-        dt: float (time in seconds)
+        dt: float
             The imposed timestep.
         """
 

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -320,8 +320,8 @@ class GroundwaterDupuitPercolator(Component):
             zero.
             Default = 0.5
         vn_coefficient: float (-)
-            The multiplying factor C for the condition dt >= C*dx^2/(4D),
-            where D = Kh/n is the diffusivity of the Boussinesq
+            The multiplying factor C for the condition :math:`dt >= C*dx^2/(4D)`,
+            where :math:`D = Kh/n` is the diffusivity of the Boussinesq
             equation. This arises from a von Neumann stability analysis of
             the Boussinesq equation when the hydraulic gradient is small.
             This parameter is only used with ``run_with_adaptive_time_step_solver``

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -287,6 +287,7 @@ class GroundwaterDupuitPercolator(Component):
         regularization_f=1e-2,
         courant_coefficient=0.5,
         vn_coefficient=0.8,
+        callback_fun=None,
     ):
         """
         Parameters
@@ -365,6 +366,8 @@ class GroundwaterDupuitPercolator(Component):
         # save courant_coefficient (and test)
         self.courant_coefficient = courant_coefficient
         self.vn_coefficient = vn_coefficient
+
+        self._callback_fun = callback_fun
 
     @property
     def courant_coefficient(self):
@@ -725,5 +728,7 @@ class GroundwaterDupuitPercolator(Component):
             # calculate the time remaining and advance count of substeps
             remaining_time -= substep_dt
             self._num_substeps += 1
+
+            self._callback_fun(self._grid, substep_dt)
 
         self._qsavg[:] = qs_cumulative / dt

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -159,7 +159,7 @@ class GroundwaterDupuitPercolator(Component):
 
     Litwin, D. G., Tucker, G.E., Barnhart, K. R., Harman, C. J. (2020).
     GroundwaterDupuitPercolator: A Landlab component for groundwater flow.
-    Journal of Open Source Software, 5(46), 1935.
+    Journal of Open Source Software, 5(46), 1935, https://doi.org/10.21105/joss.01935.
 
     **Additional References**
 
@@ -332,9 +332,9 @@ class GroundwaterDupuitPercolator(Component):
             in the run_with_adaptive_time_step_solver method. Intended purpose
             is to write output not otherwise visible outside of the method call.
             The function should have two required arguments:
-                grid: the ModelGrid instance used by GroundwaterDupuitPercolator
-                substep_dt: the length of the current substep determined internally
-                by run_with_adaptive_time_step_solver to meet stability criteria.
+            grid: the ModelGrid instance used by GroundwaterDupuitPercolator
+            substep_dt: the length of the current substep determined internally
+            by run_with_adaptive_time_step_solver to meet stability criteria.
         """
         super().__init__(grid)
 

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -326,11 +326,11 @@ class GroundwaterDupuitPercolator(Component):
             This parameter is only used with ``run_with_adaptive_time_step_solver``
             and must be greater than zero.
             Default = 0.8
-        callback_fun: function(grid, substep_dt)
+        callback_fun: function(grid, substep_dt, **kwargs)
             Optional function that will be executed at the end of each sub-timestep
             in the run_with_adaptive_time_step_solver method. Intended purpose
             is to write output not otherwise visible outside of the method call.
-            Arguments:
+            The function should have two required arguments:
                 grid: the ModelGrid instance used by GroundwaterDupuitPercolator
                 substep_dt: the length of the current substep determined internally
                 by run_with_adaptive_time_step_solver to meet stability criteria.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,5 +40,4 @@ ignore =
 	E203
 	E501
 	W503
-  W605 
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,5 @@ ignore =
 	E203
 	E501
 	W503
+  W605 
 max-line-length = 88

--- a/tests/components/groundwater/test_dupuit_percolator.py
+++ b/tests/components/groundwater/test_dupuit_percolator.py
@@ -345,10 +345,7 @@ def test_callback_func():
 
     # initialize groundwater model
     gdp = GroundwaterDupuitPercolator(
-        grid,
-        recharge_rate=0.0,
-        hydraulic_conductivity=0.0001,
-        callback_fun=test_fun,
+        grid, recharge_rate=0.0, hydraulic_conductivity=0.0001, callback_fun=test_fun,
     )
 
     # run groundawter model

--- a/tests/components/groundwater/test_dupuit_percolator.py
+++ b/tests/components/groundwater/test_dupuit_percolator.py
@@ -304,3 +304,57 @@ def test_k_func():
 
     gdp1.run_with_adaptive_time_step_solver(0)
     assert np.equal(0.005, gdp1.K).all()
+
+
+def test_callback_func():
+    """
+    Test the use of a callback function to return the storage and
+    substep durations while using the run_with_adaptive_time_step_solver
+    method.
+
+    Notes:
+    ----
+    Two tests here: make sure that the substeps sum to the global timestep,
+    and make sure that when recharge is 0.0, the total storage does not
+    increase during any of the substeps. See component documentation for
+    more detail on arguments for the callback_fun.
+    """
+
+    # make a function that writes storage and substep duration to
+    # externally defined lists
+    storage_subdt = []
+    subdt = []
+    def test_fun(grid,dt):
+        cores = grid.core_nodes
+        h = grid.at_node["aquifer__thickness"]
+        area = grid.cell_area_at_node
+        storage = np.sum(n*h[cores]*area[cores])
+
+        storage_subdt.append(storage)
+        subdt.append(dt)
+
+    #initialize grid
+    grid = RasterModelGrid((3, 3))
+    grid.set_closed_boundaries_at_grid_edges(True, True, False, True)
+    elev = grid.add_ones("topographic__elevation", at="node")
+    elev[3] = 0.1
+    grid.add_zeros("aquifer_base__elevation", at="node")
+    wt = grid.add_zeros("water_table__elevation", at="node")
+    wt[:] = elev
+
+    # initialize groundwater model
+    gdp = GroundwaterDupuitPercolator(
+        grid,
+        recharge_rate=0.0,
+        hydraulic_conductivity=0.0001,
+        callback_fun = test_fun,
+    )
+
+    # run groundawter model
+    gdp.run_with_adaptive_time_step_solver(1e5)
+
+    # assert that the water table does not increase during substeps
+    assert (np.diff(storage_subdt)<=0.0).all()
+
+    # assert that substeps sum to the global timestep
+    assert_almost_equal(1e5,sum(subdt))

--- a/tests/components/groundwater/test_dupuit_percolator.py
+++ b/tests/components/groundwater/test_dupuit_percolator.py
@@ -324,16 +324,17 @@ def test_callback_func():
     # externally defined lists
     storage_subdt = []
     subdt = []
-    def test_fun(grid,dt):
+
+    def test_fun(grid, dt, n=0.2):
         cores = grid.core_nodes
         h = grid.at_node["aquifer__thickness"]
         area = grid.cell_area_at_node
-        storage = np.sum(n*h[cores]*area[cores])
+        storage = np.sum(n * h[cores] * area[cores])
 
         storage_subdt.append(storage)
         subdt.append(dt)
 
-    #initialize grid
+    # initialize grid
     grid = RasterModelGrid((3, 3))
     grid.set_closed_boundaries_at_grid_edges(True, True, False, True)
     elev = grid.add_ones("topographic__elevation", at="node")
@@ -347,14 +348,14 @@ def test_callback_func():
         grid,
         recharge_rate=0.0,
         hydraulic_conductivity=0.0001,
-        callback_fun = test_fun,
+        callback_fun=test_fun,
     )
 
     # run groundawter model
     gdp.run_with_adaptive_time_step_solver(1e5)
 
     # assert that the water table does not increase during substeps
-    assert (np.diff(storage_subdt)<=0.0).all()
+    assert (np.diff(storage_subdt) <= 0.0).all()
 
     # assert that substeps sum to the global timestep
-    assert_almost_equal(1e5,sum(subdt))
+    assert_almost_equal(1e5, sum(subdt))


### PR DESCRIPTION
In my work I've found it useful to be able to get some information about the  state of the groundwater model during the intermediate steps taken by the adaptive timestep solver. In particular I am  using grid info to determine transient runoff generation patterns and develop storage-discharge relationships.

Here I've added the option for a user to supply a function that is executed every substep of the adaptive timestep solver.  It could append to a list outside of the model instance, print soemthing, write to a file, etc. The function supplied should have two required arguments, the grid and the substep duration, which I think should be sufficiently general for almost anything you would want to do as far as analysis and testing. 

There is an example of how I'm using this in the component tests. I suspect that some testing should happen in __init__ to make sure that the function supplied is of the right type and has the right arguments, but I didn't know how to go about this exactly. Any other ideas you have on this would be appreciated!
