### PR TITLE
Fix netcdf uint8 tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyshp
 scipy
 statsmodels
 pandas
-xarray
+xarray>=0.16

--- a/tests/io/netcdf/test_to_netcdf.py
+++ b/tests/io/netcdf/test_to_netcdf.py
@@ -30,16 +30,11 @@ def test_netcdf_write_uint8(tmpdir, format):
     grid.add_field("topographic__elevation", np.arange(12, dtype=np.uint8), at="node")
 
     with tmpdir.as_cwd():
-        if format != "NETCDF4":
-            with pytest.raises(RuntimeError):
-                to_netcdf(grid, "test.nc", format=format)
-        else:
-            to_netcdf(grid, "test.nc", format=format)
+        to_netcdf(grid, "test.nc", format=format)
 
-            assert_array_equal(
-                xr.open_dataset("test.nc")["at_node:topographic__elevation"],
-                grid.at_node["topographic__elevation"],
-            )
+        actual = xr.open_dataset("test.nc")["at_node:topographic__elevation"]
+        assert_array_equal(actual, grid.at_node["topographic__elevation"])
+        assert actual.dtype == np.uint8 if format == "NETCDF4" else np.int8
 
 
 @pytest.mark.parametrize("dtype", ("int32", "float32", "float64"))


### PR DESCRIPTION
The latest version of *xarray* (*v0.16*) is now able to write fields of type *uint8*. Previously, *xarray* would return a *RuntimeError* when writing variables of that type unless writing to *NETCDF4*. With *v0.16*, the variables are written without error but are written as *int8* (as before, this is only an issue with formats other than *NETCDF*).

This pull request updates the tests that assumed a *RuntimeError* would be raised.