### PR TITLE
Fix OverlandFlow notebook bug

### DIFF
--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -273,7 +273,7 @@ class OverlandFlow(Component):
         theta : float, optional
             Weighting factor from de Almeida et al., 2012.
         rainfall_intensity : float, optional
-            Rainfall intensity.
+            Rainfall intensity. Default is zero.
         steep_slopes : bool, optional
             Modify the algorithm to handle steeper slopes at the expense of
             speed. If model runs become unstable, consider setting to True.
@@ -292,7 +292,7 @@ class OverlandFlow(Component):
 
         self._g = g
         self._theta = theta
-        self._rainfall_intensity = rainfall_intensity
+        self.rainfall_intensity = rainfall_intensity
         self._steep_slopes = steep_slopes
 
         # Now setting up fields at the links...
@@ -370,6 +370,21 @@ class OverlandFlow(Component):
     def dt(self, dt):
         assert dt > 0
         self._dt = dt
+
+    @property
+    def rainfall_intensity(self):
+        """rainfall_intensity: the rainfall rate [m/s]
+
+        Must be positive.
+        """
+        return self._rainfall_intensity
+
+    @rainfall_intensity.setter
+    def rainfall_intensity(self, rainfall_intensity):
+        if rainfall_intensity >= 0:
+            self._rainfall_intensity = rainfall_intensity
+        else:
+            raise ValueError("Rainfall intensity must be positive")
 
     def calc_time_step(self):
         """Calculate time step.

--- a/notebooks/teaching/surface_water_hydrology_exercises/overland_flow_notebooks/hydrograph_class_notebook.ipynb
+++ b/notebooks/teaching/surface_water_hydrology_exercises/overland_flow_notebooks/hydrograph_class_notebook.ipynb
@@ -272,7 +272,7 @@
     "    else:  # elapsed time exceeds the storm duration, rainfall ceases.\n",
     "        of.rainfall_intensity = 0.0\n",
     "\n",
-    "    of.overland_flow()  # Generating overland flow based on the deAlmeida solution.\n",
+    "    of.run_one_step()  # Generating overland flow based on the deAlmeida solution.\n",
     "\n",
     "    ## Append time and discharge to their lists to save data and for plotting.\n",
     "    hydrograph_time.append(elapsed_time)\n",


### PR DESCRIPTION
Addresses bug identified by @kxwhipple on #1227 

The notebook at: notebooks/notebooks/teaching/surface_water_hydrology_exercises/overland_flow_notebooks/hydrograph_class_notebook.ipynb

set rainfall as OverlandFlow.rainfall_intensity = value. 

But in the migration to v2 I made many variables private, including rainfall intensity. 

This meant that the command in the notebook set a variable that was no longer used (OverlandFlow.rainfall_intesity rather than OverlandFlow._rainfall_intensity). Maybe there should be a test for this (since the notebook tests just enforce that they run without errors.... 

This PR makes a setter for this value, and enforces that the value should be zero or positive.  

Tagging @nicgaspar @jadams15 @gregtucker @mcflugen 

Also noting that the ESPIN is happening right now and many of these people are involved in instruction... And as a result may not respond quickly.

- [x] Someone else should run the notebook locally. I have done it, and it works for me. 