### PR TITLE
Fix doc bugs

### DIFF
--- a/docs/source/user_guide/grid.rst
+++ b/docs/source/user_guide/grid.rst
@@ -151,7 +151,7 @@ whose length is equal to the number of nodes in the grid.
 
 .. code-block:: python
 
-    z - mg.add_zeros("elevation", at="node")
+    z = mg.add_zeros("elevation", at="node")
 
 Here *z* is an array of zeros. We can verify that *z* has the same length as the number of nodes:
 
@@ -206,8 +206,8 @@ that prevents accidentally overwriting an existing field.
 .. code-block:: python
 
     import numpy as np
-    elevs_in - np.random.rand(mg.number_of_nodes)
-    mg.add_field("elevation", at="node", elevs_in, units="m", copy=True, clobber=False)
+    elevs_in = np.random.rand(mg.number_of_nodes)
+    mg.add_field("elevation", elevs_in, at="node", units="m", copy=True, clobber=True)
 
 Fields can store data at nodes, cells, links, faces, patches, junctions, and corners (though the
 latter two or three are very rarely, if ever, used). The grid element you select is
@@ -228,7 +228,7 @@ element type is provided:
 
 .. code-block:: python
 
-    veg - mg.add_ones("percent_vegetation", at="cell")
+    veg = mg.add_ones("percent_vegetation", at="cell")
     mg.at_cell.keys()
     ['percent_vegetation']
 

--- a/landlab/components/flow_accum/flow_accumulator.py
+++ b/landlab/components/flow_accum/flow_accumulator.py
@@ -158,6 +158,7 @@ class FlowAccumulator(Component):
 
     Third, we can import a FlowDirector component from Landlab and pass it to
     `flow_director`:
+
     >>> from landlab.components import FlowDirectorSteepest
     >>> fa = FlowAccumulator(
     ...      mg,


### PR DESCRIPTION
Was looking at the documentation for landlab and came across a few things that didn't seem quite right. 

1. In the `grid` [section of the user guide](https://landlab.readthedocs.io/en/master/user_guide/grid.html#adding-data-to-a-landlab-grid-element-using-fields) several `=` signs were displayed as `-`. The `add_field` function was shown with the inputs `value_array` and `at='node'` flipped. Also when written as `clobber=False` this would not work if the previous code block defining the field 'elevation' with 0s has been run. 

2. In the [FlowAccumulator documentation](https://landlab.readthedocs.io/en/master/reference/components/flow_accum.html#landlab.components.flow_accum.flow_accumulator.FlowAccumulator) it looked like one of the example code blocks from the docstring didn't render. I think it is because of a missing blank line, so I added one.

I assume it is okay to open a PR to the master branch as I didn't see an obvious 'dev' or 'develop' branch. But my apologies if this isn't quite the right way to open a PR for this project.

-Jay