### PR TITLE
add cython version of priority queue

### DIFF
--- a/landlab/utils/__init__.py
+++ b/landlab/utils/__init__.py
@@ -13,6 +13,7 @@ from .source_tracking_algorithm import (
     track_source,
 )
 from .stable_priority_queue import StablePriorityQueue
+from .cfuncs import StablePriorityQueueC
 from .watershed import (
     get_watershed_mask,
     get_watershed_masks,

--- a/landlab/utils/cfuncs.pyx
+++ b/landlab/utils/cfuncs.pyx
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import numpy as np
+cimport numpy as np
+cimport cython
+
+import heapq
+
+
+cdef double LARGE_ELEV = 9999999999.0
+
+
+cdef class StablePriorityQueueC:
+    """Implements a stable priority queue, that tracks insertion order; i.e.,
+    this is used to break ties.
+
+    See https://docs.python.org/2/library/heapq.html#priority-queue-implementation-notes
+    & https://www.sciencedirect.com/science/article/pii/S0098300413001337
+    """
+    cdef public list _pq
+    cdef dict _entry_finder
+    cdef float _REMOVED
+    cdef int _counter
+
+    def __init__(self):
+        self._pq = []  # list of entries as a heap
+        self._entry_finder = {}  # mapping of tasks to entries
+        self._REMOVED = float("inf")  # placeholder for a removed task
+        self._counter = 0  # unique sequence count
+
+    def add_task(self, task, priority=0):
+        """Add a new task or update the priority of an existing task."""
+        if task == self._REMOVED:
+            raise ValueError("StablePriorityQueue cannot accept tasks equal to INF!")
+        if task in self._entry_finder:
+            self.remove_task(task)
+        #count = next(self._counter)
+        self._counter += 1
+        entry = [priority, self._counter, task]
+        self._entry_finder[task] = entry
+        heapq.heappush(self._pq, entry)
+
+    def remove_task(self, task):
+        """Mark an existing task as _REMOVED.
+
+        Raise KeyError if not found.
+        """
+        entry = self._entry_finder.pop(task)
+        entry[-1] = self._REMOVED
+
+    def pop_task(self):
+        """Remove and return the lowest priority task.
+
+        Raise KeyError if empty.
+        """
+        while self._pq:
+            priority, count, task = heapq.heappop(self._pq)
+            #print("popped: ")
+            #print(priority, count, task)
+            if task != self._REMOVED:
+                del self._entry_finder[task]
+                return task
+        raise KeyError("pop from an empty priority queue")
+
+    def peek_at_task(self):
+        """Return the lowest priority task without removal.
+
+        Raise KeyError if empty.
+        """
+        counter = 0
+        while self._pq:
+            priority, count, task = self._pq[counter]
+            #print('trying to peek at:')
+            #print(priority, count, task)
+            if task != self._REMOVED:
+                return task
+            counter += 1
+        raise KeyError("peeked at an empty priority queue")
+
+    def tasks_currently_in_queue(self):
+        """Return array of nodes currently in the queue."""
+        mynodes = [
+            task for (priority, count, task) in self._pq if task != self._REMOVED
+        ]
+        return np.array(mynodes)

--- a/tests/utils/test_priority_queue_cython.py
+++ b/tests/utils/test_priority_queue_cython.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Fri Sep 18 16:10:56 2020
+
+@author: gtucker
+"""
+
+import numpy as np
+from landlab.utils import StablePriorityQueueC
+
+
+def test_stable_priority_queue_cython_implementation():
+    q = StablePriorityQueueC()
+    q.add_task('b', priority=2)
+    q.add_task('a', priority=1)
+    q.add_task(0, priority=0)
+    q.add_task('c', priority=2)
+    q.remove_task(0)
+    task = q.peek_at_task()
+    assert(task == 'b')
+    task = q.pop_task()
+    assert(task == 'a')
+    task = q.peek_at_task()
+    assert(task == 'b')
+    assert(np.all(q.tasks_currently_in_queue() == np.array(['b', 'c'])))
+    task = q.pop_task()
+    assert(task == 'b')


### PR DESCRIPTION
Adds a cythonized version of the StablePriorityQueue class created by @SiccarPoint. This one is called StablePriorityQueueC to differentiate it. The hope is that it increases performance of LakeMapperBarnes, and perhaps future uses of a PQ (note: there is also one implemented in CellLab; ultimately they should probably be merged).

Differences:
o Testing of "removed" entries uses != instead of "is not", because I believe use of nan as code for "REMOVED" should unconditionally pass the "is not" test.
o The peek method in StablePriorityQueue has the potential for an infinite loop if the first item was flagged as remove (I think the first bullet point kept it from being triggered in the tests). Modified it to use a counter to keep accessing the next item until a non-REMOVED one is found. However, I don't know whether this is the desired behavior? Alternative behavior would be to return None if the first item is REMOVED (in which case the while loop should not be needed...?) This required changing one of the test outcomes (I still don't understand why that test passed).
o Removed the tracking of tasks_ever_added, to prevent ballooning of memory usage.
o Replaced the use of an iterator for counting with a simple integer and increment.

@SiccarPoint can you take a quick look and see whether you think this does the trick?