### PR TITLE
add Wavefront OBJ output

### DIFF
--- a/docs/source/reference/io/index.rst
+++ b/docs/source/reference/io/index.rst
@@ -14,6 +14,7 @@ output to a file.
   native_landlab
   netcdf
   shapefile
+  obj
 
 Module contents
 ---------------

--- a/docs/source/reference/io/obj.rst
+++ b/docs/source/reference/io/obj.rst
@@ -1,0 +1,7 @@
+Output of Landlab raster- and hex-grid data in Wavefront OBJ format
+-------------------------------------------------------------------
+
+.. automodule:: landlab.io.obj
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/landlab/io/__init__.py
+++ b/landlab/io/__init__.py
@@ -13,12 +13,14 @@ from .esri_ascii import (
     write_esri_ascii,
 )
 from .shapefile import read_shapefile
+from .obj import write_obj
 
 __all__ = [
     "read_esri_ascii",
     "read_asc_header",
     "read_shapefile",
     "write_esri_ascii",
+    "write_obj",
     "MissingRequiredKeyError",
     "KeyTypeError",
     "DataSizeError",

--- a/landlab/io/obj.py
+++ b/landlab/io/obj.py
@@ -8,66 +8,58 @@ OBJ functions
 
     ~landlab.io.obj.write_obj
 """
-
 import os
+import pathlib
 
 
-def _write_nodes_as_vertices(file, grid, z):
-    """Write node (x,y,z) coordinates as OBJ vertices."""
-    for i in range(grid.number_of_nodes):
-        file.write(
-            "v "
-            + str(grid.x_of_node[i])
-            + " "
-            + str(grid.y_of_node[i])
-            + " "
-            + str(z[i])
-            + "\n"
-        )
+def _write_obj_vertices(file_like, xyz_at_vertex):
+    """Write node (x,y,z) coordinates as OBJ vertices.
+
+    Parameters
+    ----------
+    file_like : file-like
+        Opened file-like object to write vertices to.
+    xyz_at_vertex : array-like, shape *(n_vertices, 3)*
+        (x, y, z) values for each vertex.
+    """
+    for x, y, z in xyz_at_vertex:
+        print(f"v {x} {y} {z}", file=file_like)
 
 
-def _write_triangular_patches_as_faces(file, grid, z):
+def _write_triangles_as_obj_faces(file_like, vertices_at_face):
     """Write triangular patches as OBJ faces.
 
-    OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
-    for i in range(len(grid.nodes_at_patch)):
-        file.write(
-            "f "
-            + str(grid.nodes_at_patch[i, 0] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 1] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 2] + 1)
-            + "//\n"
-        )
+    OBJ format uses vertex/UVtexture/normal; latter two left blank here.
+
+    Parameters
+    ----------
+    file_like : file-like
+        Opened file-like object to write faces to.
+    vertices_at_face : array-like of int, shape *(n_faces, 3)*
+        Vertex ids for each triangle.
+    """
+    for vertex_0, vertex_1, vertex_2 in vertices_at_face:
+        print(f"f {vertex_0}// {vertex_1}// {vertex_2}//", file=file_like)
 
 
-def _write_quad_patches_as_triangular_faces(file, grid, z):
+def _write_quads_as_obj_faces(file_, vertices_at_face):
     """Write quad patches as OBJ (triangle) faces.
 
     Subdivide each patch into two triangles using vertices 0-1-2 (upper left)
     and 2-3-0 (lower right).
 
-    OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
-    for i in range(len(grid.nodes_at_patch)):
-        file.write(
-            "f "
-            + str(grid.nodes_at_patch[i, 0] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 1] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 2] + 1)
-            + "//\n"
-        )
-        file.write(
-            "f "
-            + str(grid.nodes_at_patch[i, 2] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 3] + 1)
-            + "// "
-            + str(grid.nodes_at_patch[i, 0] + 1)
-            + "//\n"
-        )
+    OBJ format uses vertex/UVtexture/normal; latter two left blank here.
+
+    Parameters
+    ----------
+    file_like : file-like
+        Opened file-like object to write faces to.
+    vertices_at_face : array-like of int, shape *(n_faces, 4)*
+        Vertex ids for each quadrilateral.
+    """
+    for vertex_0, vertex_1, vertex_2, vertex_3 in vertices_at_face:
+        print(f"f {vertex_0}// {vertex_1}// {vertex_2}//", file=file_)
+        print(f"f {vertex_2}// {vertex_3}// {vertex_0}//", file=file_)
 
 
 def _patches_are_triangles(grid):
@@ -85,55 +77,75 @@ def write_obj(path, grid, field_for_z="topographic__elevation", clobber=False):
 
     Parameters
     ----------
-    path : str
+    path : str, or file-like
         Path to output file.
     grid : Landlab grid object
         Landlab grid object that includes associated values.
-    clobber : boolean
+    field_for_z : str, optional
+        Name of a field to use for the *z*-values of the OBJ file.
+    clobber : boolean, optional
         If *path* exists, clobber the existing file, otherwise raise an
         exception.
 
+    Returns
+    -------
+    str or file-like
+        The input path used to write the OBJ file.
+
     Examples
     --------
-    >>> import numpy as np
-    >>> import os
-    >>> import tempfile
+    >>> import io
     >>> from landlab import HexModelGrid, RasterModelGrid
     >>> from landlab.io.obj import write_obj
 
     >>> grid = HexModelGrid((3, 2), spacing=2.)
     >>> z = grid.add_zeros("topographic__elevation", at="node")
     >>> z[3] = 1.0
-    >>> with tempfile.TemporaryDirectory() as tmpdirname:
-    ...     fname = os.path.join(tmpdirname, 'test_tri.obj')
-    ...     file = write_obj(fname, grid)
-    >>> print(os.path.basename(file))
-    test_tri.obj
 
-    >>> grid = RasterModelGrid((3, 3), xy_spacing=2.)
-    >>> z = grid.add_zeros("topographic__elevation", at="node")
-    >>> z[3] = 1.0
-    >>> with tempfile.TemporaryDirectory() as tmpdirname:
-    ...     fname = os.path.join(tmpdirname, 'test_quad.obj')
-    ...     file = write_obj(fname, grid)
-    >>> print(os.path.basename(file))
-    test_quad.obj
+    >>> obj_file = write_obj(io.StringIO(), grid)
+    >>> print(obj_file.getvalue())
+    # landlabgrid
+    #
+    g landlabgrid
+    v 1.0 0.0 0.0
+    v 3.0 0.0 0.0
+    v 0.0 1.732051 0.0
+    v 2.0 1.732051 1.0
+    v 4.0 1.732051 0.0
+    v 1.0 3.464102 0.0
+    v 3.0 3.464102 0.0
+    f 4// 1// 2//
+    f 4// 3// 1//
+    f 5// 4// 2//
+    f 6// 3// 4//
+    f 7// 4// 5//
+    f 7// 6// 4//
+    <BLANKLINE>
     """
-    if os.path.exists(path) and not clobber:
-        raise ValueError("file exists")
+    if not (_patches_are_triangles(grid) or _patches_are_quads(grid)):
+        raise TypeError("grid faces must be triangles or quads")
 
-    z = grid.at_node[field_for_z]
-    with open(path, "w") as f:
-        f.write("# landlabgrid\n")
-        f.write("#\n")
-        f.write("g landlabgrid\n")
-        _write_nodes_as_vertices(f, grid, z)
-        if _patches_are_triangles(grid):
-            _write_triangular_patches_as_faces(f, grid, z)
-        elif _patches_are_quads(grid):
-            _write_quad_patches_as_triangular_faces(f, grid, z)
-        else:
-            raise TypeError("grid faces must be triangles or quads")
-        f.close()
+    z_at_node = grid.at_node[field_for_z]
+
+    if isinstance(path, (str, pathlib.Path)):
+        if os.path.exists(path) and not clobber:
+            raise ValueError(f"file exists ({path})")
+
+        with open(path, "w") as fp:
+            _write_obj_to_filelike(fp, grid, z_at_node)
+    else:
+        _write_obj_to_filelike(path, grid, z_at_node)
 
     return path
+
+
+def _write_obj_to_filelike(file_like, grid, z_at_node):
+    file_like.write("# landlabgrid\n")
+    file_like.write("#\n")
+    file_like.write("g landlabgrid\n")
+
+    _write_obj_vertices(file_like, zip(grid.x_of_node, grid.y_of_node, z_at_node))
+    if _patches_are_triangles(grid):
+        _write_triangles_as_obj_faces(file_like, grid.nodes_at_patch + 1)
+    elif _patches_are_quads(grid):
+        _write_quads_as_obj_faces(file_like, grid.nodes_at_patch + 1)

--- a/landlab/io/obj.py
+++ b/landlab/io/obj.py
@@ -1,0 +1,110 @@
+#! /usr/bin/env python
+"""Write (x,y,z) data from a Landlab grid + 1 field to a Wavefront OBJ file.
+
+OBJ functions
++++++++++++++
+
+.. autosummary::
+
+    ~landlab.io.obj.write_obj
+"""
+
+import os
+
+
+def _write_nodes_as_vertices(file, grid, z):
+    """Write node (x,y,z) coordinates as OBJ vertices."""
+    for i in range(grid.number_of_nodes):
+        file.write('v ' + str(grid.x_of_node[i]) + ' '
+                   + str(grid.y_of_node[i]) + ' '
+                   + str(z[i]) + '\n')
+
+def _write_triangular_patches_as_faces(file, grid, z):
+    """Write triangular patches as OBJ faces.
+
+    OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
+    for i in range(len(grid.nodes_at_patch)):
+        file.write('f ' + str(grid.nodes_at_patch[i,0] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,1] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,2] + 1) + '//\n')
+
+def _write_quad_patches_as_triangular_faces(file, grid, z):
+    """Write quad patches as OBJ (triangle) faces.
+
+    Subdivide each patch into two triangles using vertices 0-1-2 (upper left)
+    and 2-3-0 (lower right).
+
+    OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
+    for i in range(len(grid.nodes_at_patch)):
+        file.write('f ' + str(grid.nodes_at_patch[i,0] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,1] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,2] + 1) + '//\n')
+        file.write('f ' + str(grid.nodes_at_patch[i,2] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,3] + 1) + '// '
+                   + str(grid.nodes_at_patch[i,0] + 1) + '//\n')
+
+def _patches_are_triangles(grid):
+    """Returns True if patches have 3 nodes, False otherwise."""
+    return grid.nodes_at_patch.shape[1] == 3
+
+def _patches_are_quads(grid):
+    """Returns True if patches have 4 nodes, False otherwise."""
+    return grid.nodes_at_patch.shape[1] == 4
+
+def write_obj(path, grid, field_for_z='topographic__elevation', clobber=False):
+    """Write landlab grid and one field to Wavefront OBJ.
+
+    Parameters
+    ----------
+    path : str
+        Path to output file.
+    grid : Landlab grid object
+        Landlab grid object that includes associated values.
+    clobber : boolean
+        If *path* exists, clobber the existing file, otherwise raise an
+        exception.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import os
+    >>> import tempfile
+    >>> from landlab import HexModelGrid, RasterModelGrid
+    >>> from landlab.io.obj import write_obj
+
+    >>> grid = HexModelGrid((3, 2), spacing=2.)
+    >>> z = grid.add_zeros("topographic__elevation", at="node")
+    >>> z[3] = 1.0
+    >>> with tempfile.TemporaryDirectory() as tmpdirname:
+    ...     fname = os.path.join(tmpdirname, 'test_tri.obj')
+    ...     file = write_obj(fname, grid)
+    >>> print(os.path.basename(file))
+    test_tri.obj
+
+    >>> grid = RasterModelGrid((3, 3), xy_spacing=2.)
+    >>> z = grid.add_zeros("topographic__elevation", at="node")
+    >>> z[3] = 1.0
+    >>> with tempfile.TemporaryDirectory() as tmpdirname:
+    ...     fname = os.path.join(tmpdirname, 'test_quad.obj')
+    ...     file = write_obj(fname, grid)
+    >>> print(os.path.basename(file))
+    test_quad.obj
+    """
+    if os.path.exists(path) and not clobber:
+        raise ValueError("file exists")
+
+    z = grid.at_node[field_for_z]
+    with open(path, 'w') as f:
+        f.write('# landlabgrid\n')
+        f.write('#\n')
+        f.write('g landlabgrid\n')
+        _write_nodes_as_vertices(f, grid, z)
+        if _patches_are_triangles(grid):
+            _write_triangular_patches_as_faces(f, grid, z)
+        elif _patches_are_quads(grid):
+            _write_quad_patches_as_triangular_faces(f, grid, z)
+        else:
+            raise TypeError("grid faces must be triangles or quads")
+        f.close()
+
+    return path

--- a/landlab/io/obj.py
+++ b/landlab/io/obj.py
@@ -15,18 +15,32 @@ import os
 def _write_nodes_as_vertices(file, grid, z):
     """Write node (x,y,z) coordinates as OBJ vertices."""
     for i in range(grid.number_of_nodes):
-        file.write('v ' + str(grid.x_of_node[i]) + ' '
-                   + str(grid.y_of_node[i]) + ' '
-                   + str(z[i]) + '\n')
+        file.write(
+            "v "
+            + str(grid.x_of_node[i])
+            + " "
+            + str(grid.y_of_node[i])
+            + " "
+            + str(z[i])
+            + "\n"
+        )
+
 
 def _write_triangular_patches_as_faces(file, grid, z):
     """Write triangular patches as OBJ faces.
 
     OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
     for i in range(len(grid.nodes_at_patch)):
-        file.write('f ' + str(grid.nodes_at_patch[i,0] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,1] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,2] + 1) + '//\n')
+        file.write(
+            "f "
+            + str(grid.nodes_at_patch[i, 0] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 1] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 2] + 1)
+            + "//\n"
+        )
+
 
 def _write_quad_patches_as_triangular_faces(file, grid, z):
     """Write quad patches as OBJ (triangle) faces.
@@ -36,22 +50,37 @@ def _write_quad_patches_as_triangular_faces(file, grid, z):
 
     OBJ format uses vertex/UVtexture/normal; latter two left blank here."""
     for i in range(len(grid.nodes_at_patch)):
-        file.write('f ' + str(grid.nodes_at_patch[i,0] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,1] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,2] + 1) + '//\n')
-        file.write('f ' + str(grid.nodes_at_patch[i,2] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,3] + 1) + '// '
-                   + str(grid.nodes_at_patch[i,0] + 1) + '//\n')
+        file.write(
+            "f "
+            + str(grid.nodes_at_patch[i, 0] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 1] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 2] + 1)
+            + "//\n"
+        )
+        file.write(
+            "f "
+            + str(grid.nodes_at_patch[i, 2] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 3] + 1)
+            + "// "
+            + str(grid.nodes_at_patch[i, 0] + 1)
+            + "//\n"
+        )
+
 
 def _patches_are_triangles(grid):
     """Returns True if patches have 3 nodes, False otherwise."""
     return grid.nodes_at_patch.shape[1] == 3
 
+
 def _patches_are_quads(grid):
     """Returns True if patches have 4 nodes, False otherwise."""
     return grid.nodes_at_patch.shape[1] == 4
 
-def write_obj(path, grid, field_for_z='topographic__elevation', clobber=False):
+
+def write_obj(path, grid, field_for_z="topographic__elevation", clobber=False):
     """Write landlab grid and one field to Wavefront OBJ.
 
     Parameters
@@ -94,10 +123,10 @@ def write_obj(path, grid, field_for_z='topographic__elevation', clobber=False):
         raise ValueError("file exists")
 
     z = grid.at_node[field_for_z]
-    with open(path, 'w') as f:
-        f.write('# landlabgrid\n')
-        f.write('#\n')
-        f.write('g landlabgrid\n')
+    with open(path, "w") as f:
+        f.write("# landlabgrid\n")
+        f.write("#\n")
+        f.write("g landlabgrid\n")
         _write_nodes_as_vertices(f, grid, z)
         if _patches_are_triangles(grid):
             _write_triangular_patches_as_faces(f, grid, z)

--- a/tests/io/test_write_obj.py
+++ b/tests/io/test_write_obj.py
@@ -49,12 +49,6 @@ f 5// 6// 9//
 """
 
 
-def remove_newline_chars(mystr):
-    mystr = mystr.replace("\n", "")
-    mystr = mystr.replace("\r", "")
-    return mystr
-
-
 def test_write_to_filelike(tmpdir):
     grid = RasterModelGrid((3, 3), xy_spacing=2.0)
     z = grid.add_zeros("topographic__elevation", at="node")

--- a/tests/io/test_write_obj.py
+++ b/tests/io/test_write_obj.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""unit tests for landlab.io.obj module"""
+
+import os
+import tempfile
+from landlab import HexModelGrid, RasterModelGrid
+from landlab.io import write_obj
+
+LITTLE_HEX_OBJ = """# landlabgrid
+#
+g landlabgrid
+v 1.0 0.0 0.0
+v 3.0 0.0 0.0
+v 0.0 1.732051 0.0
+v 2.0 1.732051 1.0
+v 4.0 1.732051 0.0
+v 1.0 3.464102 0.0
+v 3.0 3.464102 0.0
+f 4// 1// 2//
+f 4// 3// 1//
+f 5// 4// 2//
+f 6// 3// 4//
+f 7// 4// 5//
+f 7// 6// 4//
+"""
+
+LITTLE_RAST_OBJ = """# landlabgrid
+#
+g landlabgrid
+v 0.0 0.0 0.0
+v 2.0 0.0 0.0
+v 4.0 0.0 0.0
+v 0.0 2.0 0.0
+v 2.0 2.0 1.0
+v 4.0 2.0 0.0
+v 0.0 4.0 0.0
+v 2.0 4.0 0.0
+v 4.0 4.0 0.0
+f 5// 4// 1//
+f 1// 2// 5//
+f 6// 5// 2//
+f 2// 3// 6//
+f 8// 7// 4//
+f 4// 5// 8//
+f 9// 8// 5//
+f 5// 6// 9//
+"""
+
+
+def remove_newline_chars(mystr):
+    mystr = mystr.replace("\n", "")
+    mystr = mystr.replace("\r", "")
+    return mystr
+
+
+def test_write_obj():
+
+    grid = HexModelGrid((3, 2), spacing=2.0)
+    z = grid.add_zeros("topographic__elevation", at="node")
+    z[3] = 1.0
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        fname = os.path.join(tmpdirname, "test_tri.obj")
+        write_obj(fname, grid)
+        file = open(fname)
+        contents = file.read()
+        contents = remove_newline_chars(contents)
+        assert contents == remove_newline_chars(LITTLE_HEX_OBJ)
+
+    grid = RasterModelGrid((3, 3), xy_spacing=2.0)
+    z = grid.add_zeros("topographic__elevation", at="node")
+    z[4] = 1.0
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        fname = os.path.join(tmpdirname, "test_quad.obj")
+        write_obj(fname, grid)
+        file = open(fname)
+        contents = file.read()
+        contents = remove_newline_chars(contents)
+        assert contents == remove_newline_chars(LITTLE_RAST_OBJ)


### PR DESCRIPTION
Simple utility to write a Landlab grid and 1 field (default `topographic__elevation`) to a Wavefront OBJ file, for import into visualization programs like Blender.