### PR TITLE
Build and test landlab with Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -284,9 +284,15 @@ def wrap_as_bmi(cls):
             """Names of the input exchange items."""
             return self._input_var_names
 
+        def get_input_item_count(self):
+            return len(self._input_var_names)
+
         def get_output_var_names(self):
             """Names of the output exchange items."""
             return self._output_var_names
+
+        def get_output_item_count(self):
+            return len(self._output_var_names)
 
         def get_current_time(self):
             """Current component time."""
@@ -508,6 +514,12 @@ def wrap_as_bmi(cls):
                 return self._base.grid.nodes_at_patch
             elif grid == 1:
                 return self._base.grid.corners_at_cell
+
+        def get_grid_face_edges(self, grid):
+            if grid == 0:
+                return self._base.grid.links_at_patch
+            elif grid == 1:
+                return self._base.grid.faces_at_cell
 
         def get_grid_node_count(self, grid):
             if grid == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bmipy<1
+bmipy
 matplotlib
 netcdf4
 numpy


### PR DESCRIPTION
This pull request adds Python 3.9 (and drops Python 3.6) from our testing. To get this to work, I had to make a small change to landlab's bmi wrapper so that we could use the latest *bmipy*. Previously we had been requiring *bmipy<2*, which wasn't available for Python 3.9.