### PR TITLE
Add release and prerelease github actions

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   lint:
+    name: Check code format
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          black_args: ". --check"
+          args: ". --check"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,23 +1,22 @@
 name: Documentation
 
-on: [push, pull_request]
-# on:
-#     push:
-#         paths:
-#             - "docs/**"
-#             - "AUTHORS.rst"
-#             - "CHANGES.rst"
-#             - "CONTRIBUTING.rst"
-#             - "LICENSE.rst"
-#             - "README.rst"
-#     pull_request:
-#         paths:
-#             - "docs/**"
-#             - "AUTHORS.rst"
-#             - "CHANGES.rst"
-#             - "CONTRIBUTING.rst"
-#             - "LICENSE.rst"
-#             - "README.rst"
+on:
+    push:
+        paths:
+            - "docs/**"
+            - "AUTHORS.rst"
+            - "CHANGES.rst"
+            - "CONTRIBUTING.rst"
+            - "LICENSE.rst"
+            - "README.rst"
+    pull_request:
+        paths:
+            - "docs/**"
+            - "AUTHORS.rst"
+            - "CHANGES.rst"
+            - "CONTRIBUTING.rst"
+            - "LICENSE.rst"
+            - "README.rst"
 
 jobs:
     build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
     build:
+        name: Build documentation
         # We want to run on external PRs, but not on our own internal PRs as they'll be run
         # by the push to the branch. Without this if check, checks are duplicated since
         # internal PRs match both the push and pull_request events.

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   lint:
+    name: Check for lint
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,4 +1,4 @@
-name: PyPI
+name: TestPyPI
 
 on:
   push:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   build-and-publish:
-    name: Build and publish to PyPI
+    name: Build and publish to TestPyPI
     runs-on: ${{ matrix.os }}
 
     defaults:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,79 @@
+name: PyPI
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+[ab][0-9]*
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+  TWINE_REPOSITORY_URL: 'https://test.pypi.org/legacy/'
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: ubuntu-latest
+            platform: manylinux
+            python_versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+          - os: macos-latest
+            platform: macosx
+          - os: windows-latest
+            platform: win
+        exclude:
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Show conda installation info
+        run: |
+          conda info
+          conda list
+
+      - name: Install build environment
+        run: pip install twine wheel numpy cython
+
+      - name: Build macosx/win Python wheels
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        run: |
+          conda install mamba
+          mamba install --file=requirements.txt
+          python setup.py bdist_wheel
+
+      - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python setup.py sdist
+          twine upload --skip-existing dist/*.tar.gz
+
+      - name: Build manylinux Python wheels
+        if: matrix.os == 'ubuntu-latest'
+        uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+        with:
+          python-versions: ${{ matrix.python_versions }}
+          build-requirements: 'cython numpy'
+
+      - name: Upload distributions
+        run: twine upload --skip-existing dist/*-${{ matrix.platform }}*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: PyPI
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+      - '!*[ab][0-9]*'
+
+
+env:
+  TWINE_USERNAME: __token__
+  TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: ubuntu-latest
+            platform: manylinux
+            python_versions: 'cp37-cp37m cp38-cp38 cp39-cp39'
+          - os: macos-latest
+            platform: macosx
+          - os: windows-latest
+            platform: win
+        exclude:
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.9
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Show conda installation info
+        run: |
+          conda info
+          conda list
+
+      - name: Install build environment
+        run: pip install twine wheel numpy cython
+
+      - name: Build macosx/win Python wheels
+        if: matrix.os == 'macos-latest' || matrix.os == 'windows-latest'
+        run: |
+          conda install mamba
+          mamba install --file=requirements.txt
+          python setup.py bdist_wheel
+
+      - name: Build source distribution
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          python setup.py sdist
+          twine upload --skip-existing dist/*.tar.gz
+
+      - name: Build manylinux Python wheels
+        if: matrix.os == 'ubuntu-latest'
+        uses: RalfG/python-wheels-manylinux-build@v0.3.3-manylinux2010_x86_64
+        with:
+          python-versions: ${{ matrix.python_versions }}
+          build-requirements: 'cython numpy'
+
+      - name: Upload distributions
+        run: twine upload --skip-existing dist/*-${{ matrix.platform }}*.whl

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
+    name: Check notebooks
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-ssame: Test
+name: Test
 
 on: [push, pull_request]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build-and-test:
+    name: Run the tests
     # We want to run on external PRs, but not on our own internal PRs as they'll be run
     # by the push to the branch. Without this if check, checks are duplicated since
     # internal PRs match both the push and pull_request events.

--- a/notebooks/test_notebooks.py
+++ b/notebooks/test_notebooks.py
@@ -75,7 +75,7 @@ def _notebook_run(path_to_notebook):
     except subprocess.CalledProcessError:
         raise
     else:
-        nb = nbformat.read(unique_name, nbformat.current_nbformat, encoding="UTF-8")
+        nb = nbformat.read(unique_name, nbformat.current_nbformat)
     finally:
         try:
             unique_name.unlink()


### PR DESCRIPTION
This pull request adds actions for publishing landlab releases to PyPI and prereleases TestPyPI. The release action is run if a tag is pushed that looks like *v.X.Y.Z* and the preprelease action is run if the tag looks like *vX.Y.XbN*. In both cases, a source distribution and wheels for all the platforms and Python 3.[789] will be built and uploaded.