### PR TITLE
Update install instructions

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -1,7 +1,0 @@
-ignore-patterns:
-  - ez_setup.py
-  - setup.py
-ignore-paths:
-  - docs
-strictness: veryhigh
-doc-warnings: True

--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,4 @@ docs: ## generate Sphinx HTML documentation, including API docs and link check
 	$(BROWSER) docs/build/html/index.html
 
 install: clean ## install the package to the active Python's site-packages
-	python setup.py develop
+	pip install -e .

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ the following commands:
 
     $ conda env create --file=environment-dev.yml
     $ conda activate landlab_dev
-    $ python setup.py develop
+    $ pip install -e .
 
 How do I verify I've installed Landlab correctly?
 -------------------------------------------------

--- a/README.rst
+++ b/README.rst
@@ -65,8 +65,7 @@ We distribute through both conda-forge and pip.
 Landlab 2.0
 ```````````
 
-In late December 2019 Landlab switched to version 2.0-beta. Landlab will be
-in 2.0-beta until the Landlab 2.0 publication is finalized. Landlab dropped
+In April 2020 Landlab switched to version 2.0. Landlab dropped
 support of Python 2.7 with this transition.
 
 Supported Python Versions
@@ -74,8 +73,7 @@ Supported Python Versions
 
 Landlab supports Python versions >= 3.6. Landlab distributes pre-packaged
 binaries through `conda-forge <https://anaconda.org/conda-forge/landlab>`_
-and `PyPI <https://pypi.org/project/landlab/>`_ for versions 3.6 and 3.7
-(3.8 coming soon). 
+and `PyPI <https://pypi.org/project/landlab/>`_ for versions 3.6 through 3.9.
 
 Conda Environment with Pre-packaged Binary Distribution
 ```````````````````````````````````````````````````````
@@ -105,7 +103,7 @@ which describe cloning the source code, creating a conda environment for
 development, compiling, and testing the code.
 
 In short, clone the repository, navigate to the top level directory, and
-the following commands:
+run the following commands:
 
 .. code-block:: bash
 
@@ -117,8 +115,8 @@ How do I verify I've installed Landlab correctly?
 -------------------------------------------------
 
 Landlab uses pytest to discover and run tests. These include docstring tests
-located within the core source code (``landlab\landlab`` directory) and unit
-tests located within the ``landlab\tests`` directory. Presuming you have used a
+located within the core source code (``landlab/landlab`` directory) and unit
+tests located within the ``landlab/tests`` directory. Presuming you have used a
 source code installation with the above conda environment, you will be able to
 test your install with
 

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,6 @@
 .. image:: https://coveralls.io/repos/landlab/landlab/badge.png
     :target: https://coveralls.io/r/landlab/landlab
 
-.. image:: https://landscape.io/github/landlab/landlab/master/landscape.svg
-    :target: https://landscape.io/github/landlab/landlab/master
-
 .. image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/welcome.ipynb
 

--- a/README.rst
+++ b/README.rst
@@ -4,13 +4,17 @@
 .. image:: https://readthedocs.org/projects/landlab/badge/?version=latest
     :target: https://readthedocs.org/projects/landlab/?badge=latest
 
-.. image:: https://github.com/landlab/landlab/workflows/Build/Test%20CI/badge.svg
+.. image:: https://github.com/landlab/landlab/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/landlab/landlab/actions/workflows/test.yml
 
-.. image:: https://github.com/landlab/landlab/workflows/Flake8/badge.svg
+.. image:: https://github.com/landlab/landlab/actions/workflows/flake8.yml/badge.svg
+    :target: https://github.com/landlab/landlab/actions/workflows/flake8.yml
 
-.. image:: https://github.com/landlab/landlab/workflows/Black/badge.svg
+.. image:: https://github.com/landlab/landlab/actions/workflows/black.yml/badge.svg
+    :target: https://github.com/landlab/landlab/actions/workflows/black.yml
 
-.. image:: https://github.com/landlab/landlab/workflows/Documentation/badge.svg
+.. image:: https://github.com/landlab/landlab/actions/workflows/docs.yml/badge.svg
+    :target: https://github.com/landlab/landlab/actions/workflows/docs.yml
 
 .. image:: https://coveralls.io/repos/landlab/landlab/badge.png
     :target: https://coveralls.io/r/landlab/landlab

--- a/docs/source/development/install/index.rst
+++ b/docs/source/development/install/index.rst
@@ -40,7 +40,7 @@ replacing with Anaconda is probably the more stress-free way to go.*
 *Either way, you'll need a working C++ compiler running alongside Python
 to be able to perform a full developer install. You'll see errors
 referring to* :ref:`Cython <cython>` *if you
-don't have working compiler when calling* ``python setup.py develop``
+don't have working compiler when calling* ``pip install -e .``
 *(see* :ref:`the developer install instructions <dev_install_install>` *).*
 
 Working with your local version of Landlab

--- a/docs/source/development/install/install.rst
+++ b/docs/source/development/install/install.rst
@@ -90,7 +90,7 @@ any changes you make to your copy of the code is seen by Python the
 
 .. code-block:: bash
 
-   $ python setup.py develop
+   $ pip install -e .
 
 Conda Environment Tips
 ----------------------
@@ -116,7 +116,7 @@ To uninstall your development version of Landlab (again from the root
 
 .. code-block:: bash
 
-   $ python setup.py develop -u
+   $ pip uninstall
 
 With Landlab uninstalled, you will no longer be able to import Landlab
 from outside the root folder of your working copy.

--- a/docs/source/development/install/installing_windows_compiler.rst
+++ b/docs/source/development/install/installing_windows_compiler.rst
@@ -26,7 +26,7 @@ until you attempt to perform the developer installation
 
 .. code-block:: bash
 
- $ python setup.py develop
+ $ pip install -e .
 
 If you have compiler issues, you will see an error message. On April 24, 2019
 on a clean install on Windows 10 this error message said: ::

--- a/docs/source/development/install/troubleshooting_install.rst
+++ b/docs/source/development/install/troubleshooting_install.rst
@@ -14,7 +14,7 @@ address this, re-run the following lines and then test the installation.
 .. code-block:: bash
 
    $ conda install --yes --file=requirements.txt
-   $ python setup.py develop
+   $ pip install -e .
 
 .. _what_do_if_cant_merge_pr:
 
@@ -70,7 +70,7 @@ again from the main Landlab local folder
 
 .. code-block:: bash
 
-   $ python setup.py develop
+   $ pip install -e .
 
 as described above in the main text. If this is happening when you call
 this install function rather than when you try to actually run some
@@ -80,7 +80,7 @@ I see errors about Cython when I try to *install* Landlab
 ---------------------------------------------------------
 
 If you see errors referring to Cython when you try to run
-``python setup.py develop``, it indicates you have a problem with your
+``pip install -e .``, it indicates you have a problem with your
 local compilers. This can happen both the first time you ever try this,
 or also subsequently, apparently at random. On a Mac, check first that
 you have the free Apple Xcode app (get it from the app store). If you do

--- a/docs/source/install/rough_guide_to_python.rst
+++ b/docs/source/install/rough_guide_to_python.rst
@@ -146,7 +146,7 @@ and run
 
 .. code-block:: bash
 
-    $ python setup.py develop
+    $ pip install -e .
 
 and test:
 

--- a/docs/source/user_guide/faq.rst
+++ b/docs/source/user_guide/faq.rst
@@ -163,7 +163,7 @@ And then you can cd to landlab and this works:
 
 .. code-block:: python
 
-    python setup.py develop
+    pip install -e .
 
 Support: How can I ask more questions and get help?
 ---------------------------------------------------


### PR DESCRIPTION
This PR contains minor updates to the README and documentation 📝 . In particular, it changes the developer install instructions to use `pip install -e .` instead of `python setup.py develop` to ensure that Cython is called.

Also:
* Removed landscape.io
* Updated targets on Actions badges
* Made minor edits to README text 

This fixes #1271.