### PR TITLE
docs: add linkcheck to docs testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,22 +1,6 @@
 name: Documentation
 
-on:
-    push:
-        paths:
-            - "docs/**"
-            - "AUTHORS.rst"
-            - "CHANGES.rst"
-            - "CONTRIBUTING.rst"
-            - "LICENSE.rst"
-            - "README.rst"
-    pull_request:
-        paths:
-            - "docs/**"
-            - "AUTHORS.rst"
-            - "CHANGES.rst"
-            - "CONTRIBUTING.rst"
-            - "LICENSE.rst"
-            - "README.rst"
+on: [push, pull_request]
 
 jobs:
     build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,4 +56,4 @@ jobs:
               pip install -e .
 
           - name: Build documentation
-            run: make -C docs clean html
+            run: make -C docs clean html linkcheck

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,6 +1,14 @@
 name: Notebooks
 
-on: [push, pull_request]
+on:
+  push:
+      paths:
+          - "landlab/**"
+          - "notebooks/**"
+  pull_request:
+      paths:
+          - "landlab/**"
+          - "notebooks/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -1,14 +1,16 @@
 name: Notebooks
 
-on:
-  push:
-      paths:
-          - "landlab/**"
-          - "notebooks/**"
-  pull_request:
-      paths:
-          - "landlab/**"
-          - "notebooks/**"
+on: [push, pull_request]
+
+# on:
+#   push:
+#       paths:
+#           - "landlab/**"
+#           - "notebooks/**"
+#   pull_request:
+#       paths:
+#           - "landlab/**"
+#           - "notebooks/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,16 @@
 name: Test
 
+on: [push, pull_request]
 
-on:
-  push:
-      paths:
-          - "landlab/**"
-          - "tests/**"
-  pull_request:
-      paths:
-          - "landlab/**"
-          - "tests/**"
+# on:
+#   push:
+#       paths:
+#           - "landlab/**"
+#           - "tests/**"
+#   pull_request:
+#       paths:
+#           - "landlab/**"
+#           - "tests/**"
 
 jobs:
   build-and-test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,15 @@
 name: Test
 
-on: [push, pull_request]
+
+on:
+  push:
+      paths:
+          - "landlab/**"
+          - "tests/**"
+  pull_request:
+      paths:
+          - "landlab/**"
+          - "tests/**"
 
 jobs:
   build-and-test:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,17 +57,17 @@ source_suffix = ".rst"
 
 # Regex for links that we know work in browser, but do not work in sphinx/CI (BE VERY CAREFUL ADDING LINKS TO THIS LIST)
 if os.getenv("GITHUB_ACTIONS"):
-    # linkcheck_ignore = [
-    #     r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
-    #     r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
-    #     re.escape(
-    #         r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"
-    #     ),  # Added by EWHH Feb 2020
-    #     r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
-    #     r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
-    #     r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
-    #     r"https://yaml.org/start.html",  # Added by EWHH September 2021
-    # ]
+    linkcheck_ignore = [
+        #     r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
+        #     r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
+        re.escape(
+            r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"
+        ),  # Added by EWHH Feb 2020
+        #     r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
+        #     r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
+        #     r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
+        #     r"https://yaml.org/start.html",  # Added by EWHH September 2021
+    ]
     linkcheck_retries = 5
 
 # The master toctree document.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,6 +65,7 @@ if os.getenv("GITHUB_ACTIONS"):
         ),  # Added by EWHH Feb 2020
         r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
         r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
+        r"https://doi.org/10.3133/pp294B",   # Added by EWHH September 2021
     ]
 
 # The master toctree document.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,7 @@ if os.getenv("GITHUB_ACTIONS"):
         r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
         r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
         r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
+        r"https://yaml.org/start.html",  # Added by EWHH September 2021
     ]
 
 # The master toctree document.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,7 @@ if os.getenv("GITHUB_ACTIONS"):
         ),  # Added by EWHH Feb 2020
         r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
         r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
-        r"https://doi.org/10.3133/pp294B",   # Added by EWHH September 2021
+        r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
     ]
 
 # The master toctree document.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,14 +58,14 @@ source_suffix = ".rst"
 # Regex for links that we know work in browser, but do not work in sphinx/CI (BE VERY CAREFUL ADDING LINKS TO THIS LIST)
 if os.getenv("GITHUB_ACTIONS"):
     linkcheck_ignore = [
-        #     r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
-        #     r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
+        r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
+        r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
         re.escape(
             r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"
         ),  # Added by EWHH Feb 2020
-        #     r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
-        #     r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
-        #     r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
+        r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
+        r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
+        r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
         #     r"https://yaml.org/start.html",  # Added by EWHH September 2021
     ]
     linkcheck_retries = 5

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -57,17 +57,18 @@ source_suffix = ".rst"
 
 # Regex for links that we know work in browser, but do not work in sphinx/CI (BE VERY CAREFUL ADDING LINKS TO THIS LIST)
 if os.getenv("GITHUB_ACTIONS"):
-    linkcheck_ignore = [
-        r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
-        r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
-        re.escape(
-            r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"
-        ),  # Added by EWHH Feb 2020
-        r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
-        r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
-        r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
-        r"https://yaml.org/start.html",  # Added by EWHH September 2021
-    ]
+    # linkcheck_ignore = [
+    #     r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
+    #     r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern
+    #     re.escape(
+    #         r"https://github.us18.list-manage.com/subscribe?u=2db7cea82e3ea40fcf4c91247&id=b9bad233c7"
+    #     ),  # Added by EWHH Feb 2020
+    #     r"https://dx.doi.org/10.1029/2011jf002181",  # Added by EWHH April 2020
+    #     r"https://doi.org/10.1029/2019JB018596",  # Added by EWHH April 2020
+    #     r"https://doi.org/10.3133/pp294B",  # Added by EWHH September 2021
+    #     r"https://yaml.org/start.html",  # Added by EWHH September 2021
+    # ]
+    linkcheck_retries = 5
 
 # The master toctree document.
 master_doc = "index"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ source_suffix = ".rst"
 # source_encoding = 'utf-8-sig'
 
 # Regex for links that we know work in browser, but do not work in sphinx/CI (BE VERY CAREFUL ADDING LINKS TO THIS LIST)
-if os.getenv("TRAVIS"):
+if os.getenv("GITHUB_ACTIONS"):
     linkcheck_ignore = [
         r"https://pubs.geoscienceworld.org/gsa/geology.*",  # Added by KRB Dec 2019, at this point two links match this pattern
         r"https://dx.doi.org/10.1130/*",  # Added by KRB Jan 2019. Four links match this pattern

--- a/docs/source/user_guide/components.rst
+++ b/docs/source/user_guide/components.rst
@@ -155,7 +155,7 @@ Landlab components always want to see a Python dictionary as their input, as
 illustrated above. However, Landlab does offer a native file
 reader called `load_params` that allows you to create dictionaries to pass to
 components from input files. This function recognizes both
-`"yaml" <https://yaml.org/start.html>`_ formatted data files, e.g.,
+`"yaml" <https://yaml.org/spec/1.2/>`_ formatted data files, e.g.,
 
 .. code-block:: yaml
 

--- a/landlab/components/detachment_ltd_erosion/generate_erosion_by_depth_slope.py
+++ b/landlab/components/detachment_ltd_erosion/generate_erosion_by_depth_slope.py
@@ -13,16 +13,28 @@ from landlab import Component
 class DepthSlopeProductErosion(Component):
     """Calculate erosion rate as a function of the depth-slope product.
 
-    Erosion rate = k_e * ((Tau**a - Tau_crit**a))
+    Erosion rate is calculated as, ``erosion_rate = k_e * ((tau ** a - tau_crit ** a))``
 
-    k_e = erodibility coefficient
-    Tau = bed shear stress
-        = density of fluid (rho) * gravitational acceleration (g) * water depths (h) * slopes (S)
-    Tau_crit = critical shear stress
-    a = positive exponent
+    *k_e*
+        Erodibility coefficient
+    *tau*
+        Bed shear stress: ``tau = rho * g * h * S``
+    *rho*
+        Density of fluid
+    *g*
+        Gravitational acceleration
+    *h*
+        Water depths
+    *S*
+        Slope
+    *tau_crit*
+        Critical shear stress
+    *a*
+        Positive exponent
+
 
     Note this equation was presented in Tucker, G.T., 2004, Drainage basin
-    sensitivityto tectonic and climatic forcing: Implications of a stochastic
+    sensitivity to tectonic and climatic forcing: Implications of a stochastic
     model for the role of entrainment and erosion thresholds,
     Earth Surface Processes and Landforms.
 
@@ -56,7 +68,8 @@ class DepthSlopeProductErosion(Component):
 
     Create fields of data for each of these input variables.
 
-    First create toopgraphy. This is a flat surface of elevation 10 m.
+    First create topopgraphy. This is a flat surface of elevation 10 m.
+
     >>> grid.at_node['topographic__elevation'] = np.ones(grid.number_of_nodes)
     >>> grid.at_node['topographic__elevation'] *= 10.
     >>> grid.at_node['topographic__elevation'] = np.array([
@@ -67,6 +80,7 @@ class DepthSlopeProductErosion(Component):
     ...      10., 10., 10., 10., 10.])
 
     Now we'll add an arbitrary water depth field on top of that topography.
+
     >>> grid.at_node['surface_water__depth'] = np.array([
     ...      5., 5., 5., 5., 5.,
     ...      4., 4., 4., 4., 4.,
@@ -77,6 +91,7 @@ class DepthSlopeProductErosion(Component):
     Using the set topography, now we will calculate slopes on all nodes.
 
     First calculating slopes on links
+
     >>> grid.at_link['water_surface__slope'] = grid.calc_grad_at_link('surface_water__depth')
 
     Now putting slopes on nodes
@@ -109,6 +124,7 @@ class DepthSlopeProductErosion(Component):
             0.    ,  0.    ,  0.    ,  0.    ])
 
     Now, our updated topography...
+
     >>> grid.at_node['topographic__elevation'] # doctest: +NORMALIZE_WHITESPACE
     array([ 10.    ,   7.5475,   7.5475,   7.5475,  10.    ,  10.    ,
              8.038 ,   8.038 ,   8.038 ,  10.    ,  10.    ,   8.5285,


### PR DESCRIPTION
This pull request is intended to fix #1334. In the move from Travis to GitHub Actions for our CI, we turned off *linkcheck* when testing our documentation build. It may be we had a good reason for doing so but I've turned it back on here to see if we can get it to work again.