### PR TITLE
dev: add a pre-commit configuration file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 21.7b0
+  hooks:
+  - id: black
+    name: black
+    description: "Black: The uncompromising Python code formatter"
+    entry: black
+    language: python
+    language_version: python3
+    minimum_pre_commit_version: 2.9.2
+    require_serial: true
+    types_or: [python, pyi]
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    additional_dependencies: [flake8-bugbear]
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 black
 flake8
+flake8-bugbear
 isort
+pre-commit


### PR DESCRIPTION
This pull request simply adds a *.pre-commit-config.yaml* file for installing  [pre-commit](https://pre-commit.com/) hooks when developing with *landlab*. Once installed, *pre-commit* will run both *black* and *flake8* before every commit. This is in response to #1324 and closes #1332.