### PR TITLE
bld: drop "file:" prefix for pip requirements files

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,8 +2,8 @@ name: landlab_dev
 dependencies:
 - pip
 - pip:
-  - -r file:requirements.txt
-  - -r file:requirements-testing.txt
-  - -r file:requirements-dev.txt
-  - -r file:requirements-notebooks.txt
-  - -r file:requirements-docs.txt
+  - -r requirements.txt
+  - -r requirements-testing.txt
+  - -r requirements-dev.txt
+  - -r requirements-notebooks.txt
+  - -r requirements-docs.txt

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ dependencies:
 - landlab>=2.1
 - pip
 - pip:
-  - -r file:requirements-notebooks.txt
+  - -r requirements-notebooks.txt


### PR DESCRIPTION
This pull request fixes the error found by @slundell123 and described in #1330. Newer versions of *pip* do not like it when we refer to requirements files with a *file:* prefix followed by a relative path (as we do in our *conda* environment files). We should, instead, either use a relative path name without the prefix or use the prefix followed by an absolute path. Since using absolute paths doesn't make sense, I've changed our environment files to use relative paths.