### PR TITLE
Add links to launch notebooks on CSDMS JupyterHub

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,20 +164,37 @@ of Earth-surface dynamics, Earth Surface Dynamics, 5, p 21-46,
 Are there any examples of using Landlab I can look at?
 ------------------------------------------------------
 
-The Landlab package contains a directory at ``landlab/notebooks`` which contains
-Jupyter notebooks describe core concepts and give examples of using components.
+The Landlab package contains a directory, ``landlab/notebooks``, with
+Jupyter Notebooks describing core concepts and giving examples of using components.
 The file ``landlab/notebooks/welcome.ipynb`` provides a table of contents to
-the notebooks and is the recommended starting place. To launch an instance of
+the notebooks and is the recommended starting place.
+Additionally, there are a set of notebooks curated to teach physical processes
+located in the directory ``landlab/notebooks/teaching``.
+
+Run on Binder
+`````````````
+
+To launch an instance of
 Binder and `explore the notebooks click here`_.
 
 .. _explore the notebooks click here: https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/welcome.ipynb
 
-In addition there are a set of notebooks curated to teach physical processes
-located in the directory ``landlab/notebooks/teaching``.
-
-To launch an Binder instance that goes straight to these `teaching notebooks click here`_.
+To launch a Binder instance that goes straight to the `teaching notebooks click here`_.
 
 .. _teaching notebooks click here: https://mybinder.org/v2/gh/landlab/landlab/release?filepath=notebooks/teaching/welcome_teaching.ipynb
+
+Run on the CSDMS JupyterHub
+```````````````````````````
+
+The Landlab notebooks can also be run on the CSDMS JupyterHub.
+To sign up for a free account,
+`visit the CSDMS wiki`_ and follow the instructions there.
+Then, click to explore the `example notebooks`_,
+or to go straight to the `teaching notebooks`_.
+
+.. _visit the CSDMS wiki: https://csdms.colorado.edu/wiki/JupyterHub
+.. _example notebooks: https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fwelcome.ipynb&branch=master
+.. _teaching notebooks: https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fteaching%2Fwelcome_teaching.ipynb&branch=master
 
 
 What License does Landlab use?


### PR DESCRIPTION
This PR adds links to the README to launch the Landlab example and teaching notebooks on the CSDMS JupyterHub, as well as a link to sign up for the JupyterHub if someone hasn't already done so.