### PR TITLE
fix the building of source distributions for release workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
+          pip install numpy
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Build source distribution
         if: matrix.os == 'ubuntu-latest'
         run: |
+          pip install numpy
           python setup.py sdist --dist-dir wheelhouse
           twine upload --skip-existing wheelhouse/*.tar.gz
 


### PR DESCRIPTION
This is a small pull request that fixes how our *prerelease* and *release* workflows build our source distributions. Because our *setup.py* imports *numpy*, we must install *numpy* before running `python setup.py sdist`.