### PR TITLE
fix: install with richdem even if it is not available

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,6 @@ jobs:
           - name: Install dependencies
             run: |
               conda install mamba
-              mamba install --file=requirements.txt
               pip install -r requirements-docs.txt
               pip install -e .
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,7 @@ jobs:
           - name: Install dependencies
             run: |
               conda install mamba
-              pip install -r requirements-docs.txt
-              pip install -e .
+              pip install -e ".[docs]"
 
           - name: Build documentation
             run: make -C docs clean html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,7 @@ jobs:
               conda list
     
           - name: Install dependencies
-            run: |
-              conda install mamba
-              pip install -e ".[docs]"
+            run: pip install -e ".[docs]"
 
           - name: Build documentation
             run: make -C docs clean html

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Install testing dependencies
         run: |
+          mamba install rasterio
           pip install -e .[tests,notebooks]
 
       - name: Test jupyter notebooks a clean

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -51,16 +51,14 @@ jobs:
       - name: Install requirements
         run: |
           conda install mamba
+          mamba install --file=requirements.txt
+          mamba install --file=requirements-testing.txt
+          mamba install --file=requirements-notebooks.txt
           mamba list
 
       - name: Build and install package
         run: |
           pip install -e .
-
-      - name: Install testing dependencies
-        run: |
-          mamba install rasterio
-          pip install -e .[tests,notebooks]
 
       - name: Test jupyter notebooks a clean
         run: python notebooks/run_notebook_checks.py notebooks

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Install requirements
         run: |
           conda install mamba
-          mamba install --file=requirements.txt
           mamba list
 
       - name: Build and install package

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -59,8 +59,7 @@ jobs:
 
       - name: Install testing dependencies
         run: |
-          pip install -r requirements-testing.txt
-          pip install -r requirements-notebooks.txt
+          pip install -e .[tests,notebooks]
 
       - name: Test jupyter notebooks a clean
         run: python notebooks/run_notebook_checks.py notebooks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,6 @@ jobs:
           conda info
           conda list
 
-      - name: Install requirements
-        run: |
-          conda install mamba
-          mamba list
-
       - name: Build and install package
         run: |
           pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           pip install -e .
 
       - name: Install testing dependencies
-        run: mamba install --file=requirements-testing.txt
+        run: pip install -e .[tests]
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Install requirements
         run: |
           conda install mamba
-          mamba install --file=requirements.txt
           mamba list
 
       - name: Build and install package

--- a/README.rst
+++ b/README.rst
@@ -111,8 +111,9 @@ run the following commands:
 
 .. code-block:: bash
 
-    $ conda env create --file=environment-dev.yml
-    $ conda activate landlab_dev
+    $ conda create -n landlab python
+    $ conda install -n landlab --file=requirements.txt
+    $ conda activate landlab
     $ pip install -e .
 
 How do I verify I've installed Landlab correctly?

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,17 @@ run the following commands:
     $ conda activate landlab
     $ pip install -e .
 
+This will install *landlab* and it's dependencies. You may want to install
+some additional utilities used for developing, testing, and running *landlab*
+notebooks. This can be done with the following:
+
+.. code-block:: bash
+
+    $ conda install --file=requirements-dev.txt
+    $ conda install --file=requirements-testing.txt
+    $ conda install --file=requirements-notebooks.txt
+
+
 How do I verify I've installed Landlab correctly?
 -------------------------------------------------
 

--- a/docs/source/development/install/install.rst
+++ b/docs/source/development/install/install.rst
@@ -64,7 +64,11 @@ The next step is it create this environment, called *landlab_dev*.
 
 .. code-block:: bash
 
-   $ conda env create --file=environment-dev.yml
+   $ conda create -n landlab_dev python
+   $ conda install -n landlab_dev --file=requirements.txt -c conda-forge
+   $ conda install -n landlab_dev --file=requirements-testing.txt -c conda-forge
+   $ conda install -n landlab_dev --file=requirements-notebooks.txt -c conda-forge
+   $ conda install -n landlab_dev --file=requirements-dev.txt -c conda-forge
 
 The conda environment described by ``environment-dev.yml`` contains the minimal
 set of dependencies necessary to run the Landlab tests and notebooks, and keep
@@ -74,7 +78,8 @@ packages into the conda environment.
 
 In addition, this environment does not have everything needed to build the
 documentation. These requirements are specified in the file
-``landlab/docs/environment.yml``.
+``landlab/docs/environment.yml`` or the ``requirements-docs.txt``
+requirements file.
 
 Activate that environment so that you will be using that version of python and
 all of the dependencies you just installed.

--- a/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
+++ b/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
@@ -36,9 +36,9 @@ except ModuleNotFoundError:
             )
 
     rd = richdem()
-    WITH_PRIORITY_FLOOD_FLOW_ROUTER = False
+    WITH_RICHDEM = False
 else:
-    WITH_PRIORITY_FLOOD_FLOW_ROUTER = True
+    WITH_RICHDEM = True
 
 
 # Codes for depression status
@@ -341,6 +341,8 @@ class PriorityFloodFlowRouter(Component):
             "doc": "Node array of proportion of flow sent to each receiver.",
         },
     }
+
+    WITH_RICHDEM = WITH_RICHDEM
 
     def __init__(
         self,

--- a/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
+++ b/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
@@ -36,6 +36,9 @@ except ModuleNotFoundError:
             )
 
     rd = richdem()
+    WITH_PRIORITY_FLOOD_FLOW_ROUTER = False
+else:
+    WITH_PRIORITY_FLOOD_FLOW_ROUTER = True
 
 
 # Codes for depression status

--- a/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
+++ b/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
@@ -17,7 +17,6 @@ from functools import partial
 
 import numpy as np
 import numpy.matlib as npm
-import richdem as rd
 
 from landlab import Component, FieldError, RasterModelGrid
 from landlab.grid.nodestatus import NodeStatus
@@ -25,6 +24,19 @@ from landlab.utils.return_array import return_array_at_node
 
 from ...utils.suppress_output import suppress_output
 from .cfuncs import _D8_FlowAcc, _D8_flowDir
+
+try:
+    import richdem as rd
+except ModuleNotFoundError:
+
+    class richdem:
+        def __getattribute__(self, name):
+            raise RuntimeError(
+                "PriorityFloodFlowRouter requires richdem but richdem is not installed"
+            )
+
+    rd = richdem()
+
 
 # Codes for depression status
 _UNFLOODED = 0

--- a/notebooks/exclude.yml
+++ b/notebooks/exclude.yml
@@ -9,6 +9,8 @@
 - file: nst_scaling_profiling.ipynb
   reason: "stalls travis builds"
 - file: PriorityFlood_LandscapeEvolutionModel.ipynb
+  unless: "sys_platform != 'win32' or python_version < '3.10'"
   reason: "requires richdem, bmi-topography"
 - file: PriorityFlood_realDEMs.ipynb
+  unless: "sys_platform != 'win32' or python_version < '3.10'"
   reason: "requires richdem, bmi-topography"

--- a/notebooks/exclude.yml
+++ b/notebooks/exclude.yml
@@ -8,3 +8,7 @@
   reason: "stalls travis builds"
 - file: nst_scaling_profiling.ipynb
   reason: "stalls travis builds"
+- file: PriorityFlood_LandscapeEvolutionModel.ipynb
+  reason: "requires richdem, bmi-topography"
+- file: PriorityFlood_realDEMs.ipynb
+  reason: "requires richdem, bmi-topography"

--- a/requirements-notebooks.txt
+++ b/requirements-notebooks.txt
@@ -3,3 +3,4 @@ jupyter
 holoviews
 nbformat
 mesa
+bmi-topography ; sys_platform != 'win32' or python_version < '3.10'

--- a/requirements-notebooks.txt
+++ b/requirements-notebooks.txt
@@ -3,4 +3,4 @@ jupyter
 holoviews
 nbformat
 mesa
-bmi-topography ; sys_platform != 'win32' or python_version < '3.10'
+bmi-topography

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pyshp
 scipy
 statsmodels
 pandas
-xarray>=0.16
-richdem
+xarray >= 0.16
+richdem ; sys_platform != 'win32' or python_version < '3.10'
 bmi-topography

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,3 @@ statsmodels
 pandas
 xarray >= 0.16
 richdem ; sys_platform != 'win32' or python_version < '3.10'
-bmi-topography

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ scipy
 statsmodels
 pandas
 xarray >= 0.16
-richdem ; sys_platform != 'win32' or python_version < '3.10'
+richdem

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,17 @@ def read(filename):
         return fp.read()
 
 
+def read_requirements(filename):
+    lines = [line.strip() for line in read(filename).splitlines()]
+    requirements = []
+    for requirement in lines:
+        if requirement.startswith(("richdem", "bmi-topography")):
+            requirement += "; sys_platform != 'win32' or python_version < '3.10'"
+        requirements.append(requirement)
+
+    return requirements
+
+
 long_description = u"\n\n".join(
     [
         read("README.rst"),
@@ -36,6 +47,14 @@ def find_extensions(path="."):
     ]
 
 
+install_requires = read_requirements("requirements.txt")
+extras_require = {
+    "tests": read_requirements("requirements-testing.txt"),
+    "docs": read_requirements("requirements-docs.txt"),
+    "dev": read_requirements("requirements-dev.txt"),
+    "notebooks": read_requirements("requirements-notebooks.txt"),
+}
+
 setup(
     name="landlab",
     version="2.4.2.dev0",
@@ -44,8 +63,9 @@ setup(
     url="https://github.com/landlab",
     description="Plugin-based component modeling tool.",
     long_description=long_description,
-    python_requires=">=3.6",
-    install_requires=open("requirements.txt", "r").read().splitlines(),
+    python_requires=">=3.7",
+    install_requires=install_requires,
+    extras_require=extras_require,
     include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,12 @@ def read(filename):
 
 
 def read_requirements(filename):
+    """Read requirements from a file, adding dependency specifications where needed.
+
+    Dependency specifications could be included in the requirements file but,
+    since the requirements file is also used by conda and conda doesn't
+    understand dependency specifications, we add them here.
+    """
     lines = [line.strip() for line in read(filename).splitlines()]
     requirements = []
     for requirement in lines:
@@ -73,9 +79,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Cython",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Scientific/Engineering :: Physics",
     ],

--- a/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
+++ b/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
@@ -8,12 +8,15 @@ from numpy import testing
 from numpy.testing import assert_array_equal
 
 from landlab import FieldError, HexModelGrid, RasterModelGrid
-from landlab.components import PriorityFloodFlowRouter
+from landlab.components import PriorityFloodFlowRouter, WITH_PRIORITY_FLOOD_FLOW_ROUTER
 from landlab.components.priority_flood_flow_router.cfuncs import (
     _D8_FlowAcc,
     _D8_flowDir,
 )
 from landlab.grid.nodestatus import NodeStatus
+
+if not WITH_PRIORITY_FLOOD_FLOW_ROUTER:
+    pytestmark = pytest.mark.skip(reason="richdem is not installed")
 
 
 def test_check_fields():

--- a/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
+++ b/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
@@ -8,14 +8,14 @@ from numpy import testing
 from numpy.testing import assert_array_equal
 
 from landlab import FieldError, HexModelGrid, RasterModelGrid
-from landlab.components import PriorityFloodFlowRouter, WITH_PRIORITY_FLOOD_FLOW_ROUTER
+from landlab.components import PriorityFloodFlowRouter
 from landlab.components.priority_flood_flow_router.cfuncs import (
     _D8_FlowAcc,
     _D8_flowDir,
 )
 from landlab.grid.nodestatus import NodeStatus
 
-if not WITH_PRIORITY_FLOOD_FLOW_ROUTER:
+if not PriorityFloodFlowRouter.WITH_RICHDEM:
     pytestmark = pytest.mark.skip(reason="richdem is not installed")
 
 


### PR DESCRIPTION
This pull request allows *landlab* to be installed even if the *richdem* package is not available, which, for now, means leaving out *richdem* for Python 3.10 on Windows. Users will be able to use the entirety of *landlab* except for the *PriorityFloodFlowRouter*.

We, ultimately, will want to fix *richdem* to work on all of *landlab*'s supported platforms but this acts as a workaround until that time.