### PR TITLE
Add OPENTOPOGRAPHY_API_KEY to notebook tests

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -60,10 +60,12 @@ jobs:
         run: |
           pip install -e .
 
-      - name: Test jupyter notebooks a clean
+      - name: Test jupyter notebooks are clean
         run: python notebooks/run_notebook_checks.py notebooks
 
       - name: Test jupyter notebooks
+        env:
+          OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
         run: |
           python -c 'import landlab; print(landlab.__version__)'
           pytest notebooks --run-notebook -vvv

--- a/requirements-notebooks.txt
+++ b/requirements-notebooks.txt
@@ -3,4 +3,4 @@ jupyter
 holoviews
 nbformat
 mesa
-bmi-topography
+bmi-topography >= 0.5


### PR DESCRIPTION
This pull request adds the OPENTOPOGRAPHY_API_KEY to the notebook testing so that a notebook is able to download data from OpenTopography using the *bmi-topography* package.