### PR TITLE
tests: update the black action to use new options

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          options: "--check --verbose"
+          options: "--check --verbose --diff"
           src: "setup.py landlab tests"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -19,4 +19,5 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: psf/black@stable
         with:
-          args: ". --check"
+          options: "--check --verbose"
+          src: "setup.py landlab tests"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.9b0
+  rev: 22.1.0
   hooks:
   - id: black
     name: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
   rev: 3.9.2
   hooks:
   - id: flake8
-    additional_dependencies: [flake8-bugbear]
+    # additional_dependencies: [flake8-bugbear]
 - repo: https://gitlab.com/iamlikeme/nbhooks
   rev: 1.0.0
   hooks:

--- a/landlab/components/bedrock_landslider/bedrock_landslider.py
+++ b/landlab/components/bedrock_landslider/bedrock_landslider.py
@@ -535,9 +535,9 @@ class BedrockLandslider(Component):
                         topo[upstream_neighbors[0]] = new_el
 
                         vol_sed = (
-                            sed_landslide_ero * (1 - self._phi) * (self.grid.dx ** 2)
+                            sed_landslide_ero * (1 - self._phi) * (self.grid.dx**2)
                         )
-                        vol_bed = bed_landslide_ero * (self.grid.dx ** 2)
+                        vol_bed = bed_landslide_ero * (self.grid.dx**2)
                         store_volume_sed = store_volume_sed + vol_sed
                         store_volume_bed = store_volume_bed + vol_bed
 

--- a/landlab/components/depression_finder/lake_mapper.py
+++ b/landlab/components/depression_finder/lake_mapper.py
@@ -229,7 +229,7 @@ class DepressionFinderAndRouter(Component):
         if isinstance(grid, RasterModelGrid) and (routing == "D8"):
             self._D8 = True
             self._num_nbrs = 8
-            self._diag_link_length = np.sqrt(grid.dx ** 2 + grid.dy ** 2)
+            self._diag_link_length = np.sqrt(grid.dx**2 + grid.dy**2)
         else:
             self._D8 = False  # useful shorthand for thia test we do a lot
             if isinstance(grid, RasterModelGrid):

--- a/landlab/components/depth_dependent_taylor_soil_creep/hillslope_depth_dependent_taylor_flux.py
+++ b/landlab/components/depth_dependent_taylor_soil_creep/hillslope_depth_dependent_taylor_flux.py
@@ -399,7 +399,7 @@ class DepthDependentTaylorDiffuser(Component):
             courant_slope_term = 0.0
             courant_s_over_scrit = self._slope.max() / self._slope_crit
             for i in range(0, 2 * self._nterms, 2):
-                courant_slope_term += courant_s_over_scrit ** i
+                courant_slope_term += courant_s_over_scrit**i
                 if np.any(np.isinf(courant_slope_term)):
                     message = (
                         "Soil flux term is infinite in Courant condition "
@@ -410,7 +410,7 @@ class DepthDependentTaylorDiffuser(Component):
             # Calculate De Max
             De_max = self._K * (courant_slope_term)
             # Calculate longest stable timestep
-            self._dt_max = self._courant_factor * (self._grid.dx ** 2) / De_max
+            self._dt_max = self._courant_factor * (self._grid.dx**2) / De_max
 
             # Test for the Courant condition and print warning if user intended
             # for it to be printed.
@@ -452,7 +452,7 @@ class DepthDependentTaylorDiffuser(Component):
         slope_term = 0.0
         s_over_scrit = self._slope / self._slope_crit
         for i in range(0, 2 * self._nterms, 2):
-            slope_term += s_over_scrit ** i
+            slope_term += s_over_scrit**i
             if np.any(np.isinf(slope_term)):
                 message = (
                     "Soil flux term is infinite. This is likely due to "

--- a/landlab/components/detachment_ltd_erosion/generate_erosion_by_depth_slope.py
+++ b/landlab/components/detachment_ltd_erosion/generate_erosion_by_depth_slope.py
@@ -241,7 +241,7 @@ class DepthSlopeProductErosion(Component):
         self._E[less_than_tc] = 0.0
 
         self._E[greater_than_tc] = self._k_e * (
-            (self._tau[greater_than_tc] ** self._a) - (self._tau_crit ** self._a)
+            (self._tau[greater_than_tc] ** self._a) - (self._tau_crit**self._a)
         )
 
         self._E[self._E < 0.0] = 0.0

--- a/landlab/components/diffusion/diffusion.py
+++ b/landlab/components/diffusion/diffusion.py
@@ -276,7 +276,7 @@ class LinearDiffuser(Component):
             rt2 = np.sqrt(2.0)
             horizontal_face = self._grid.dx / (1.0 + rt2)
             vertical_face = self._grid.dy / (1.0 + rt2)
-            diag_face = np.sqrt(0.5 * (horizontal_face ** 2 + vertical_face ** 2))
+            diag_face = np.sqrt(0.5 * (horizontal_face**2 + vertical_face**2))
 
             # NOTE: Do these need to be flattened?
             # self._hoz = self.grid.horizontal_links.flatten()
@@ -506,8 +506,8 @@ class LinearDiffuser(Component):
                     )
                     Kx[self._vert] = vert_link_crosslink_K.mean(axis=1)
                     Ky[self._hoz] = hoz_link_crosslink_K.mean(axis=1)
-                    Cslope = np.sqrt(slx ** 2 + sly ** 2)
-                    v = np.sqrt(Kx ** 2 + Ky ** 2)
+                    Cslope = np.sqrt(slx**2 + sly**2)
+                    v = np.sqrt(Kx**2 + Ky**2)
                     flux_links = v * Cslope
                     # NEW, to resolve issue with K being off angle to S:
                     # in fact, no. Doing this just makes this equivalent

--- a/landlab/components/discharge_diffuser/diffuse_by_discharge.py
+++ b/landlab/components/discharge_diffuser/diffuse_by_discharge.py
@@ -198,7 +198,7 @@ class DischargeDiffuser(Component):
         # do the sediment diffusion
         for dir in ("W", "E", "S", "N"):
             self._grad_on_link(pad_eta, dir)
-            Cslope = np.sqrt(self._slx ** 2 + self._sly ** 2)
+            Cslope = np.sqrt(self._slx**2 + self._sly**2)
             self._link_sed_flux_from_slope(Cslope, self._slope, dir)
 
         try:

--- a/landlab/components/flexure/flexure.py
+++ b/landlab/components/flexure/flexure.py
@@ -270,7 +270,7 @@ class Flexure(Component):
             np.arange(shape[1]) * xy_spacing[1], np.arange(shape[0]) * xy_spacing[0]
         )
 
-        return kei(np.sqrt(dx ** 2 + dy ** 2) / alpha)
+        return kei(np.sqrt(dx**2 + dy**2) / alpha)
 
     def update(self):
         """Update fields with current loading conditions."""

--- a/landlab/components/flexure/flexure_1d.py
+++ b/landlab/components/flexure/flexure_1d.py
@@ -310,7 +310,7 @@ class Flexure1D(Component):
             self._rigidity
         except AttributeError:
             self._rigidity = (
-                self._eet ** 3.0 * self._youngs / (12.0 * (1.0 - self._POISSON ** 2.0))
+                self._eet**3.0 * self._youngs / (12.0 * (1.0 - self._POISSON**2.0))
             )
         finally:
             return self._rigidity

--- a/landlab/components/flow_director/flow_direction_dinf.py
+++ b/landlab/components/flow_director/flow_direction_dinf.py
@@ -310,7 +310,7 @@ def flow_directions_dinf(grid, elevs="topographic__elevation", baselevel_nodes=N
 
     # calculate r and s, the direction and magnitude
     r = np.arctan2(s2, s1)
-    s = ((s1 ** 2) + (s2 ** 2)) ** 0.5
+    s = ((s1**2) + (s2**2)) ** 0.5
 
     r[np.isnan(r)] = 0
     # adjust r if it doesn't sit in the realm of (0, arctan(d2,d1))

--- a/landlab/components/flow_director/flow_direction_mfd.py
+++ b/landlab/components/flow_director/flow_direction_mfd.py
@@ -285,7 +285,7 @@ def flow_directions_mfd(
     flow_slopes[inactive_link_to_neighbor] = 0.0
 
     if partition_method == "square_root_of_slope":
-        values_for_partitioning = flow_slopes ** 0.5
+        values_for_partitioning = flow_slopes**0.5
     elif partition_method == "slope":
         values_for_partitioning = flow_slopes
     else:

--- a/landlab/components/fracture_grid/fracture_grid.py
+++ b/landlab/components/fracture_grid/fracture_grid.py
@@ -52,11 +52,11 @@ def _calc_fracture_starting_position_and_angle_hex(shape, is_horiz, spacing):
     grid_side = np.random.randint(0, 3)  # east, north, west, south
     ang = np.pi * np.random.rand()
     if is_horiz:
-        row_spacing = 0.5 * 3.0 ** 0.5 * spacing
+        row_spacing = 0.5 * 3.0**0.5 * spacing
         col_spacing = spacing
     else:
         row_spacing = spacing
-        col_spacing = 0.5 * 3.0 ** 0.5 * spacing
+        col_spacing = 0.5 * 3.0**0.5 * spacing
 
     if (grid_side % 2) == 0:  # east or west
         c = (1 - grid_side // 2) * (shape[1] - 1)

--- a/landlab/components/groundwater/dupuit_percolator.py
+++ b/landlab/components/groundwater/dupuit_percolator.py
@@ -741,7 +741,7 @@ class GroundwaterDupuitPercolator(Component):
             # calculate criteria for timestep
             dt_vn = self._vn_coefficient * np.min(
                 np.divide(
-                    (self._n_link * self._grid.length_of_link ** 2),
+                    (self._n_link * self._grid.length_of_link**2),
                     (4 * self._K * hlink),
                     where=hlink > 0,
                     out=np.ones_like(self._q) * 1e15,

--- a/landlab/components/hack_calculator/hack_calculator.py
+++ b/landlab/components/hack_calculator/hack_calculator.py
@@ -345,7 +345,7 @@ class HackCalculator(Component):
                             "basin_outlet_id": outlet_node * np.ones(A.shape),
                             "A": A,
                             "L_obs": L,
-                            "L_est": C * A ** h,
+                            "L_est": C * A**h,
                             "node_id": nodes,
                         }
                     )

--- a/landlab/components/landslides/landslide_probability.py
+++ b/landlab/components/landslides/landslide_probability.py
@@ -421,11 +421,11 @@ class LandslideProbability(Component):
             self._recharge_mean = groundwater__recharge_mean
             self._recharge_stdev = groundwater__recharge_standard_deviation
             self._mu_lognormal = np.log(
-                (self._recharge_mean ** 2)
-                / np.sqrt(self._recharge_stdev ** 2 + self._recharge_mean ** 2)
+                (self._recharge_mean**2)
+                / np.sqrt(self._recharge_stdev**2 + self._recharge_mean**2)
             )
             self._sigma_lognormal = np.sqrt(
-                np.log((self._recharge_stdev ** 2) / (self._recharge_mean ** 2) + 1)
+                np.log((self._recharge_stdev**2) / (self._recharge_mean**2) + 1)
             )
             self._Re = np.random.lognormal(
                 self._mu_lognormal, self._sigma_lognormal, self._n

--- a/landlab/components/lateral_erosion/lateral_erosion.py
+++ b/landlab/components/lateral_erosion/lateral_erosion.py
@@ -388,7 +388,7 @@ class LateralEroder(Component):
             self._inlet_node = inlet_node
             self._inlet_area = inlet_area
             # runoff is an array with values of the area of each node (dx**2)
-            runoffinlet = np.full(grid.number_of_nodes, grid.dx ** 2, dtype=float)
+            runoffinlet = np.full(grid.number_of_nodes, grid.dx**2, dtype=float)
             # Change the runoff at the inlet node to node area + inlet node
             runoffinlet[inlet_node] += inlet_area
             grid.add_field("water__unit_flux_in", runoffinlet, at="node", clobber=True)
@@ -446,7 +446,7 @@ class LateralEroder(Component):
             qsinlet = self._qsinlet
             qs_in[inlet_node] = qsinlet
             q = grid.at_node["surface_water__discharge"]
-            da = q / grid.dx ** 2
+            da = q / grid.dx**2
         # if inlet flag is not on, proceed as normal.
         else:
             da = grid.at_node["drainage_area"]
@@ -501,9 +501,9 @@ class LateralEroder(Component):
             # and lateral erosion is sent downstream
             #            print("debug before 406")
             qs_in[flowdirs[i]] += (
-                qs_in[i] - (dzver[i] * grid.dx ** 2) - (petlat * grid.dx * wd)
+                qs_in[i] - (dzver[i] * grid.dx**2) - (petlat * grid.dx * wd)
             )  # qsin to next node
-        qs[:] = qs_in - (dzver * grid.dx ** 2)
+        qs[:] = qs_in - (dzver * grid.dx**2)
         dzdt[:] = dzver * dt
         vol_lat[:] += vol_lat_dt * dt
         # this loop determines if enough lateral erosion has happened to change
@@ -518,11 +518,11 @@ class LateralEroder(Component):
                     # UC model: this would represent undercutting (the water height at
                     # node i), slumping, and instant removal.
                     if UC == 1:
-                        voldiff = (z[i] + wd - z[flowdirs[i]]) * grid.dx ** 2
+                        voldiff = (z[i] + wd - z[flowdirs[i]]) * grid.dx**2
                     # TB model: entire lat node must be eroded before lateral erosion
                     # occurs
                     if TB == 1:
-                        voldiff = (z[lat_node] - z[flowdirs[i]]) * grid.dx ** 2
+                        voldiff = (z[lat_node] - z[flowdirs[i]]) * grid.dx**2
                     # if the total volume eroded from lat_node is greater than the volume
                     # needed to be removed to make node equal elevation,
                     # then instantaneously remove this height from lat node. already has
@@ -574,7 +574,7 @@ class LateralEroder(Component):
             qsinlet = self._qsinlet
             qs_in[inlet_node] = qsinlet
             q = grid.at_node["surface_water__discharge"]
-            da = q / grid.dx ** 2
+            da = q / grid.dx**2
         # if inlet flag is not on, proceed as normal.
         else:
             # renamed this drainage area set by flow router
@@ -625,10 +625,10 @@ class LateralEroder(Component):
                 # send sediment downstream. sediment eroded from vertical incision
                 # and lateral erosion is sent downstream
                 qs_in[flowdirs[i]] += (
-                    qs_in[i] - (dzver[i] * grid.dx ** 2) - (petlat * grid.dx * wd)
+                    qs_in[i] - (dzver[i] * grid.dx**2) - (petlat * grid.dx * wd)
                 )  # qsin to next node
             # summing qs for this entire timestep
-            qs[:] += qs_in - (dzver * grid.dx ** 2)
+            qs[:] += qs_in - (dzver * grid.dx**2)
             dzdt[:] = dzver
             # Do a time-step check
             # If the downstream node is eroding at a slower rate than the
@@ -678,11 +678,11 @@ class LateralEroder(Component):
                         # UC model: this would represent undercutting (the water height
                         # at node i), slumping, and instant removal.
                         if UC == 1:
-                            voldiff = (z[i] + wd - z[flowdirs[i]]) * grid.dx ** 2
+                            voldiff = (z[i] + wd - z[flowdirs[i]]) * grid.dx**2
                         # TB model: entire lat node must be eroded before lateral
                         # erosion occurs
                         if TB == 1:
-                            voldiff = (z[lat_node] - z[flowdirs[i]]) * grid.dx ** 2
+                            voldiff = (z[lat_node] - z[flowdirs[i]]) * grid.dx**2
                         # if the total volume eroded from lat_node is greater than the volume
                         # needed to be removed to make node equal elevation,
                         # then instantaneously remove this height from lat node. already
@@ -719,7 +719,7 @@ class LateralEroder(Component):
                     # if inlet on, reset drainage area and qsin to reflect inlet conditions
                     # this is the drainage area needed for code below with an inlet
                     # set by spatially varible runoff.
-                    da = q / grid.dx ** 2
+                    da = q / grid.dx**2
                     qs_in[inlet_node] = qsinlet
                 else:
                     # otherwise, drainage area is just drainage area.

--- a/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
+++ b/landlab/components/nonlinear_diffusion/Perron_nl_diffuse.py
@@ -115,9 +115,9 @@ class PerronNLDiffuse(Component):
         self._delta_y = grid.dy
         self._one_over_delta_x = 1.0 / self._delta_x
         self._one_over_delta_y = 1.0 / self._delta_y
-        self._one_over_delta_x_sqd = self._one_over_delta_x ** 2.0
-        self._one_over_delta_y_sqd = self._one_over_delta_y ** 2.0
-        self._b = 1.0 / self._S_crit ** 2.0
+        self._one_over_delta_x_sqd = self._one_over_delta_x**2.0
+        self._one_over_delta_y_sqd = self._one_over_delta_y**2.0
+        self._b = 1.0 / self._S_crit**2.0
 
         ncols = grid.number_of_node_columns
         self._ncols = ncols

--- a/landlab/components/overland_flow/generate_overland_flow_Bates.py
+++ b/landlab/components/overland_flow/generate_overland_flow_Bates.py
@@ -16,7 +16,7 @@ from landlab import Component
 
 
 class OverlandFlowBates(Component):
-    u"""Simulate overland flow using Bates et al. (2010).
+    """Simulate overland flow using Bates et al. (2010).
 
     Landlab component that simulates overland flow using the Bates et al.,
     (2010) approximations of the 1D shallow water equations to be used for 2D
@@ -246,7 +246,7 @@ class OverlandFlowBates(Component):
             * self._dt
             * self._mannings_n_squared
             * abs(self._q[self._active_links])
-            / hflow ** self._ten_thirds
+            / hflow**self._ten_thirds
         )
 
         # Update our water depths

--- a/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
+++ b/landlab/components/overland_flow/generate_overland_flow_deAlmeida.py
@@ -613,7 +613,7 @@ class OverlandFlow(Component):
                     1
                     + self._g
                     * self._dt
-                    * self._mannings_n ** 2.0
+                    * self._mannings_n**2.0
                     * abs(self._q[horiz])
                     / self._h_links[horiz] ** _SEVEN_OVER_THREE
                 )
@@ -632,7 +632,7 @@ class OverlandFlow(Component):
                     1
                     + self._g
                     * self._dt
-                    * self._mannings_n ** 2.0
+                    * self._mannings_n**2.0
                     * abs(self._q[vert])
                     / self._h_links[vert] ** _SEVEN_OVER_THREE
                 )
@@ -776,7 +776,7 @@ class OverlandFlow(Component):
             # as it showed the smallest amount of mass creation in the grid
             # during testing.
             if self._steep_slopes is True:
-                self._h[self._h < self._h_init] = self._h_init * 10.0 ** -3
+                self._h[self._h < self._h_init] = self._h_init * 10.0**-3
 
             # And reset our field values with the newest water depth and
             # discharge.

--- a/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_implicit_kinwave.py
@@ -363,7 +363,7 @@ class KinwaveImplicitOverlandFlow(Component):
                 # Calc outflow
                 Heff = self._weight * self._depth[n] + (1.0 - self._weight) * cc
                 outflow = (
-                    self._vel_coef * (Heff ** self._depth_exp) * self._grad_width_sum[n]
+                    self._vel_coef * (Heff**self._depth_exp) * self._grad_width_sum[n]
                 )  # this is manning/chezy/darcy
 
                 # Send flow downstream. Here we take total inflow discharge

--- a/landlab/components/overland_flow/generate_overland_flow_kinwave.py
+++ b/landlab/components/overland_flow/generate_overland_flow_kinwave.py
@@ -171,7 +171,7 @@ class KinwaveOverlandFlowModel(Component):
 
         # Calculate velocity using the Manning equation.
         self._vel = (
-            -self._sign_slope * self._vel_coef * H_link ** 0.66667 * self._sqrt_slope
+            -self._sign_slope * self._vel_coef * H_link**0.66667 * self._sqrt_slope
         )
 
         # Calculate discharge

--- a/landlab/components/overland_flow/kinematic_wave_rengers.py
+++ b/landlab/components/overland_flow/kinematic_wave_rengers.py
@@ -312,7 +312,7 @@ class KinematicWaveRengers(Component):
                 (_hnew - self._h[active]).sum() / self._h[active].sum()
             )
         n = self._n * (_hnew / self._hc) ** self._negepsilon
-        twothirds_hnewbyn = _hnew ** 0.66666666 / n
+        twothirds_hnewbyn = _hnew**0.66666666 / n
         self._vely[active] = twothirds_hnewbyn * self._vertslopept5
         self._velx[active] = twothirds_hnewbyn * self._hozslopept5
         self._vely[self._posvertgrads] *= -1.0

--- a/landlab/components/pet/potential_evapotranspiration_field.py
+++ b/landlab/components/pet/potential_evapotranspiration_field.py
@@ -393,7 +393,7 @@ class PotentialEvapotranspiration(Component):
             # Sunset Hour Angle - ASCE-EWRI Task Committee Report,
             # Jan-2005 - Eqn 28,(60)
         self._ws = (np.pi / 2.0) - np.arctan(
-            (-1 * np.tan(self._phi) * np.tan(self._sdecl)) / (self._x ** 2.0)
+            (-1 * np.tan(self._phi) * np.tan(self._sdecl)) / (self._x**2.0)
         )
 
         # Extraterrestrial radmodel.docx - ASCE-EWRI Task Committee Report,

--- a/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
+++ b/landlab/components/priority_flood_flow_router/priority_flood_flow_router.py
@@ -825,7 +825,7 @@ class PriorityFloodFlowRouter(Component):
             q = self._hill_discharges
 
         # Create weight for flow accum: both open (status ==1) and closed nodes (status ==4) will have zero weight
-        wg = np.full(self.grid.number_of_nodes, self.grid.dx ** 2)
+        wg = np.full(self.grid.number_of_nodes, self.grid.dx**2)
 
         # Only core nodes (status == 0) need to receive a weight
         wg[self._grid.status_at_node != NodeStatus.CORE] = 0

--- a/landlab/components/radiation/radiation.py
+++ b/landlab/components/radiation/radiation.py
@@ -264,7 +264,7 @@ class Radiation(Component):
         self._Rsflat = self._Rgl * self._flat
 
         # flat surface Net incoming shortwave radiation
-        self._Rnetflat = (1 - self._A) * (1 - 0.65 * (self._N ** 2)) * self._Rsflat
+        self._Rnetflat = (1 - self._A) * (1 - 0.65 * (self._N**2)) * self._Rsflat
 
         self._sloped = np.cos(self._slope) * np.sin(self._alpha) + np.sin(
             self._slope

--- a/landlab/components/spatial_precip/generate_spatial_precip.py
+++ b/landlab/components/spatial_precip/generate_spatial_precip.py
@@ -1174,7 +1174,7 @@ class SpatialPrecipitationDistribution(Component):
                     # ^Samples from distribution of storm areas
 
                     r = np.sqrt(area_val / np.pi)  # value here shd be selected
-                    rsq = r ** 2
+                    rsq = r**2
                     # based on area above in meters to match the UTM values
 
                     # This way of handling storm locations is really quite
@@ -1335,7 +1335,7 @@ class SpatialPrecipitationDistribution(Component):
                     # Xin -> only the open nodes, note
                     self._gauge_dist_km[:entries] = np.sqrt(gdist[mask_name]) / 1000.0
                     self._temp_dataslots2[:entries] = gdist[mask_name] / 1.0e6
-                    self._temp_dataslots2[:entries] *= -2.0 * recess_val ** 2
+                    self._temp_dataslots2[:entries] *= -2.0 * recess_val**2
                     np.exp(
                         self._temp_dataslots2[:entries],
                         out=self._temp_dataslots2[:entries],

--- a/landlab/components/steepness_index/channel_steepness.py
+++ b/landlab/components/steepness_index/channel_steepness.py
@@ -281,7 +281,7 @@ class SteepnessFinder(Component):
                     log_S = np.log10(ch_S[:-1])
                     # we're potentially propagating nans here if S<=0
                     log_ksn = log_S + reftheta * log_A
-                    ch_ksn = 10.0 ** log_ksn
+                    ch_ksn = 10.0**log_ksn
                 # save the answers into the main arrays:
                 assert np.all(self._mask[ch_nodes[:-1]])
                 # Final node gets trimmed off...
@@ -505,7 +505,7 @@ class SteepnessFinder(Component):
             meanlogseg_A = np.mean(logseg_A)
             meanlogseg_S = np.mean(logseg_S)
             logseg_ksn = meanlogseg_S + ref_theta * meanlogseg_A
-            ch_ksn[pts_in_seg] = 10.0 ** logseg_ksn
+            ch_ksn[pts_in_seg] = 10.0**logseg_ksn
             i -= 1
 
         return ch_ksn[:-1]

--- a/landlab/components/stream_power/fastscape_stream_power.py
+++ b/landlab/components/stream_power/fastscape_stream_power.py
@@ -322,7 +322,7 @@ class FastscapeEroder(Component):
             self._K[defined_flow_receivers]
             * dt
             * self._A_to_the_m[defined_flow_receivers]
-            / (flow_link_lengths ** self._n)
+            / (flow_link_lengths**self._n)
         )
 
         # Handle flooded nodes, if any (no erosion there)

--- a/landlab/components/stream_power/sed_flux_dep_incision.py
+++ b/landlab/components/stream_power/sed_flux_dep_incision.py
@@ -529,22 +529,22 @@ class SedDepEroder(Component):
             twothirds = 2.0 / 3.0
             self._Qs_prefactor = (
                 4.0
-                * self._C_MPM ** twothirds
-                * self._fluid_density ** twothirds
+                * self._C_MPM**twothirds
+                * self._fluid_density**twothirds
                 / (self._sed_density - self._fluid_density) ** twothirds
                 * self._g ** (twothirds / 2.0)
-                * mannings_n ** 0.6
+                * mannings_n**0.6
                 * self._k_w ** (1.0 / 15.0)
                 * self._k_Q ** (0.6 + self._b / 15.0)
-                / self._sed_density ** twothirds
+                / self._sed_density**twothirds
             )
             self._Qs_thresh_prefactor = (
                 4.0
                 * (
                     self._C_MPM
                     * self._k_w
-                    * self._k_Q ** self._b
-                    / self._fluid_density ** 0.5
+                    * self._k_Q**self._b
+                    / self._fluid_density**0.5
                     / (self._sed_density - self._fluid_density)
                     / self._g
                     / self._sed_density
@@ -575,7 +575,7 @@ class SedDepEroder(Component):
             """Returns K*f(qs,qc)"""
             sed_flux_fn = (
                 self._kappa
-                * (rel_sed_flux ** self._nu + self._c)
+                * (rel_sed_flux**self._nu + self._c)
                 * np.exp(-self._phi * rel_sed_flux)
             )
         elif self._type == "linear_decline":
@@ -623,7 +623,7 @@ class SedDepEroder(Component):
             def sed_flux_fn_gen(rel_sed_flux_in):
                 return (
                     self._kappa
-                    * (rel_sed_flux_in ** self._nu + self._c)
+                    * (rel_sed_flux_in**self._nu + self._c)
                     * np.exp(-self._phi * rel_sed_flux_in)
                 )
 
@@ -744,7 +744,7 @@ class SedDepEroder(Component):
                     * self._Dchar
                 )
             if self._lamb_flag:
-                variable_shields_crit = 0.15 * node_S ** 0.25
+                variable_shields_crit = 0.15 * node_S**0.25
                 try:
                     variable_thresh = (
                         variable_shields_crit * self._shields_prefactor_to_shear
@@ -756,29 +756,29 @@ class SedDepEroder(Component):
                         * self._Dchar
                     )
 
-            node_Q = self._k_Q * self._runoff_rate * node_A ** self._c
+            node_Q = self._k_Q * self._runoff_rate * node_A**self._c
             shear_stress_prefactor_timesAparts = (
-                self._shear_stress_prefactor * node_Q ** self._point6onelessb
+                self._shear_stress_prefactor * node_Q**self._point6onelessb
             )
             try:
                 transport_capacities_thresh = (
                     self._thresh
                     * self._Qs_thresh_prefactor
                     * self._runoff_rate ** (0.66667 * self._b)
-                    * node_A ** self._Qs_power_onAthresh
+                    * node_A**self._Qs_power_onAthresh
                 )
             except AttributeError:
                 transport_capacities_thresh = (
                     variable_thresh
                     * self._Qs_thresh_prefactor
                     * self._runoff_rate ** (0.66667 * self._b)
-                    * node_A ** self._Qs_power_onAthresh
+                    * node_A**self._Qs_power_onAthresh
                 )
 
             transport_capacity_prefactor_withA = (
                 self._Qs_prefactor
                 * self._runoff_rate ** (0.6 + self._b / 15.0)
-                * node_A ** self._Qs_power_onA
+                * node_A**self._Qs_power_onA
             )
 
             internal_t = 0.0
@@ -801,7 +801,7 @@ class SedDepEroder(Component):
                 # gradient, including in any lake depressions
                 # we DON'T immediately zero trp capacity in the lake.
                 # positive_slopes = np.greater(downward_slopes, 0.)
-                slopes_tothe07 = downward_slopes ** 0.7
+                slopes_tothe07 = downward_slopes**0.7
                 transport_capacities_S = (
                     transport_capacity_prefactor_withA * slopes_tothe07
                 )
@@ -810,7 +810,7 @@ class SedDepEroder(Component):
                 )
                 transport_capacities = np.sqrt(trp_diff * trp_diff * trp_diff)
                 shear_stress = shear_stress_prefactor_timesAparts * slopes_tothe07
-                shear_tothe_a = shear_stress ** self._a
+                shear_tothe_a = shear_stress**self._a
 
                 dt_this_step = dt_secs - internal_t
                 # ^timestep adjustment is made AFTER the dz calc
@@ -935,8 +935,8 @@ class SedDepEroder(Component):
                 internal_t += dt_this_step  # still in seconds, remember
 
         elif self._Qc == "power_law":
-            transport_capacity_prefactor_withA = self._Kt * node_A ** self._mt
-            erosion_prefactor_withA = self._K_unit_time * node_A ** self._m
+            transport_capacity_prefactor_withA = self._Kt * node_A**self._mt
+            erosion_prefactor_withA = self._K_unit_time * node_A**self._m
             # ^doesn't include S**n*f(Qc/Qc)
             internal_t = 0.0
             break_flag = False
@@ -948,8 +948,8 @@ class SedDepEroder(Component):
                 # print counter
                 downward_slopes = node_S.clip(0.0)
                 # positive_slopes = np.greater(downward_slopes, 0.)
-                slopes_tothen = downward_slopes ** self._n
-                slopes_tothent = downward_slopes ** self._nt
+                slopes_tothen = downward_slopes**self._n
+                slopes_tothent = downward_slopes**self._nt
                 transport_capacities = (
                     transport_capacity_prefactor_withA * slopes_tothent
                 )
@@ -1049,7 +1049,7 @@ class SedDepEroder(Component):
         if self._return_ch_props:
             # add the channel property field entries,
             # 'channel__width', 'channel__depth', and 'channel__discharge'
-            W = self._k_w * node_Q ** self._b
+            W = self._k_w * node_Q**self._b
             H = shear_stress / self._rho_g / node_S  # ...sneaky!
             grid.at_node["channel__width"][:] = W
             grid.at_node["channel__depth"][:] = H

--- a/landlab/components/stream_power/stream_power.py
+++ b/landlab/components/stream_power/stream_power.py
@@ -394,7 +394,7 @@ class StreamPowerEroder(Component):
                 * dt
                 * self._A[defined_flow_receivers] ** self._m
                 / self._W[defined_flow_receivers]
-                / (flow_link_lengths ** self._n)
+                / (flow_link_lengths**self._n)
             )
 
         else:
@@ -402,7 +402,7 @@ class StreamPowerEroder(Component):
                 self._K[defined_flow_receivers]
                 * dt
                 * self._A[defined_flow_receivers] ** self._m
-                / (flow_link_lengths ** self._n)
+                / (flow_link_lengths**self._n)
             )
 
         # Handle flooded nodes, if any (no erosion there)

--- a/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
+++ b/landlab/components/taylor_nonlinear_hillslope_flux/taylor_nonlinear_hillslope_flux.py
@@ -269,7 +269,7 @@ class TaylorNonLinearDiffuser(Component):
             courant_slope_term = 0.0
             courant_s_over_scrit = self._slope.max() / self._slope_crit
             for i in range(0, 2 * self._nterms, 2):
-                courant_slope_term += courant_s_over_scrit ** i
+                courant_slope_term += courant_s_over_scrit**i
                 if np.any(np.isinf(courant_slope_term)):
                     message = (
                         "Soil flux term is infinite in Courant condition "
@@ -280,7 +280,7 @@ class TaylorNonLinearDiffuser(Component):
             # Calculate De Max
             De_max = self._K * (courant_slope_term)
             # Calculate longest stable timestep
-            self._dt_max = self._courant_factor * (self._grid.dx ** 2) / De_max
+            self._dt_max = self._courant_factor * (self._grid.dx**2) / De_max
 
             # Test for the Courant condition and print warning if user intended
             # for it to be printed.
@@ -316,7 +316,7 @@ class TaylorNonLinearDiffuser(Component):
             slope_term = 0.0
             s_over_scrit = self._slope / self._slope_crit
             for i in range(0, 2 * self._nterms, 2):
-                slope_term += s_over_scrit ** i
+                slope_term += s_over_scrit**i
                 if np.any(np.isinf(slope_term)):
                     message = (
                         "Soil flux term is infinite. This is likely due to "

--- a/landlab/components/tidal_flow/tidal_flow_calculator.py
+++ b/landlab/components/tidal_flow/tidal_flow_calculator.py
@@ -298,8 +298,8 @@ class TidalFlowCalculator(Component):
         )
 
         # Calculate velocity and diffusion coefficients on links
-        velocity_coef = self._water_depth_at_links ** _FOUR_THIRDS / (
-            (self.roughness ** 2) * self._scale_velocity
+        velocity_coef = self._water_depth_at_links**_FOUR_THIRDS / (
+            (self.roughness**2) * self._scale_velocity
         )
         self._diffusion_coef_at_links[:] = self._water_depth_at_links * velocity_coef
 

--- a/landlab/core/model_parameter_loader.py
+++ b/landlab/core/model_parameter_loader.py
@@ -5,9 +5,9 @@ import yaml
 
 _loader = yaml.SafeLoader
 _loader.add_implicit_resolver(
-    u"tag:yaml.org,2002:float",
+    "tag:yaml.org,2002:float",
     re.compile(
-        u"""^(?:
+        """^(?:
                [-+]?(?:[0-9][0-9_]*)\\.[0-9_]*(?:[eE][-+]?[0-9]+)?
                |[-+]?(?:[0-9][0-9_]*)(?:[eE][-+]?[0-9]+)
                |\\.[0-9_]+(?:[eE][-+][0-9]+)?
@@ -16,7 +16,7 @@ _loader.add_implicit_resolver(
                |\\.(?:nan|NaN|NAN))$""",
         re.X,
     ),
-    list(u"-+0123456789."),
+    list("-+0123456789."),
 )
 
 

--- a/landlab/graph/quantity/of_link.py
+++ b/landlab/graph/quantity/of_link.py
@@ -89,4 +89,4 @@ def get_length_of_link(graph):
     nodes_at_link = graph.nodes_at_link
     dx = graph.x_of_node[nodes_at_link[:, 0]] - graph.x_of_node[nodes_at_link[:, 1]]
     dy = graph.y_of_node[nodes_at_link[:, 0]] - graph.y_of_node[nodes_at_link[:, 1]]
-    return np.sqrt(dx ** 2 + dy ** 2)
+    return np.sqrt(dx**2 + dy**2)

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -1500,7 +1500,7 @@ class RasterModelGrid(
 
         slope = np.zeros([ids.shape[0]], dtype=float)
         aspect = np.zeros([ids.shape[0]], dtype=float)
-        slope = np.arctan(np.sqrt(dz_dx ** 2 + dz_dy ** 2))
+        slope = np.arctan(np.sqrt(dz_dx**2 + dz_dy**2))
         aspect = np.arctan2(dz_dy, -dz_dx)
         aspect = np.pi * 0.5 - aspect
         aspect[aspect < 0.0] = aspect[aspect < 0.0] + 2.0 * np.pi

--- a/landlab/grid/raster_gradients.py
+++ b/landlab/grid/raster_gradients.py
@@ -374,7 +374,7 @@ def calc_grad_across_cell_corners(grid, node_values, *args, **kwds):
     values_at_nodes = node_values[node_ids].reshape(len(node_ids), 1)
 
     out = np.subtract(values_at_diagonals, values_at_nodes, **kwds)
-    np.divide(out, np.sqrt(grid.dy ** 2.0 + grid.dx ** 2.0), out=out)
+    np.divide(out, np.sqrt(grid.dy**2.0 + grid.dx**2.0), out=out)
 
     return out
 

--- a/landlab/io/shapefile/read_shapefile.py
+++ b/landlab/io/shapefile/read_shapefile.py
@@ -415,7 +415,7 @@ def read_shapefile(
             x_diff = grid.x_of_node - point_x
             y_diff = grid.y_of_node - point_y
 
-            dist = np.sqrt(x_diff ** 2 + y_diff ** 2)
+            dist = np.sqrt(x_diff**2 + y_diff**2)
 
             # check that the distance is small.
             if np.min(dist) > threshold:

--- a/landlab/utils/fault_facet_finder.py
+++ b/landlab/utils/fault_facet_finder.py
@@ -325,15 +325,10 @@ class find_facets(object):
                 # new distances is far from the actual pts:
                 multiplier = 10.0 * np.ptp(grid.node_y[grid.core_nodes[nodes_possible]])
                 # derive the position:
-                x_ref = (
-                    grid.node_x[i]
-                    + cmp(
-                        grid.node_x[i],
-                        np.mean(grid.node_x[grid.core_nodes[nodes_possible]]),
-                    )
-                    * multiplier
-                    * abs(grad)
-                )
+                x_ref = grid.node_x[i] + cmp(
+                    grid.node_x[i],
+                    np.mean(grid.node_x[grid.core_nodes[nodes_possible]]),
+                ) * multiplier * abs(grad)
                 y_ref = (
                     grid.node_y[i]
                     + cmp(
@@ -363,7 +358,7 @@ class find_facets(object):
                 # max_diff = 3.*np.median(dist_diffs) #######this might need
                 # attention if there's a heavy tail on the distances
                 if grad < 1:
-                    mod = np.sqrt(1.0 + grad ** 2.0)
+                    mod = np.sqrt(1.0 + grad**2.0)
                 else:
                     mod = np.sqrt(1.0 + (1.0 / grad) ** 2.0)
                 max_diff = 1.9 * mod * grid.dx

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ def read_requirements(filename):
     return requirements
 
 
-long_description = u"\n\n".join(
+long_description = "\n\n".join(
     [
         read("README.rst"),
         read("AUTHORS.rst"),

--- a/tests/components/depression_finder/test_lake_mapper.py
+++ b/tests/components/depression_finder/test_lake_mapper.py
@@ -1404,7 +1404,7 @@ def test_three_pits():
 
     # test conservation of mass:
     assert mg.at_node["drainage_area"].reshape((10, 10))[1:-1, 1].sum() == approx(
-        8.0 ** 2
+        8.0**2
     )
     # ^all the core nodes
 
@@ -1561,7 +1561,7 @@ def test_composite_pits():
 
     # test conservation of mass:
     assert mg.at_node["drainage_area"].reshape((10, 10))[1:-1, 1].sum() == approx(
-        8.0 ** 2
+        8.0**2
     )
     # ^all the core nodes
 

--- a/tests/components/erosion_deposition/test_erodep.py
+++ b/tests/components/erosion_deposition/test_erodep.py
@@ -214,7 +214,7 @@ def test_can_run_with_hex():
     a18 = mg.at_node["drainage_area"][18]
     a28 = mg.at_node["drainage_area"][28]
     s = mg.at_node["topographic__steepest_slope"]
-    s18 = sa_factor * (a18 ** -0.5)
-    s28 = sa_factor * (a28 ** -0.5)
+    s18 = sa_factor * (a18**-0.5)
+    s28 = sa_factor * (a28**-0.5)
     testing.assert_equal(np.round(s[18], 3), np.round(s18, 3))
     testing.assert_equal(np.round(s[28], 3), np.round(s28, 3))

--- a/tests/components/erosion_deposition/test_erodep_steady_state.py
+++ b/tests/components/erosion_deposition/test_erodep_steady_state.py
@@ -45,8 +45,8 @@ def test_erodep_slope_area_small_vs():
     a11 = 2.0
     a12 = 1.0
     s = rg.at_node["topographic__steepest_slope"]
-    s11 = sa_factor * (a11 ** -0.5)
-    s12 = sa_factor * (a12 ** -0.5)
+    s11 = sa_factor * (a11**-0.5)
+    s12 = sa_factor * (a12**-0.5)
     assert_equal(np.round(s[11], 3), np.round(s11, 3))
     assert_equal(np.round(s[12], 3), np.round(s12, 3))
 
@@ -82,8 +82,8 @@ def test_erodep_slope_area_big_vs():
     sa_factor = (1.0 + vs) * U / K
     a11 = 2.0
     a12 = 1.0
-    s11 = sa_factor * (a11 ** -0.5)
-    s12 = sa_factor * (a12 ** -0.5)
+    s11 = sa_factor * (a11**-0.5)
+    s12 = sa_factor * (a12**-0.5)
     assert_equal(np.round(s[11], 2), np.round(s11, 2))
     assert_equal(np.round(s[12], 2), np.round(s12, 2))
 
@@ -119,8 +119,8 @@ def test_erodep_slope_area_with_vs_unity():
     sa_factor = (1.0 + vs) * U / K
     a11 = 2.0
     a12 = 1.0
-    s11 = sa_factor * (a11 ** -0.5)
-    s12 = sa_factor * (a12 ** -0.5)
+    s11 = sa_factor * (a11**-0.5)
+    s12 = sa_factor * (a12**-0.5)
     assert_equal(np.round(s[11], 2), np.round(s11, 2))
     assert_equal(np.round(s[12], 2), np.round(s12, 2))
 
@@ -198,7 +198,7 @@ def test_erodep_slope_area_with_threshold():
     sa_factor = ((1.0 + vs) * U + wc) / K  # approximate sol'n
     a11 = 2.0
     a12 = 1.0
-    s11 = sa_factor * (a11 ** -0.5)
-    s12 = sa_factor * (a12 ** -0.5)
+    s11 = sa_factor * (a11**-0.5)
+    s12 = sa_factor * (a12**-0.5)
     assert_equal(np.round(s[11], 2), np.round(s11, 2))
     assert_equal(np.round(s[12], 2), np.round(s12, 2))

--- a/tests/components/flow_accum/test_flow_accumulator.py
+++ b/tests/components/flow_accum/test_flow_accumulator.py
@@ -28,7 +28,7 @@ def test_check_fields():
 
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     z = mg.add_field(
-        "topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node"
+        "topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node"
     )
 
     FlowAccumulator(mg)
@@ -45,28 +45,28 @@ def test_director_adding_methods_are_equivalent_Steepest():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = FlowAccumulator(mg0, flow_director="D4")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = FlowAccumulator(mg1, flow_director="Steepest")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = FlowAccumulator(mg2, flow_director=FlowDirectorSteepest)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorSteepest(mg3)
     fa3 = FlowAccumulator(mg3, flow_director=fd)
@@ -93,28 +93,28 @@ def test_director_adding_methods_are_equivalent_D8():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = FlowAccumulator(mg0, flow_director="D8")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = FlowAccumulator(mg1, flow_director="FlowDirectorD8")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = FlowAccumulator(mg2, flow_director=FlowDirectorD8)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorD8(mg3)
     fa3 = FlowAccumulator(mg3, flow_director=fd)
@@ -141,28 +141,28 @@ def test_director_adding_methods_are_equivalent_Dinf():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = FlowAccumulator(mg0, flow_director="DINF")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = FlowAccumulator(mg1, flow_director="FlowDirectorDINF")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = FlowAccumulator(mg2, flow_director=FlowDirectorDINF)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorDINF(mg3)
     fa3 = FlowAccumulator(mg3, flow_director=fd)
@@ -189,28 +189,28 @@ def test_director_adding_methods_are_equivalent_MFD():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = FlowAccumulator(mg0, flow_director="MFD")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = FlowAccumulator(mg1, flow_director="FlowDirectorMFD")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = FlowAccumulator(mg2, flow_director=FlowDirectorMFD)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorMFD(mg3)
     fa3 = FlowAccumulator(mg3, flow_director=fd)
@@ -249,12 +249,12 @@ def test_error_for_to_many_with_depression():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
 
     with pytest.raises(NotImplementedError):

--- a/tests/components/flow_accum/test_lossy_flow_accumulator.py
+++ b/tests/components/flow_accum/test_lossy_flow_accumulator.py
@@ -26,7 +26,7 @@ _THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 def test_loss_func_arguments():
     """Check the loss_function only has one argument."""
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
-    mg.add_field("topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node")
+    mg.add_field("topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node")
 
     def funcgood(x):
         return 0.0
@@ -147,7 +147,7 @@ def test_check_fields():
 
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     z = mg.add_field(
-        "topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node"
+        "topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node"
     )
 
     LossyFlowAccumulator(mg)
@@ -172,28 +172,28 @@ def test_director_adding_methods_are_equivalent_Steepest():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = LossyFlowAccumulator(mg0, flow_director="D4")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = LossyFlowAccumulator(mg1, flow_director="Steepest")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = LossyFlowAccumulator(mg2, flow_director=FlowDirectorSteepest)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorSteepest(mg3)
     fa3 = LossyFlowAccumulator(mg3, flow_director=fd)
@@ -212,28 +212,28 @@ def test_director_adding_methods_are_equivalent_D8():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = LossyFlowAccumulator(mg0, flow_director="D8")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = LossyFlowAccumulator(mg1, flow_director="FlowDirectorD8")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = LossyFlowAccumulator(mg2, flow_director=FlowDirectorD8)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorD8(mg3)
     fa3 = LossyFlowAccumulator(mg3, flow_director=fd)
@@ -252,28 +252,28 @@ def test_director_adding_methods_are_equivalent_Dinf():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = LossyFlowAccumulator(mg0, flow_director="DINF")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = LossyFlowAccumulator(mg1, flow_director="FlowDirectorDINF")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = LossyFlowAccumulator(mg2, flow_director=FlowDirectorDINF)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorDINF(mg3)
     fa3 = LossyFlowAccumulator(mg3, flow_director=fd)
@@ -292,28 +292,28 @@ def test_director_adding_methods_are_equivalent_MFD():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     fa0 = LossyFlowAccumulator(mg0, flow_director="MFD")
     fa0.run_one_step()
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     fa1 = LossyFlowAccumulator(mg1, flow_director="FlowDirectorMFD")
     fa1.run_one_step()
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     fa2 = LossyFlowAccumulator(mg2, flow_director=FlowDirectorMFD)
     fa2.run_one_step()
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     fd = FlowDirectorMFD(mg3)
     fa3 = LossyFlowAccumulator(mg3, flow_director=fd)
@@ -344,12 +344,12 @@ def test_error_for_to_many_with_depression():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
 
     with pytest.raises(NotImplementedError):

--- a/tests/components/flow_director/test_dinf.py
+++ b/tests/components/flow_director/test_dinf.py
@@ -247,7 +247,7 @@ def test_D_infinity_SW_slope():
 def test_D_infinity_WSW_slope():
     mg = RasterModelGrid((10, 10))
     mg.add_field(
-        "topographic__elevation", mg.node_y * (2 ** 0.5 - 1.0) + mg.node_x, at="node"
+        "topographic__elevation", mg.node_y * (2**0.5 - 1.0) + mg.node_x, at="node"
     )
     fa = FlowAccumulator(mg, flow_director="FlowDirectorDINF")
     fa.run_one_step()

--- a/tests/components/flow_director/test_flow_director.py
+++ b/tests/components/flow_director/test_flow_director.py
@@ -27,7 +27,7 @@ def test_not_implemented():
     """Test that private run_one_step is not implemented"""
 
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
-    mg.add_field("topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node")
+    mg.add_field("topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node")
 
     fd0 = _FlowDirector(mg, "topographic__elevation")
     with pytest.raises(NotImplementedError):
@@ -45,7 +45,7 @@ def test_not_implemented():
 def test_fields_already_added():
 
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
-    mg.add_field("topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node")
+    mg.add_field("topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node")
     r = mg.add_field("flow__receiver_node", mg.nodes, at="node")
     s = mg.add_field("topographic__steepest_slope", mg.nodes, at="node")
     links_to_receiver = mg.add_field("flow__link_to_receiver_node", mg.nodes, at="node")
@@ -58,7 +58,7 @@ def test_fields_already_added():
 
 def test_grid_type_testing():
     """Test that only the right grids can be implemented."""
-    dx = (2.0 / (3.0 ** 0.5)) ** 0.5
+    dx = (2.0 / (3.0**0.5)) ** 0.5
     hmg = HexModelGrid((3, 3), spacing=dx)
     hmg.add_field(
         "topographic__elevation", hmg.node_x + np.round(hmg.node_y), at="node"
@@ -82,7 +82,7 @@ def test_check_fields():
 
     mg0 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg0.add_field(
-        "topographic__elevation", mg0.node_x ** 2 + mg0.node_y ** 2, at="node"
+        "topographic__elevation", mg0.node_x**2 + mg0.node_y**2, at="node"
     )
     _FlowDirector(mg0, "topographic__elevation")
     assert sorted(list(mg0.at_node.keys())) == [
@@ -93,7 +93,7 @@ def test_check_fields():
 
     mg1 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg1.add_field(
-        "topographic__elevation", mg1.node_x ** 2 + mg1.node_y ** 2, at="node"
+        "topographic__elevation", mg1.node_x**2 + mg1.node_y**2, at="node"
     )
     _FlowDirectorToMany(mg1, "topographic__elevation")
     assert sorted(list(mg1.at_node.keys())) == [
@@ -108,7 +108,7 @@ def test_check_fields():
 
     mg2 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg2.add_field(
-        "topographic__elevation", mg2.node_x ** 2 + mg2.node_y ** 2, at="node"
+        "topographic__elevation", mg2.node_x**2 + mg2.node_y**2, at="node"
     )
     _FlowDirectorToOne(mg2, "topographic__elevation")
     assert sorted(list(mg2.at_node.keys())) == [
@@ -122,7 +122,7 @@ def test_check_fields():
 
     mg3 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg3.add_field(
-        "topographic__elevation", mg3.node_x ** 2 + mg3.node_y ** 2, at="node"
+        "topographic__elevation", mg3.node_x**2 + mg3.node_y**2, at="node"
     )
     FlowDirectorMFD(mg3, "topographic__elevation")
     assert sorted(list(mg3.at_node.keys())) == [
@@ -137,7 +137,7 @@ def test_check_fields():
 
     mg4 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg4.add_field(
-        "topographic__elevation", mg4.node_x ** 2 + mg4.node_y ** 2, at="node"
+        "topographic__elevation", mg4.node_x**2 + mg4.node_y**2, at="node"
     )
     FlowDirectorDINF(mg4, "topographic__elevation")
     assert sorted(list(mg4.at_node.keys())) == [
@@ -152,7 +152,7 @@ def test_check_fields():
 
     mg5 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg5.add_field(
-        "topographic__elevation", mg5.node_x ** 2 + mg5.node_y ** 2, at="node"
+        "topographic__elevation", mg5.node_x**2 + mg5.node_y**2, at="node"
     )
     FlowDirectorSteepest(mg5, "topographic__elevation")
     assert sorted(list(mg5.at_node.keys())) == [
@@ -166,7 +166,7 @@ def test_check_fields():
 
     mg6 = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg6.add_field(
-        "topographic__elevation", mg6.node_x ** 2 + mg6.node_y ** 2, at="node"
+        "topographic__elevation", mg6.node_x**2 + mg6.node_y**2, at="node"
     )
     FlowDirectorD8(mg6, "topographic__elevation")
     assert sorted(list(mg6.at_node.keys())) == [
@@ -181,7 +181,7 @@ def test_check_fields():
 
 def test_properties():
     mg = RasterModelGrid((5, 5), xy_spacing=(1, 1))
-    mg.add_field("topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node")
+    mg.add_field("topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node")
     fd = FlowDirectorMFD(mg, "topographic__elevation")
     fd.run_one_step()
 
@@ -317,7 +317,7 @@ def test_properties():
 
 def test_change_bc_post_init():
     mg = RasterModelGrid((5, 5))
-    mg.add_field("topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node")
+    mg.add_field("topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node")
     fd = FlowDirectorSteepest(mg, "topographic__elevation")
     fd.run_one_step()
     true_reciever = np.array(

--- a/tests/components/flow_director/test_mfd.py
+++ b/tests/components/flow_director/test_mfd.py
@@ -145,11 +145,11 @@ def test_MFD_SW_slope_w_diags():
     true_proportions = np.zeros(fa.flow_director._proportions.shape)
     true_proportions[mg.boundary_nodes, 0] = 1
 
-    total_sum_of_slopes = 1.0 + 1.0 + (2.0 / 2.0 ** 0.5)
+    total_sum_of_slopes = 1.0 + 1.0 + (2.0 / 2.0**0.5)
 
     true_proportions[mg.core_nodes, 2] = 1.0 / total_sum_of_slopes
     true_proportions[mg.core_nodes, 3] = 1.0 / total_sum_of_slopes
-    true_proportions[mg.core_nodes, 6] = (2.0 / 2.0 ** 0.5) / total_sum_of_slopes
+    true_proportions[mg.core_nodes, 6] = (2.0 / 2.0**0.5) / total_sum_of_slopes
 
     assert_array_equal(true_receivers, fa.flow_director._receivers)
     assert_array_almost_equal(true_proportions, fa.flow_director._proportions)
@@ -197,11 +197,11 @@ def test_MFD_S_slope_w_diag():
     true_proportions = np.zeros(fa.flow_director._proportions.shape)
     true_proportions[mg.boundary_nodes, 0] = 1
 
-    total_sum_of_slopes = 1.0 + 2.0 * (1.0 / 2.0 ** 0.5)
+    total_sum_of_slopes = 1.0 + 2.0 * (1.0 / 2.0**0.5)
 
     true_proportions[mg.core_nodes, 3] = 1.0 / total_sum_of_slopes
-    true_proportions[mg.core_nodes, 6] = (1.0 / 2.0 ** 0.5) / total_sum_of_slopes
-    true_proportions[mg.core_nodes, 7] = (1.0 / 2.0 ** 0.5) / total_sum_of_slopes
+    true_proportions[mg.core_nodes, 6] = (1.0 / 2.0**0.5) / total_sum_of_slopes
+    true_proportions[mg.core_nodes, 7] = (1.0 / 2.0**0.5) / total_sum_of_slopes
 
     assert_array_equal(true_receivers, fa.flow_director._receivers)
     assert_array_almost_equal(true_proportions, fa.flow_director._proportions)

--- a/tests/components/lateral_erosion/test_latero.py
+++ b/tests/components/lateral_erosion/test_latero.py
@@ -362,7 +362,7 @@ def test_latero_steady_inlet():
             U * dt
         )  # uplift the landscape
 
-    da = mg.at_node["surface_water__discharge"] / dx ** 2
+    da = mg.at_node["surface_water__discharge"] / dx**2
     num_sedflux = mg.at_node["qs"]
     analytical_sedflux = U * da
 

--- a/tests/components/overland_flow/test_bates_overland_flow.py
+++ b/tests/components/overland_flow/test_bates_overland_flow.py
@@ -67,12 +67,12 @@ def test_Bates_analytical():
     bates.dt = 1.0
     while time < 500:
         bates.overland_flow(grid)
-        h_boundary = ((7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 3) * time) ** (3.0 / 7.0)
+        h_boundary = ((7.0 / 3.0) * (0.01**2) * (0.4**3) * time) ** (3.0 / 7.0)
         grid.at_node["surface_water__depth"][grid.nodes[1:-1, 1]] = h_boundary
         time += bates.dt
 
     x = np.arange(0, ((grid.shape[1]) * grid.dx), grid.dx)
-    h_analytical = -(7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 2) * (x - (0.4 * 500))
+    h_analytical = -(7.0 / 3.0) * (0.01**2) * (0.4**2) * (x - (0.4 * 500))
 
     h_analytical[np.where(h_analytical > 0)] = h_analytical[
         np.where(h_analytical > 0)

--- a/tests/components/overland_flow/test_dealmeida_overland_flow.py
+++ b/tests/components/overland_flow/test_dealmeida_overland_flow.py
@@ -65,12 +65,12 @@ def test_deAlm_analytical():
         ][left_inactive_ids + 1]
         dt = deAlm.calc_time_step()
         deAlm.overland_flow(dt)
-        h_boundary = ((7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 3) * time) ** (3.0 / 7.0)
+        h_boundary = ((7.0 / 3.0) * (0.01**2) * (0.4**3) * time) ** (3.0 / 7.0)
         grid.at_node["surface_water__depth"][grid.nodes[1:-1, 1]] = h_boundary
         time += dt
 
     x = np.arange(0, ((grid.shape[1]) * grid.dx), grid.dx)
-    h_analytical = -(7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 2) * (x - (0.4 * 500))
+    h_analytical = -(7.0 / 3.0) * (0.01**2) * (0.4**2) * (x - (0.4 * 500))
 
     h_analytical[np.where(h_analytical > 0)] = h_analytical[
         np.where(h_analytical > 0)
@@ -98,12 +98,12 @@ def test_deAlm_analytical_imposed_dt_short():
         ][left_inactive_ids + 1]
         dt = 10.0
         deAlm.overland_flow(dt)
-        h_boundary = ((7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 3) * time) ** (3.0 / 7.0)
+        h_boundary = ((7.0 / 3.0) * (0.01**2) * (0.4**3) * time) ** (3.0 / 7.0)
         grid.at_node["surface_water__depth"][grid.nodes[1:-1, 1]] = h_boundary
         time += dt
 
     x = np.arange(0, ((grid.shape[1]) * grid.dx), grid.dx)
-    h_analytical = -(7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 2) * (x - (0.4 * 500))
+    h_analytical = -(7.0 / 3.0) * (0.01**2) * (0.4**2) * (x - (0.4 * 500))
 
     h_analytical[np.where(h_analytical > 0)] = h_analytical[
         np.where(h_analytical > 0)
@@ -131,12 +131,12 @@ def test_deAlm_analytical_imposed_dt_long():
         ][left_inactive_ids + 1]
         dt = 100.0
         deAlm.run_one_step(dt)
-        h_boundary = ((7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 3) * time) ** (3.0 / 7.0)
+        h_boundary = ((7.0 / 3.0) * (0.01**2) * (0.4**3) * time) ** (3.0 / 7.0)
         grid.at_node["surface_water__depth"][grid.nodes[1:-1, 1]] = h_boundary
         time += dt
 
     x = np.arange(0, ((grid.shape[1]) * grid.dx), grid.dx)
-    h_analytical = -(7.0 / 3.0) * (0.01 ** 2) * (0.4 ** 2) * (x - (0.4 * 500))
+    h_analytical = -(7.0 / 3.0) * (0.01**2) * (0.4**2) * (x - (0.4 * 500))
 
     h_analytical[np.where(h_analytical > 0)] = h_analytical[
         np.where(h_analytical > 0)

--- a/tests/components/overland_flow/test_kinwave_implicit.py
+++ b/tests/components/overland_flow/test_kinwave_implicit.py
@@ -115,7 +115,7 @@ def test_curved_surface():
     # Create a grid
     rg = RasterModelGrid((10, 10), xy_spacing=(2, 2))
     rg.add_field(
-        "topographic__elevation", 3.0 * rg.node_x ** 2 + rg.node_y ** 2, at="node"
+        "topographic__elevation", 3.0 * rg.node_x**2 + rg.node_y**2, at="node"
     )
 
     # Create component and run it

--- a/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
+++ b/tests/components/priority_flood_flow_router/test_priority_flood_flow_router.py
@@ -24,7 +24,7 @@ def test_check_fields():
     # %%
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     z = mg.add_field(
-        "topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2, at="node"
+        "topographic__elevation", mg.node_x**2 + mg.node_y**2, at="node"
     )
 
     PriorityFloodFlowRouter(mg)

--- a/tests/components/soil_moisture/conftest.py
+++ b/tests/components/soil_moisture/conftest.py
@@ -23,9 +23,9 @@ def si():
     grid = RasterModelGrid((10, 10), xy_spacing=25)
     grid.add_ones("soil_water_infiltration__depth", at="node", dtype=float)
     grid.add_ones("surface_water__depth", at="node")
-    hydraulic_conductivity = 2.5 * (10 ** -5)
+    hydraulic_conductivity = 2.5 * (10**-5)
     grid.at_node["surface_water__depth"] *= 0.5
-    grid.at_node["soil_water_infiltration__depth"] *= 10 ** -5
+    grid.at_node["soil_water_infiltration__depth"] *= 10**-5
     return SoilInfiltrationGreenAmpt(
         grid,
         hydraulic_conductivity=hydraulic_conductivity,

--- a/tests/components/soil_moisture/test_green_ampt_infil.py
+++ b/tests/components/soil_moisture/test_green_ampt_infil.py
@@ -75,9 +75,9 @@ def test_run_one_step():
     grid = RasterModelGrid((10, 10), xy_spacing=25)
     grid.add_ones("soil_water_infiltration__depth", at="node", dtype=float)
     grid.add_ones("surface_water__depth", at="node")
-    hydraulic_conductivity = 2.5 * (10 ** -6)
+    hydraulic_conductivity = 2.5 * (10**-6)
     grid["node"]["surface_water__depth"] *= 5.0
-    grid["node"]["soil_water_infiltration__depth"] *= 10 ** -5
+    grid["node"]["soil_water_infiltration__depth"] *= 10**-5
     SI = SoilInfiltrationGreenAmpt(
         grid,
         hydraulic_conductivity=hydraulic_conductivity,

--- a/tests/components/stream_power/test_smooth_thresh.py
+++ b/tests/components/stream_power/test_smooth_thresh.py
@@ -37,7 +37,7 @@ def test_no_thresh():
     actual_slopes = mg.at_node["topographic__steepest_slope"][mg.core_nodes[1:-1]]
     actual_areas = mg.at_node["drainage_area"][mg.core_nodes[1:-1]]
 
-    predicted_slopes = (U / (K * (actual_areas ** m))) ** (1.0 / n)
+    predicted_slopes = (U / (K * (actual_areas**m))) ** (1.0 / n)
 
     assert_array_almost_equal(actual_slopes, predicted_slopes)
 
@@ -65,8 +65,8 @@ def test_with_thresh():
     actual_slopes = mg.at_node["topographic__steepest_slope"][mg.core_nodes[1:-1]]
     actual_areas = mg.at_node["drainage_area"][mg.core_nodes[1:-1]]
 
-    predicted_slopes_upper = ((U + threshold) / (K * (actual_areas ** m))) ** (1.0 / n)
-    predicted_slopes_lower = ((U + 0.0) / (K * (actual_areas ** m))) ** (1.0 / n)
+    predicted_slopes_upper = ((U + threshold) / (K * (actual_areas**m))) ** (1.0 / n)
+    predicted_slopes_lower = ((U + 0.0) / (K * (actual_areas**m))) ** (1.0 / n)
 
     # assert actual and predicted slopes are in the correct range for the slopes.
     assert np.all(actual_slopes > predicted_slopes_lower)

--- a/tests/graph/sort/test_intpair.py
+++ b/tests/graph/sort/test_intpair.py
@@ -153,7 +153,7 @@ def test_map_pairs_all_missing():
 
 
 def test_map_pairs_big_data():
-    n_src_pairs = 2 ** 20
+    n_src_pairs = 2**20
     src = np.random.randint(n_src_pairs * 2, size=n_src_pairs * 2, dtype=int).reshape(
         (-1, 2)
     )

--- a/tests/graph/structured_quad/test_quad.py
+++ b/tests/graph/structured_quad/test_quad.py
@@ -148,7 +148,7 @@ def test_layouts_match(method):
 def test_layouts_cython_is_faster(method, size):
     from timeit import timeit
 
-    n_rows, n_cols = 3 * 2 ** size, 4 * 2 ** size
+    n_rows, n_cols = 3 * 2**size, 4 * 2**size
 
     def time_method(impl):
         return timeit(

--- a/tests/graph/voronoi/test_voronoi_to_graph.py
+++ b/tests/graph/voronoi/test_voronoi_to_graph.py
@@ -246,7 +246,7 @@ def test_has_suffix(hex_graph, at):
 
 @pytest.mark.parametrize(
     "n_nodes",
-    [2 ** 10, 2 ** 11, 2 ** 12, 2 ** 13, 2 ** 14, 2 ** 15],  # , 2 ** 16, 2 ** 20]
+    [2**10, 2**11, 2**12, 2**13, 2**14, 2**15],  # , 2 ** 16, 2 ** 20]
 )
 def test_big_graph(n_nodes):
     xy_of_node = np.random.rand(2 * n_nodes).reshape((-1, 2))

--- a/tests/io/shapefile/test_infer_dtype.py
+++ b/tests/io/shapefile/test_infer_dtype.py
@@ -59,7 +59,7 @@ def test_infer_dtype_from_mixed(values, dst_type, expected):
         | hynp.integer_dtypes()
         | hynp.complex_number_dtypes(),
         shape=hynp.array_shapes(),
-        elements=integers(0, 2 ** 7 - 1),
+        elements=integers(0, 2**7 - 1),
     ),
     dst_type=hynp.floating_dtypes()
     | hynp.integer_dtypes()
@@ -78,7 +78,7 @@ def test_dtype_keyword(as_iterable, values, dst_type):
         | hynp.integer_dtypes()
         | hynp.complex_number_dtypes(),
         shape=hynp.array_shapes(),
-        elements=integers(0, 2 ** 7 - 1),
+        elements=integers(0, 2**7 - 1),
     ),
     dst_type=hynp.floating_dtypes()
     | hynp.integer_dtypes()

--- a/tests/plot/test_drainage_plot.py
+++ b/tests/plot/test_drainage_plot.py
@@ -8,7 +8,7 @@ from landlab.plot.drainage_plot import drainage_plot
 def make_grid():
     mg = RasterModelGrid((10, 10), xy_spacing=(1, 1))
     mg.add_field(
-        "topographic__elevation", mg.node_x ** 2 + mg.node_y ** 2 + mg.node_y, at="node"
+        "topographic__elevation", mg.node_x**2 + mg.node_y**2 + mg.node_y, at="node"
     )
     return mg
 


### PR DESCRIPTION
This pull request updates the *black* action to use the *options* and *src* options rather than *args*.

The latest version of *black* (v22.1, the first non-beta release!) changed its opinion on some syntax—in particular, the `**` operator. The change is for the better (`x**a` vs. `x ** a`, for example) but means everything needs to be reformatted, which I've also done in this pull request.

This change to *black* is the reason our CI tests have been failing for the last couple of days.