### PR TITLE
Setup towncrier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,39 +2,7 @@
 Changelog for landlab
 =====================
 
-
-2.5.0 (unreleased)
-------------------
-
-New Components
-``````````````
-
-- Added CarbonateProducer component (`#1284 <https://github.com/landlab/landlab/issues/1284>`_)
-- LinearDiffusionOverlandFlowRouter: overland flow using the linearized diffusion-wave approximation (`#1383 <https://github.com/landlab/landlab/issues/1383>`_)
-
-
-New Features
-````````````
-
-- add at_layer variables at elements other than cell (`#1292 <https://github.com/landlab/landlab/issues/1292>`_)
-- add field units with create_grid (`#1358 <https://github.com/landlab/landlab/issues/1358>`_)
-- create network grid from raster grid functionality (`#1360 <https://github.com/landlab/landlab/issues/1360>`_)
-- make qs_in a field called sediment__influx (`#1370 <https://github.com/landlab/landlab/issues/1370>`_)
-
-
-Bug Fixes
-`````````
-
-- clip active layer thickness to zero (`#1356 <https://github.com/landlab/landlab/issues/1356>`_)
-- install with richdem even if it is not available (`#1379 <https://github.com/landlab/landlab/issues/1379>`_)
-
-
-Other Changes and Additions
-```````````````````````````
-
-- add OPENTOPOGRAPHY_API_KEY to notebook tests (`#1384 <https://github.com/landlab/landlab/issues/1384>`_)
-- update coding style to conform to new version of black (`#1385 <https://github.com/landlab/landlab/issues/1385>`_)
-
+ .. towncrier release notes start
 
 2.4.1 (2021-12-02)
 ------------------
@@ -81,8 +49,9 @@ New Tutorial Notebooks
 - Added tutorial notebook for kinwave impl (`#1308 <https://github.com/landlab/landlab/issues/1308>`_)
 - Added tutorial notebook for taylor diffuser (`#1309 <https://github.com/landlab/landlab/issues/1309>`_)
 - Added notebook tutorials for two components (both written by Jordan Adams):
-    * ``DepthSlopeProductErosion``,
-    * ``DetachmentLtdErosion``
+  * ``DepthSlopeProductErosion``,
+  * ``DetachmentLtdErosion``
+
   Added a tutorial showing how to "D4 pit fill" a DEM, and a version of the simple ``hugo_site.asc`` DEM that has been pit-filled. (`#1313 <https://github.com/landlab/landlab/issues/1313>`_)
 - Added tutorial notebook for Space component (`#1314 <https://github.com/landlab/landlab/issues/1314>`_)
 - Added tutorial notebook for erosiondeposition ttl (`#1315 <https://github.com/landlab/landlab/issues/1315>`_)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,134 +3,183 @@ Changelog for landlab
 =====================
 
 
-2.4.2 (unreleased)
+2.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+New Components
+``````````````
+
+- Added CarbonateProducer component (`#1284 <https://github.com/python-attrs/attrs/issues/1284>`_)
+- LinearDiffusionOverlandFlowRouter: overland flow using the linearized diffusion-wave approximation (`#1383 <https://github.com/python-attrs/attrs/issues/1383>`_)
+
+
+New Features
+````````````
+
+- add at_layer variables at elements other than cell (`#1292 <https://github.com/python-attrs/attrs/issues/1292>`_)
+- add field units with create_grid (`#1358 <https://github.com/python-attrs/attrs/issues/1358>`_)
+- create network grid from raster grid functionality (`#1360 <https://github.com/python-attrs/attrs/issues/1360>`_)
+- make qs_in a field called sediment__influx (`#1370 <https://github.com/python-attrs/attrs/issues/1370>`_)
+
+
+Bug Fixes
+`````````
+
+- clip active layer thickness to zero (`#1356 <https://github.com/python-attrs/attrs/issues/1356>`_)
+- install with richdem even if it is not available (`#1379 <https://github.com/python-attrs/attrs/issues/1379>`_)
+
+
+Other Changes and Additions
+```````````````````````````
+
+- add OPENTOPOGRAPHY_API_KEY to notebook tests (`#1384 <https://github.com/python-attrs/attrs/issues/1384>`_)
+- update coding style to conform to new version of black (`#1385 <https://github.com/python-attrs/attrs/issues/1385>`_)
 
 
 2.4.1 (2021-12-02)
 ------------------
 
-- Fixed the building of source distributions for prerelease and release
-  workflows (#1372); fixed a bug that causes release workflows to not
-  be triggered (#1371)
+New Tutorial Notebooks
+``````````````````````
 
-- Added two ABM tutorial notebooks (#1364)
+- Added two ABM tutorial notebooks (`#1364 <https://github.com/python-attrs/attrs/issues/1364>`_)
+
+
+Other Changes and Additions
+```````````````````````````
+
+- fixed a bug that causes release workflows to not be triggered (`#1371 <https://github.com/python-attrs/attrs/issues/1371>`_)
+- Fixed the building of source distributions for prerelease and release
+  workflows (`#1372 <https://github.com/python-attrs/attrs/issues/1372>`_)
+
 
 2.4.0 (2021-11-29)
 ------------------
 
-- Changed GitHub actions to use cibuildwheel for building wheels (#1368)
+Other Changes and Additions
+```````````````````````````
+
+- Changed GitHub actions to use cibuildwheel for building wheels (`#1368 <https://github.com/python-attrs/attrs/issues/1368>`_)
 
 
 2.4.0b0 (2021-11-28)
 --------------------
 
-- Added BedrockLandslider component (#1362)
+New Components
+``````````````
 
-- Added PriorityFloodFlowRouter and SpaceLargeScaleEroder components (#1351)
+- ListricKinematicExtender: Simulate Extensional Tectonic Motion on a Listric Fault Plane (`#1283 <https://github.com/python-attrs/attrs/issues/1283>`_)
+- PriorityFloodFlowRouter and SpaceLargeScaleEroder (`#1352 <https://github.com/python-attrs/attrs/issues/1352>`_)
+- Added BedrockLandslider component (`#1362 <https://github.com/python-attrs/attrs/issues/1362>`_)
 
-- Infer data types of fields when reading from shape files (#1357)
 
-- Fixed pits and division by zero in lateral_erosion component (#1353)
+New Tutorial Notebooks
+``````````````````````
 
-- Check that notebooks are both clean and blackened as part of continuous integration (#1355)
+- Added tutorial notebook for depth dependent taylor diffuser (`#1306 <https://github.com/python-attrs/attrs/issues/1306>`_)
+- Added tutorial notebook for chi finder (`#1307 <https://github.com/python-attrs/attrs/issues/1307>`_)
+- Added tutorial notebook for kinwave impl (`#1308 <https://github.com/python-attrs/attrs/issues/1308>`_)
+- Added tutorial notebook for taylor diffuser (`#1309 <https://github.com/python-attrs/attrs/issues/1309>`_)
+- Added notebook tutorials for two components (both written by Jordan Adams):
+    * ``DepthSlopeProductErosion``,
+    * ``DetachmentLtdErosion``
+  Added a tutorial showing how to "D4 pit fill" a DEM, and a version of the simple ``hugo_site.asc`` DEM that has been pit-filled. (`#1313 <https://github.com/python-attrs/attrs/issues/1313>`_)
+- Added tutorial notebook for Space component (`#1314 <https://github.com/python-attrs/attrs/issues/1314>`_)
+- Added tutorial notebook for erosiondeposition ttl (`#1315 <https://github.com/python-attrs/attrs/issues/1315>`_)
+- Added tutorial notebook for erodep (`#1317 <https://github.com/python-attrs/attrs/issues/1317>`_)
+- Added tutorial notebook for StreamPowerSmoothThresholdEroder (`#1331 <https://github.com/python-attrs/attrs/issues/1331>`_)
 
-- Removed usages of np.int from Cython code (#1354)
 
-- Added a link to launch landlab notebooks on the CSDMS JupyterHub (#1347)
+New Features
+````````````
 
-- Added new references to landlab (#1344)
+- Infer data types of fields when reading from shape files (`#1357 <https://github.com/python-attrs/attrs/issues/1357>`_)
 
-- Fixed documentation errors in green ampt component (#1343)
 
-- Added a pre-commit configuration file (#1338)
+Bug Fixes
+`````````
 
-- Drop the "file:" prefix when referencing pip requirements files (#1339)
+- Fixed ability to pass a masked array to imshow_grid_at_node (`#1297 <https://github.com/python-attrs/attrs/issues/1297>`_)
+- Fixed xarray 'axis' keyword error in map function (`#1300 <https://github.com/python-attrs/attrs/issues/1300>`_)
+- Fixed a missing absolute value in Courant condition in dupuit_percolator (`#1311 <https://github.com/python-attrs/attrs/issues/1311>`_)
+- Fixed pits and division by zero in lateral_erosion component (`#1353 <https://github.com/python-attrs/attrs/issues/1353>`_)
 
-- Changed continuous integration to always check the docs build; run the link checker on docs  (#1336)
 
-- Added tutorial notebook for smooth thresh eroder (#1331)
+Documentation Enhancements
+``````````````````````````
 
-- Added tutorial notebook for Space component (#1314)
+- Updated installation instructions (`#1287 <https://github.com/python-attrs/attrs/issues/1287>`_)
+- Minor updates to documentation (`#1290 <https://github.com/python-attrs/attrs/issues/1290>`_)
+- Run the link checker on docs (`#1336 <https://github.com/python-attrs/attrs/issues/1336>`_)
+- Fixed documentation errors in green ampt component (`#1343 <https://github.com/python-attrs/attrs/issues/1343>`_)
+- Added new references to landlab (`#1344 <https://github.com/python-attrs/attrs/issues/1344>`_)
+- Added a link to launch landlab notebooks on the CSDMS JupyterHub (`#1347 <https://github.com/python-attrs/attrs/issues/1347>`_)
 
-- Fixed warnings related to unnecessary use of numpy number types (#1323)
 
-- Fixed ability to pass a masked array to imshow_grid_at_node (#1297)
+Other Changes and Additions
+```````````````````````````
 
-- Fixed a missing absolute value in Courant condition in dupuit_percolator (#1311)
-
-- Added tutorial notebook for erodep (#1317)
-
-- Added tutorial notebook for erosiondeposition ttl (#1315)
-
-- Added tutorial notebook for kinwave impl (#1308)
-
-- Added tutorial notebook for dep slope eroder
-
-- Added tutorial notebook for depth dependent taylor diffuser (#1306)
-
-- Added tutorial notebook for taylor diffuser (#1309)
-
-- Added tutorial notebook for chi finder (#1307)
-
-- Fixed xarray 'axis' keyword error in map function (#1300)
-
-- Minor updates to documentation (#1290)
-
-- Gt/kinematic extender (#1283)
-
-- Updated installation instructions (#1287)
+- Fixed warnings related to unnecessary use of numpy number types (`#1323 <https://github.com/python-attrs/attrs/issues/1323>`_)
+- Changed continuous integration to always check the docs build (`#1336 <https://github.com/python-attrs/attrs/issues/1336>`_)
+- Added a pre-commit configuration file (`#1338 <https://github.com/python-attrs/attrs/issues/1338>`_)
+- Drop the "file:" prefix when referencing pip requirements files (`#1339 <https://github.com/python-attrs/attrs/issues/1339>`_)
+- Removed usages of np.int from Cython code (`#1354 <https://github.com/python-attrs/attrs/issues/1354>`_)
+- Check that notebooks are both clean and blackened as part of continuous integration (`#1355 <https://github.com/python-attrs/attrs/issues/1355>`_)
 
 
 2.3.0 (2021-03-19)
 ------------------
 
-- Fixed a bug when adding a missing at_grid field when testing components (#1286)
+New Components
+``````````````
 
-- Cleaned up landlab metadata files (#1285)
+- Added a tidal flow component (`#1225 <https://github.com/python-attrs/attrs/issues/1225>`_)
+- Added ExponentialWeathererIntegrated component (`#1254 <https://github.com/python-attrs/attrs/issues/1254>`_)
+- Added simple submarine diffuser component (`#1269 <https://github.com/python-attrs/attrs/issues/1269>`_)
 
-- Removed versioneer, we'll use zest.releaser from now on the manage versions (#1285)
 
-- Added release and prerelease github actions (#1275)
+New Tutorial Notebooks
+``````````````````````
 
-- Fixed a bug in the FlowAccumulator to update pit present logic to also include node
-  flood status (#1277)
+- Added tutorial for river input to LEMs (`#1258 <https://github.com/python-attrs/attrs/issues/1258>`_)
 
-- Fixed an error in the streampower notebook (#1260)
 
-- Added building and testing of landlab with Python 3.9 (#1274)
+New Features
+````````````
 
-- Added additional references for 2020/21 (#1273)
+- Added recharge to the GroundwaterDupuitPercolator callback (`#1223 <https://github.com/python-attrs/attrs/issues/1223>`_)
+- Added Wavefront OBJ output (`#1241 <https://github.com/python-attrs/attrs/issues/1241>`_)
 
-- Added simple submarine diffuser component (#1269)
 
-- Changed to use GitHub Actions for CI (#1270)
+Bug Fixes
+`````````
 
-- Added tutorial for river input to LEMs (#1258)
+- Fixed bug in Flow router/depression finder which incorrectly directed flow (`#1248 <https://github.com/python-attrs/attrs/issues/1248>`_)
+- Fixed an error in the streampower notebook (`#1260 <https://github.com/python-attrs/attrs/issues/1260>`_)
+- Fixed a bug in the FlowAccumulator to update pit present logic to also include node flood status (`#1277 <https://github.com/python-attrs/attrs/issues/1277>`_)
+- Fixed a bug when adding a missing at_grid field when testing components (`#1286 <https://github.com/python-attrs/attrs/issues/1286>`_)
 
-- Added a tidal flow component (#1225)
 
-- Added a reference to the papers and presentations list (#1255)
+Documentation Enhancements
+``````````````````````````
 
-- Fixed bug in Flow router/depression finder which incorrectly directed flow (#1248)
+- Fixed documentation bugs (`#1233 <https://github.com/python-attrs/attrs/issues/1233>`_)
+- Added two 2020 publications (`#1243 <https://github.com/python-attrs/attrs/issues/1243>`_)
+- Added docs for the flow accumulator (`#1251 <https://github.com/python-attrs/attrs/issues/1251>`_)
+- Added a reference to the papers and presentations list (`#1255 <https://github.com/python-attrs/attrs/issues/1255>`_)
+- Added additional references for 2020 and 2021 (`#1273 <https://github.com/python-attrs/attrs/issues/1273>`_)
 
-- Added ExponentialWeathererIntegrated component (#1254)
 
-- Added docs for the flow accumulator (#1251)
+Other Changes and Additions
+```````````````````````````
 
-- Added Wavefront OBJ output (#1241)
+- NetworkSedimentTtransporter JOSS paper fixes (`#1235 <https://github.com/python-attrs/attrs/issues/1235>`_)
+- Small changes to JOSS paper (`#1237 <https://github.com/python-attrs/attrs/issues/1237>`_)
+- Changed to use GitHub Actions for CI (`#1270 <https://github.com/python-attrs/attrs/issues/1270>`_)
+- Added building and testing of landlab with Python 3.9 (`#1274 <https://github.com/python-attrs/attrs/issues/1274>`_)
+- Added release and prerelease github actions (`#1275 <https://github.com/python-attrs/attrs/issues/1275>`_)
+- Cleaned up landlab metadata files; Removed versioneer, we'll use zest.releaser from now on the manage versions (`#1285 <https://github.com/python-attrs/attrs/issues/1285>`_)
 
-- Added two 2020 publications (#1243)
-
-- Small changes to JOSS paper (#1237)
-
-- Added recharge to the GroundwaterDupuitPercolator callback (#1223)
-
-- NetworkSedimentTtransporter JOSS paper fixes (#1235)
-
-- Fixed documentation bugs (#1233)
 
 1.5.1 (2018-06-22)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,31 +9,31 @@ Changelog for landlab
 New Components
 ``````````````
 
-- Added CarbonateProducer component (`#1284 <https://github.com/python-attrs/attrs/issues/1284>`_)
-- LinearDiffusionOverlandFlowRouter: overland flow using the linearized diffusion-wave approximation (`#1383 <https://github.com/python-attrs/attrs/issues/1383>`_)
+- Added CarbonateProducer component (`#1284 <https://github.com/landlab/landlab/issues/1284>`_)
+- LinearDiffusionOverlandFlowRouter: overland flow using the linearized diffusion-wave approximation (`#1383 <https://github.com/landlab/landlab/issues/1383>`_)
 
 
 New Features
 ````````````
 
-- add at_layer variables at elements other than cell (`#1292 <https://github.com/python-attrs/attrs/issues/1292>`_)
-- add field units with create_grid (`#1358 <https://github.com/python-attrs/attrs/issues/1358>`_)
-- create network grid from raster grid functionality (`#1360 <https://github.com/python-attrs/attrs/issues/1360>`_)
-- make qs_in a field called sediment__influx (`#1370 <https://github.com/python-attrs/attrs/issues/1370>`_)
+- add at_layer variables at elements other than cell (`#1292 <https://github.com/landlab/landlab/issues/1292>`_)
+- add field units with create_grid (`#1358 <https://github.com/landlab/landlab/issues/1358>`_)
+- create network grid from raster grid functionality (`#1360 <https://github.com/landlab/landlab/issues/1360>`_)
+- make qs_in a field called sediment__influx (`#1370 <https://github.com/landlab/landlab/issues/1370>`_)
 
 
 Bug Fixes
 `````````
 
-- clip active layer thickness to zero (`#1356 <https://github.com/python-attrs/attrs/issues/1356>`_)
-- install with richdem even if it is not available (`#1379 <https://github.com/python-attrs/attrs/issues/1379>`_)
+- clip active layer thickness to zero (`#1356 <https://github.com/landlab/landlab/issues/1356>`_)
+- install with richdem even if it is not available (`#1379 <https://github.com/landlab/landlab/issues/1379>`_)
 
 
 Other Changes and Additions
 ```````````````````````````
 
-- add OPENTOPOGRAPHY_API_KEY to notebook tests (`#1384 <https://github.com/python-attrs/attrs/issues/1384>`_)
-- update coding style to conform to new version of black (`#1385 <https://github.com/python-attrs/attrs/issues/1385>`_)
+- add OPENTOPOGRAPHY_API_KEY to notebook tests (`#1384 <https://github.com/landlab/landlab/issues/1384>`_)
+- update coding style to conform to new version of black (`#1385 <https://github.com/landlab/landlab/issues/1385>`_)
 
 
 2.4.1 (2021-12-02)
@@ -42,15 +42,15 @@ Other Changes and Additions
 New Tutorial Notebooks
 ``````````````````````
 
-- Added two ABM tutorial notebooks (`#1364 <https://github.com/python-attrs/attrs/issues/1364>`_)
+- Added two ABM tutorial notebooks (`#1364 <https://github.com/landlab/landlab/issues/1364>`_)
 
 
 Other Changes and Additions
 ```````````````````````````
 
-- fixed a bug that causes release workflows to not be triggered (`#1371 <https://github.com/python-attrs/attrs/issues/1371>`_)
+- fixed a bug that causes release workflows to not be triggered (`#1371 <https://github.com/landlab/landlab/issues/1371>`_)
 - Fixed the building of source distributions for prerelease and release
-  workflows (`#1372 <https://github.com/python-attrs/attrs/issues/1372>`_)
+  workflows (`#1372 <https://github.com/landlab/landlab/issues/1372>`_)
 
 
 2.4.0 (2021-11-29)
@@ -59,7 +59,7 @@ Other Changes and Additions
 Other Changes and Additions
 ```````````````````````````
 
-- Changed GitHub actions to use cibuildwheel for building wheels (`#1368 <https://github.com/python-attrs/attrs/issues/1368>`_)
+- Changed GitHub actions to use cibuildwheel for building wheels (`#1368 <https://github.com/landlab/landlab/issues/1368>`_)
 
 
 2.4.0b0 (2021-11-28)
@@ -68,63 +68,63 @@ Other Changes and Additions
 New Components
 ``````````````
 
-- ListricKinematicExtender: Simulate Extensional Tectonic Motion on a Listric Fault Plane (`#1283 <https://github.com/python-attrs/attrs/issues/1283>`_)
-- PriorityFloodFlowRouter and SpaceLargeScaleEroder (`#1352 <https://github.com/python-attrs/attrs/issues/1352>`_)
-- Added BedrockLandslider component (`#1362 <https://github.com/python-attrs/attrs/issues/1362>`_)
+- ListricKinematicExtender: Simulate Extensional Tectonic Motion on a Listric Fault Plane (`#1283 <https://github.com/landlab/landlab/issues/1283>`_)
+- PriorityFloodFlowRouter and SpaceLargeScaleEroder (`#1352 <https://github.com/landlab/landlab/issues/1352>`_)
+- Added BedrockLandslider component (`#1362 <https://github.com/landlab/landlab/issues/1362>`_)
 
 
 New Tutorial Notebooks
 ``````````````````````
 
-- Added tutorial notebook for depth dependent taylor diffuser (`#1306 <https://github.com/python-attrs/attrs/issues/1306>`_)
-- Added tutorial notebook for chi finder (`#1307 <https://github.com/python-attrs/attrs/issues/1307>`_)
-- Added tutorial notebook for kinwave impl (`#1308 <https://github.com/python-attrs/attrs/issues/1308>`_)
-- Added tutorial notebook for taylor diffuser (`#1309 <https://github.com/python-attrs/attrs/issues/1309>`_)
+- Added tutorial notebook for depth dependent taylor diffuser (`#1306 <https://github.com/landlab/landlab/issues/1306>`_)
+- Added tutorial notebook for chi finder (`#1307 <https://github.com/landlab/landlab/issues/1307>`_)
+- Added tutorial notebook for kinwave impl (`#1308 <https://github.com/landlab/landlab/issues/1308>`_)
+- Added tutorial notebook for taylor diffuser (`#1309 <https://github.com/landlab/landlab/issues/1309>`_)
 - Added notebook tutorials for two components (both written by Jordan Adams):
     * ``DepthSlopeProductErosion``,
     * ``DetachmentLtdErosion``
-  Added a tutorial showing how to "D4 pit fill" a DEM, and a version of the simple ``hugo_site.asc`` DEM that has been pit-filled. (`#1313 <https://github.com/python-attrs/attrs/issues/1313>`_)
-- Added tutorial notebook for Space component (`#1314 <https://github.com/python-attrs/attrs/issues/1314>`_)
-- Added tutorial notebook for erosiondeposition ttl (`#1315 <https://github.com/python-attrs/attrs/issues/1315>`_)
-- Added tutorial notebook for erodep (`#1317 <https://github.com/python-attrs/attrs/issues/1317>`_)
-- Added tutorial notebook for StreamPowerSmoothThresholdEroder (`#1331 <https://github.com/python-attrs/attrs/issues/1331>`_)
+  Added a tutorial showing how to "D4 pit fill" a DEM, and a version of the simple ``hugo_site.asc`` DEM that has been pit-filled. (`#1313 <https://github.com/landlab/landlab/issues/1313>`_)
+- Added tutorial notebook for Space component (`#1314 <https://github.com/landlab/landlab/issues/1314>`_)
+- Added tutorial notebook for erosiondeposition ttl (`#1315 <https://github.com/landlab/landlab/issues/1315>`_)
+- Added tutorial notebook for erodep (`#1317 <https://github.com/landlab/landlab/issues/1317>`_)
+- Added tutorial notebook for StreamPowerSmoothThresholdEroder (`#1331 <https://github.com/landlab/landlab/issues/1331>`_)
 
 
 New Features
 ````````````
 
-- Infer data types of fields when reading from shape files (`#1357 <https://github.com/python-attrs/attrs/issues/1357>`_)
+- Infer data types of fields when reading from shape files (`#1357 <https://github.com/landlab/landlab/issues/1357>`_)
 
 
 Bug Fixes
 `````````
 
-- Fixed ability to pass a masked array to imshow_grid_at_node (`#1297 <https://github.com/python-attrs/attrs/issues/1297>`_)
-- Fixed xarray 'axis' keyword error in map function (`#1300 <https://github.com/python-attrs/attrs/issues/1300>`_)
-- Fixed a missing absolute value in Courant condition in dupuit_percolator (`#1311 <https://github.com/python-attrs/attrs/issues/1311>`_)
-- Fixed pits and division by zero in lateral_erosion component (`#1353 <https://github.com/python-attrs/attrs/issues/1353>`_)
+- Fixed ability to pass a masked array to imshow_grid_at_node (`#1297 <https://github.com/landlab/landlab/issues/1297>`_)
+- Fixed xarray 'axis' keyword error in map function (`#1300 <https://github.com/landlab/landlab/issues/1300>`_)
+- Fixed a missing absolute value in Courant condition in dupuit_percolator (`#1311 <https://github.com/landlab/landlab/issues/1311>`_)
+- Fixed pits and division by zero in lateral_erosion component (`#1353 <https://github.com/landlab/landlab/issues/1353>`_)
 
 
 Documentation Enhancements
 ``````````````````````````
 
-- Updated installation instructions (`#1287 <https://github.com/python-attrs/attrs/issues/1287>`_)
-- Minor updates to documentation (`#1290 <https://github.com/python-attrs/attrs/issues/1290>`_)
-- Run the link checker on docs (`#1336 <https://github.com/python-attrs/attrs/issues/1336>`_)
-- Fixed documentation errors in green ampt component (`#1343 <https://github.com/python-attrs/attrs/issues/1343>`_)
-- Added new references to landlab (`#1344 <https://github.com/python-attrs/attrs/issues/1344>`_)
-- Added a link to launch landlab notebooks on the CSDMS JupyterHub (`#1347 <https://github.com/python-attrs/attrs/issues/1347>`_)
+- Updated installation instructions (`#1287 <https://github.com/landlab/landlab/issues/1287>`_)
+- Minor updates to documentation (`#1290 <https://github.com/landlab/landlab/issues/1290>`_)
+- Run the link checker on docs (`#1336 <https://github.com/landlab/landlab/issues/1336>`_)
+- Fixed documentation errors in green ampt component (`#1343 <https://github.com/landlab/landlab/issues/1343>`_)
+- Added new references to landlab (`#1344 <https://github.com/landlab/landlab/issues/1344>`_)
+- Added a link to launch landlab notebooks on the CSDMS JupyterHub (`#1347 <https://github.com/landlab/landlab/issues/1347>`_)
 
 
 Other Changes and Additions
 ```````````````````````````
 
-- Fixed warnings related to unnecessary use of numpy number types (`#1323 <https://github.com/python-attrs/attrs/issues/1323>`_)
-- Changed continuous integration to always check the docs build (`#1336 <https://github.com/python-attrs/attrs/issues/1336>`_)
-- Added a pre-commit configuration file (`#1338 <https://github.com/python-attrs/attrs/issues/1338>`_)
-- Drop the "file:" prefix when referencing pip requirements files (`#1339 <https://github.com/python-attrs/attrs/issues/1339>`_)
-- Removed usages of np.int from Cython code (`#1354 <https://github.com/python-attrs/attrs/issues/1354>`_)
-- Check that notebooks are both clean and blackened as part of continuous integration (`#1355 <https://github.com/python-attrs/attrs/issues/1355>`_)
+- Fixed warnings related to unnecessary use of numpy number types (`#1323 <https://github.com/landlab/landlab/issues/1323>`_)
+- Changed continuous integration to always check the docs build (`#1336 <https://github.com/landlab/landlab/issues/1336>`_)
+- Added a pre-commit configuration file (`#1338 <https://github.com/landlab/landlab/issues/1338>`_)
+- Drop the "file:" prefix when referencing pip requirements files (`#1339 <https://github.com/landlab/landlab/issues/1339>`_)
+- Removed usages of np.int from Cython code (`#1354 <https://github.com/landlab/landlab/issues/1354>`_)
+- Check that notebooks are both clean and blackened as part of continuous integration (`#1355 <https://github.com/landlab/landlab/issues/1355>`_)
 
 
 2.3.0 (2021-03-19)
@@ -133,52 +133,52 @@ Other Changes and Additions
 New Components
 ``````````````
 
-- Added a tidal flow component (`#1225 <https://github.com/python-attrs/attrs/issues/1225>`_)
-- Added ExponentialWeathererIntegrated component (`#1254 <https://github.com/python-attrs/attrs/issues/1254>`_)
-- Added simple submarine diffuser component (`#1269 <https://github.com/python-attrs/attrs/issues/1269>`_)
+- Added a tidal flow component (`#1225 <https://github.com/landlab/landlab/issues/1225>`_)
+- Added ExponentialWeathererIntegrated component (`#1254 <https://github.com/landlab/landlab/issues/1254>`_)
+- Added simple submarine diffuser component (`#1269 <https://github.com/landlab/landlab/issues/1269>`_)
 
 
 New Tutorial Notebooks
 ``````````````````````
 
-- Added tutorial for river input to LEMs (`#1258 <https://github.com/python-attrs/attrs/issues/1258>`_)
+- Added tutorial for river input to LEMs (`#1258 <https://github.com/landlab/landlab/issues/1258>`_)
 
 
 New Features
 ````````````
 
-- Added recharge to the GroundwaterDupuitPercolator callback (`#1223 <https://github.com/python-attrs/attrs/issues/1223>`_)
-- Added Wavefront OBJ output (`#1241 <https://github.com/python-attrs/attrs/issues/1241>`_)
+- Added recharge to the GroundwaterDupuitPercolator callback (`#1223 <https://github.com/landlab/landlab/issues/1223>`_)
+- Added Wavefront OBJ output (`#1241 <https://github.com/landlab/landlab/issues/1241>`_)
 
 
 Bug Fixes
 `````````
 
-- Fixed bug in Flow router/depression finder which incorrectly directed flow (`#1248 <https://github.com/python-attrs/attrs/issues/1248>`_)
-- Fixed an error in the streampower notebook (`#1260 <https://github.com/python-attrs/attrs/issues/1260>`_)
-- Fixed a bug in the FlowAccumulator to update pit present logic to also include node flood status (`#1277 <https://github.com/python-attrs/attrs/issues/1277>`_)
-- Fixed a bug when adding a missing at_grid field when testing components (`#1286 <https://github.com/python-attrs/attrs/issues/1286>`_)
+- Fixed bug in Flow router/depression finder which incorrectly directed flow (`#1248 <https://github.com/landlab/landlab/issues/1248>`_)
+- Fixed an error in the streampower notebook (`#1260 <https://github.com/landlab/landlab/issues/1260>`_)
+- Fixed a bug in the FlowAccumulator to update pit present logic to also include node flood status (`#1277 <https://github.com/landlab/landlab/issues/1277>`_)
+- Fixed a bug when adding a missing at_grid field when testing components (`#1286 <https://github.com/landlab/landlab/issues/1286>`_)
 
 
 Documentation Enhancements
 ``````````````````````````
 
-- Fixed documentation bugs (`#1233 <https://github.com/python-attrs/attrs/issues/1233>`_)
-- Added two 2020 publications (`#1243 <https://github.com/python-attrs/attrs/issues/1243>`_)
-- Added docs for the flow accumulator (`#1251 <https://github.com/python-attrs/attrs/issues/1251>`_)
-- Added a reference to the papers and presentations list (`#1255 <https://github.com/python-attrs/attrs/issues/1255>`_)
-- Added additional references for 2020 and 2021 (`#1273 <https://github.com/python-attrs/attrs/issues/1273>`_)
+- Fixed documentation bugs (`#1233 <https://github.com/landlab/landlab/issues/1233>`_)
+- Added two 2020 publications (`#1243 <https://github.com/landlab/landlab/issues/1243>`_)
+- Added docs for the flow accumulator (`#1251 <https://github.com/landlab/landlab/issues/1251>`_)
+- Added a reference to the papers and presentations list (`#1255 <https://github.com/landlab/landlab/issues/1255>`_)
+- Added additional references for 2020 and 2021 (`#1273 <https://github.com/landlab/landlab/issues/1273>`_)
 
 
 Other Changes and Additions
 ```````````````````````````
 
-- NetworkSedimentTtransporter JOSS paper fixes (`#1235 <https://github.com/python-attrs/attrs/issues/1235>`_)
-- Small changes to JOSS paper (`#1237 <https://github.com/python-attrs/attrs/issues/1237>`_)
-- Changed to use GitHub Actions for CI (`#1270 <https://github.com/python-attrs/attrs/issues/1270>`_)
-- Added building and testing of landlab with Python 3.9 (`#1274 <https://github.com/python-attrs/attrs/issues/1274>`_)
-- Added release and prerelease github actions (`#1275 <https://github.com/python-attrs/attrs/issues/1275>`_)
-- Cleaned up landlab metadata files; Removed versioneer, we'll use zest.releaser from now on the manage versions (`#1285 <https://github.com/python-attrs/attrs/issues/1285>`_)
+- NetworkSedimentTtransporter JOSS paper fixes (`#1235 <https://github.com/landlab/landlab/issues/1235>`_)
+- Small changes to JOSS paper (`#1237 <https://github.com/landlab/landlab/issues/1237>`_)
+- Changed to use GitHub Actions for CI (`#1270 <https://github.com/landlab/landlab/issues/1270>`_)
+- Added building and testing of landlab with Python 3.9 (`#1274 <https://github.com/landlab/landlab/issues/1274>`_)
+- Added release and prerelease github actions (`#1275 <https://github.com/landlab/landlab/issues/1275>`_)
+- Cleaned up landlab metadata files; Removed versioneer, we'll use zest.releaser from now on the manage versions (`#1285 <https://github.com/landlab/landlab/issues/1285>`_)
 
 
 1.5.1 (2018-06-22)

--- a/docs/source/development/contribution/index.rst
+++ b/docs/source/development/contribution/index.rst
@@ -37,7 +37,7 @@ summarized here when finalized. If you have any questions regarding whether
 your potential JOSS submission is appropriate, the best thing to do is to
 make a pre-submission inquiry with JOSS.
 
-NEWS Entries
+News Entries
 ------------
 
 The ``CHANGES.rst`` file is managed using `towncrier`_ and all non trivial changes

--- a/docs/source/development/contribution/index.rst
+++ b/docs/source/development/contribution/index.rst
@@ -36,3 +36,31 @@ contributions to Landlab fit the scope of a JOSS submission. These will be
 summarized here when finalized. If you have any questions regarding whether
 your potential JOSS submission is appropriate, the best thing to do is to
 make a pre-submission inquiry with JOSS.
+
+NEWS Entries
+------------
+
+The ``CHANGES.rst`` file is managed using `towncrier`_ and all non trivial changes
+must be accompanied by a news entry.
+
+To add an entry to the news file, first you need to have created an issue
+describing the change you want to make. A Pull Request itself *may* function as
+such, but it is preferred to have a dedicated issue (for example, in case the
+PR ends up rejected due to code quality reasons).
+
+Once you have an issue or pull request, you take the number and you create a
+file inside of the ``news/`` directory, named after that issue number with a
+"type" of ``component``, ``notebook``, ``feature``, ``bugfix``, ``docs``, or ``misc``
+associated with it.
+
+If your issue or PR number is ``1234`` and this change is fixing a bug,
+then you would create a file ``news/1234.bugfix.rst``. PRs can span multiple
+categories by creating multiple files (for instance, if you added a new component
+and an associated notebook that demonstrates how to use it, you would create
+``news/NNNN.component.rst`` and ``news/NNNN.notebook.rst``).
+
+If a PR touches multiple issues/PRs, you may create a file for each of them
+with the exact same contents and Towncrier will deduplicate them.
+
+
+.. _`towncrier`: https://pypi.org/project/towncrier/

--- a/news/.gitignore
+++ b/news/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/news/1284.component
+++ b/news/1284.component
@@ -1,0 +1,2 @@
+CarbonateProducer: Grow carbonate strata using growth function of Bosscher and Schlager (1992). 
+

--- a/news/1292.feature
+++ b/news/1292.feature
@@ -1,0 +1,3 @@
+Added the ability for a user to add layers at grid elements other than cells (i.e.
+nodes, links, etc.).  Previously, the *at_layer* variables could only be at cell elements.
+

--- a/news/1356.bugfix
+++ b/news/1356.bugfix
@@ -1,0 +1,3 @@
+Clip active layer thickness to zero in the NetworkSedimentTransporter component. This
+eliminates an ``invalid value encountered in power`` warning.
+

--- a/news/1358.feature
+++ b/news/1358.feature
@@ -1,0 +1,3 @@
+Added the ability to define the units of a field when creating a grid from a file
+through the ``create_grid`` function.
+

--- a/news/1360.feature
+++ b/news/1360.feature
@@ -1,0 +1,4 @@
+Added the ``network_grid_from_raster`` function that creates a ``NetworkModelGrid``
+from a ``RasterModelGrid``. This function extracts channel segments from the
+source grid to become links of the newly-created grid.
+

--- a/news/1370.feature
+++ b/news/1370.feature
@@ -1,0 +1,3 @@
+Added *sediment__influx* and *sediment__outflux* fields to the ``ErosionDeposition``,
+``LateralEroder``, ``SpaceLargeScaleEroder``, and ``Space`` components.
+

--- a/news/1379.bugfix
+++ b/news/1379.bugfix
@@ -1,0 +1,3 @@
+Allow *landlab* to be installed without the *richdem* package in the case that
+*richdem* is not available for a particular platform or Python version.
+

--- a/news/1383.component
+++ b/news/1383.component
@@ -1,0 +1,2 @@
+``LinearDiffusionOverlandFlowRouter``: overland flow using the linearized diffusion-wave approximation.
+

--- a/news/1384.misc
+++ b/news/1384.misc
@@ -1,0 +1,3 @@
+Added an OpenTopography API key to notebooks that use *bmi-topography* to fetch
+data from OpenTopography.
+

--- a/news/1385.misc
+++ b/news/1385.misc
@@ -1,0 +1,3 @@
+Updated the coding style to conform to new version of black. This was, primarily,
+hugging the ``**`` operator.
+

--- a/news/1396.docs
+++ b/news/1396.docs
@@ -1,0 +1,4 @@
+Set up *[towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/)*
+to update and manage the *landlab* changelog. New fragments are placed in the
+``news/`` folder.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ package = "landlab"
 filename = "CHANGES.rst"
 single_file = true
 underlines = "-`^"
-issue_format = "`#{issue} <https://github.com/python-attrs/attrs/issues/{issue}>`_"
+issue_format = "`#{issue} <https://github.com/landlab/landlab/issues/{issue}>`_"
 title_format = "{version} ({project_date})"
 
 [[tool.towncrier.type]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,43 @@ include_trailing_comma = true
 force_grid_wrap = 0
 combine_as_imports = true
 line_length = 88
+
+[tool.towncrier]
+directory = "news"
+package = "landlab"
+filename = "CHANGES.rst"
+single_file = true
+underlines = "-`^"
+issue_format = "`#{issue} <https://github.com/python-attrs/attrs/issues/{issue}>`_"
+title_format = "{version} ({project_date})"
+
+[[tool.towncrier.type]]
+directory = "component"
+name = "New Components"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "notebook"
+name = "New Tutorial Notebooks"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New Features"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug Fixes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "docs"
+name = "Documentation Enhancements"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Other Changes and Additions"
+showcontent = true
+


### PR DESCRIPTION
This pull request sets up *[towncrier](https://towncrier.readthedocs.io/en/actual-freaking-docs/)* for updating and organizing our changelog.

@gregtucker, @mdpiper could one or both of you have a look at this and let me know what you think?

I've set *landlab* up to use the *towncrier* utility to, hopefully, help maintain a better CHANGELOG that our users (and we) can look at to quickly see all of the great new changes. The basic idea is that when someone submits a pull request they must create one or more files in the *news/* folder (with the name `<issue/pr #>.<pr type>`; e.g. `3142.bugfix`). We can then use *towncrier* to gather these news fragments and add them to our changelog. I've added some documentation about [how to create news fragments](https://github.com/landlab/landlab/pull/1396/files#diff-afacdd599c6b35b3c037a41740e451eb355488d5ed1df11ccc8af3f2b34bb062) that highlight what a merged pull request has added to the repository.

I've defined several fragment types:
* `component`: adds a new component
* `notebook`: adds a tutorial notebook
* `feature`: adds a new feature
* `docs`: improves the documentation
* `bugfix`: fixes a bug
* `misc`: everything else

We're not limited to these and it's easy to add other categories if you think we need more.

I've updated the current CHANGES.rst so you can see what [it will look like](https://github.com/landlab/landlab/blob/mcflugen/setup-towncrier/CHANGES.rst) if we decide to go this route. For the most part the entries are basically just pull request messages and aren't really what we're after—entries should, ideally, be full sentences and more descriptive. I may go through the changelog and add better descriptions but I also might leave that for another time and another pull request.