### PR TITLE
Test landlab with Python 3.10

### DIFF
--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/notebooks/exclude.yml
+++ b/notebooks/exclude.yml
@@ -8,11 +8,5 @@
   reason: "stalls travis builds"
 - file: nst_scaling_profiling.ipynb
   reason: "stalls travis builds"
-- file: PriorityFlood_LandscapeEvolutionModel.ipynb
-  unless: "sys_platform != 'win32' or python_version < '3.10'"
-  reason: "requires richdem, bmi-topography"
-- file: PriorityFlood_realDEMs.ipynb
-  unless: "sys_platform != 'win32' or python_version < '3.10'"
-  reason: "requires richdem, bmi-topography"
 - file: test_networkcreator_otherDEMs.ipynb
   reason: "wip"


### PR DESCRIPTION
This pull request builds and tests *landlab* and the tutorial notebooks using Python 3.8, 3.9 and now 3.10 (and drops 3.7).

I hope this will also fix the notebook test failures @BCampforts is seeing in #1397.