### PR TITLE
Remove per function hypothesis deadline setting

### DIFF
--- a/news/1401.misc
+++ b/news/1401.misc
@@ -1,0 +1,3 @@
+Turn off *hypothesis* deadline setting globally when running continuous
+integration tests.
+

--- a/tests/graph/hex/test_hex.py
+++ b/tests/graph/hex/test_hex.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.strategies import integers, lists
 from pytest import approx
 
@@ -109,7 +109,6 @@ def test_create_hex():
 
 
 @given(shape=lists(integers(min_value=3, max_value=32), min_size=2, max_size=2))
-@settings(deadline=None)
 def test_spacing(shape):
     """Test spacing of nodes."""
     graph = TriGraph(shape)
@@ -122,7 +121,6 @@ def test_spacing(shape):
 @given(shape=lists(integers(min_value=3, max_value=32), min_size=2, max_size=2))
 @pytest.mark.parametrize("orientation", ("horizontal", "vertical"))
 @pytest.mark.parametrize("node_layout", ("hex", "rect"))
-@settings(deadline=None)
 def test_origin_keyword(node_layout, orientation, shape):
     """Test setting the origin."""
     graph = TriGraph(shape)

--- a/tests/grid/test_create.py
+++ b/tests/grid/test_create.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.strategies import text
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
@@ -488,7 +488,6 @@ def test_norm_grid_description():
 
 
 @given(units=text())
-@settings(deadline=None)
 def test_field_units(units):
     params = {
         "RasterModelGrid": [
@@ -515,7 +514,6 @@ def test_field_units(units):
 
 
 @given(units=text())
-@settings(deadline=None)
 def test_repeated_units(units):
     params = {
         "RasterModelGrid": [

--- a/tests/grid/test_create_network.py
+++ b/tests/grid/test_create_network.py
@@ -1,7 +1,7 @@
 import hypothesis.extra.numpy as hynp
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.strategies import composite, floats, integers, lists
 from numpy.testing import assert_array_equal
 
@@ -533,7 +533,6 @@ def test_create_xy_of_node_with_branch():
         max_size=1024,
     ),
 )
-@settings(deadline=None)
 def test_create_xy_of_node_one_segement(nodes):
     grid = RasterModelGrid((16, 64), xy_spacing=(2.0, 3.0))
     network = ChannelSegmentConnector(nodes)

--- a/tests/values/test_synthetic.py
+++ b/tests/values/test_synthetic.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis.strategies import text
 from numpy.testing import assert_array_equal
 
@@ -14,7 +14,6 @@ _POINT = (0, 0, 0)
 
 
 @given(name=text(), unit_str=text())
-@settings(deadline=None)
 def test_add_units_missing_field(at, name, unit_str):
     grid = RasterModelGrid((4, 4))
     units(grid, name, at=at, units=unit_str)
@@ -35,7 +34,6 @@ def test_add_units_existing_field(at):
 
 
 @given(name=text())
-@settings(deadline=None)
 def test_add_units_without_units(at, name):
     grid = RasterModelGrid((4, 4))
     units(grid, name, at=at, units=None)


### PR DESCRIPTION
Addresses #1401 by removing per-function *hypothesis* settings that turn off timing deadlines. Instead, timings deadlines are turned off globally when running continuous integration tests using Github Actions.