### PR TITLE
Fix notebook ci errors on osx

### DIFF
--- a/news/1410.misc
+++ b/news/1410.misc
@@ -1,0 +1,3 @@
+Fixed an issue where notebooks that download DEMs from OpenTopography were
+failing with an error about a missing API key.
+

--- a/notebooks/tutorials/flow_direction_and_accumulation/PriorityFlood_realDEMs.ipynb
+++ b/notebooks/tutorials/flow_direction_and_accumulation/PriorityFlood_realDEMs.ipynb
@@ -61,16 +61,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e3e3aec",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del os.environ[\"OPENTOPOGRAPHY_API_KEY\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "2106d9ca",
    "metadata": {},
    "outputs": [],
@@ -383,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/network_sediment_transporter/run_network_generator_OpenTopoDEM.ipynb
+++ b/notebooks/tutorials/network_sediment_transporter/run_network_generator_OpenTopoDEM.ipynb
@@ -80,16 +80,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc8e6bea",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "del os.environ[\"OPENTOPOGRAPHY_API_KEY\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "d1a4149c",
    "metadata": {},
    "outputs": [],
@@ -640,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request is an attempt to fix the continuous integration errors we are seeing for the notebook tests on *osx*. The failing tests are those for notebooks that use *bmi-topography* to download DEMs from OpenTopography. The reported error indicates that we haven't provided an API key, but that's not the case. In addition, the notebooks run just fine locally but the problem only arises when run through Github Actions. 