### PR TITLE
Update links to the new jupyterhub on lab.openearthscape

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,8 +205,8 @@ Then, click to explore the `example notebooks`_,
 or to go straight to the `teaching notebooks`_.
 
 .. _visit the CSDMS wiki: https://csdms.colorado.edu/wiki/JupyterHub
-.. _example notebooks: https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fwelcome.ipynb&branch=master
-.. _teaching notebooks: https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fteaching%2Fwelcome_teaching.ipynb&branch=master
+.. _example notebooks: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fwelcome.ipynb&branch=master
+.. _teaching notebooks: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fteaching%2Fwelcome_teaching.ipynb&branch=master
 
 
 What License does Landlab use?

--- a/README.rst
+++ b/README.rst
@@ -205,8 +205,8 @@ Then, click to explore the `example notebooks`_,
 or to go straight to the `teaching notebooks`_.
 
 .. _visit the CSDMS wiki: https://csdms.colorado.edu/wiki/JupyterHub
-.. _example notebooks: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fwelcome.ipynb&branch=master
-.. _teaching notebooks: https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fteaching%2Fwelcome_teaching.ipynb&branch=master
+.. _example notebooks: https://jupyter.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fwelcome.ipynb&branch=master
+.. _teaching notebooks: https://jupyter.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Flandlab%2Flandlab&urlpath=tree%2Flandlab%2Fnotebooks%2Fteaching%2Fwelcome_teaching.ipynb&branch=master
 
 
 What License does Landlab use?

--- a/news/1419.docs
+++ b/news/1419.docs
@@ -1,0 +1,2 @@
+Fixed the broken links to the openearthscape JupyterHub.
+


### PR DESCRIPTION
This pull request fixes the broken links to the openearthscape JupyterHub as described in #1419.

@mdpiper Does this fix the issue? Are these the appropriate links? 