### PR TITLE
Enhance *plot_graph* following #1425

### DIFF
--- a/landlab/plot/__init__.py
+++ b/landlab/plot/__init__.py
@@ -5,7 +5,9 @@ from .imshow import (
     imshowhs_grid_at_node,
 )
 from .network_sediment_transporter import plot_network_and_parcels
+from .graph import plot_graph
 from .layers import plot_layers
+
 
 __all__ = [
     "imshow_grid",
@@ -14,4 +16,5 @@ __all__ = [
     "imshowhs_grid_at_node",
     "plot_network_and_parcels",
     "plot_layers",
+    "plot_graph",
 ]

--- a/landlab/plot/graph.py
+++ b/landlab/plot/graph.py
@@ -63,6 +63,19 @@ def plot_patches(graph, color="g", with_id=False):
 
 
 def plot_graph(graph, at="node,link,patch", with_id=True):
+    """Plot elements of a graph.
+
+    Parameters
+    ----------
+    graph : graph-like
+        A landlab graph-like object.
+    at : str
+        Comma-separated list of elements to plot.
+    with_id : str or bool
+        Indicate which elements should be plotted with their corresponding id.
+        Either a comma-separated list of grid elements or ``True`` to include
+        ids for all elements of ``False`` for no elements.
+    """
     EVERYWHERE = {"node", "link", "patch", "corner", "face", "cell"}
 
     if isinstance(with_id, str):

--- a/landlab/plot/graph.py
+++ b/landlab/plot/graph.py
@@ -45,6 +45,7 @@ def plot_patches(graph, color="g", with_id=False):
     from matplotlib.patches import Polygon
 
     for patch, nodes in enumerate(graph.nodes_at_patch):
+        nodes = nodes[nodes >= 0]
         x, y = np.mean(graph.x_of_node[nodes]), np.mean(graph.y_of_node[nodes])
         plt.gca().add_patch(
             Polygon(graph.xy_of_node[nodes], ec=color, fc=None, alpha=0.5)

--- a/landlab/plot/graph.py
+++ b/landlab/plot/graph.py
@@ -62,7 +62,7 @@ def plot_patches(graph, color="g", with_id=False):
             )
 
 
-def plot_graph(graph, at="node,link,patch", with_id=True):
+def plot_graph(graph, at="node,link,patch", with_id=True, axes=None):
     """Plot elements of a graph.
 
     Parameters
@@ -75,6 +75,13 @@ def plot_graph(graph, at="node,link,patch", with_id=True):
         Indicate which elements should be plotted with their corresponding id.
         Either a comma-separated list of grid elements or ``True`` to include
         ids for all elements of ``False`` for no elements.
+    axes : , optional
+        Add the plot to an existing matplotlib ``Axes``, otherwise, create a new one.
+
+    Returns
+    -------
+    ``Axes``
+        The ``Axes`` containing the plot.
     """
     EVERYWHERE = {"node", "link", "patch", "corner", "face", "cell"}
 
@@ -84,9 +91,8 @@ def plot_graph(graph, at="node,link,patch", with_id=True):
         with_id = _parse_locations_as_set(with_id)
     locs = _parse_locations_as_set(at)
 
-    ax = plt.axes()
+    ax = plt.axes() if axes is None else axes
 
-    # plt.plot(graph.x_of_node, graph.y_of_node, ".", color="r")
     ax.set_xlim([min(graph.x_of_node) - 0.5, max(graph.x_of_node) + 0.5])
     ax.set_ylim([min(graph.y_of_node) - 0.5, max(graph.y_of_node) + 0.5])
 

--- a/news/1425.feature
+++ b/news/1425.feature
@@ -1,0 +1,4 @@
+Enhanced the ``plot_graph`` function: allow the ``with_id`` keyword to
+accept a list of elements that should have included IDs, fill in patches and
+cells.
+

--- a/news/1425.feature.1
+++ b/news/1425.feature.1
@@ -1,0 +1,2 @@
+The ``plot_graph`` function now can take lists of graph elements rather than only comma-separated strings.
+

--- a/news/1425.feature.2
+++ b/news/1425.feature.2
@@ -1,0 +1,3 @@
+Added a new keyword, ``axes`` to ``plot_graph`` to allow plotting within an
+existing axes.
+

--- a/news/1428.bugfix
+++ b/news/1428.bugfix
@@ -1,0 +1,4 @@
+Fixed a bug where ``plot_graph`` would incorrectly include the last
+node/corner with patches/cells that had fewer links/faces than the maximum of
+the graph.
+

--- a/news/1428.bugfix.1
+++ b/news/1428.bugfix.1
@@ -1,0 +1,2 @@
+Fixed a bug in ``plot_graph`` where patch and cell polygons were not drawn.
+

--- a/tests/plot/test_graph.py
+++ b/tests/plot/test_graph.py
@@ -45,3 +45,13 @@ def test_plot_graph(at):
         assert len(_axes_arrows(ax)) == grid.number_of_elements(at)
     else:
         assert len(ax.lines) == grid.number_of_elements(at)
+
+
+def test_plot_graph_onto_existing():
+    grid = RasterModelGrid((3, 4))
+    ax = plot_graph(grid, at="node")
+    plot_graph(grid, at="cell", axes=ax)
+
+    assert (
+        len(ax.patches) + len(ax.lines) == grid.number_of_nodes + grid.number_of_cells
+    )

--- a/tests/plot/test_graph.py
+++ b/tests/plot/test_graph.py
@@ -1,0 +1,47 @@
+import pytest
+
+from landlab import RasterModelGrid
+from landlab.plot.graph import _parse_locations_as_set, plot_graph
+
+
+def _axes_arrows(ax):
+    from matplotlib.patches import FancyArrow
+
+    return [child for child in ax.get_children() if isinstance(child, FancyArrow)]
+
+
+def test_parse_locations_from_str():
+    assert _parse_locations_as_set("node") == {"node"}
+    assert _parse_locations_as_set("node,link") == {"node", "link"}
+    assert _parse_locations_as_set("node,link,cell,link") == {"node", "link", "cell"}
+    assert _parse_locations_as_set("node  , link, patch  ") == {"node", "link", "patch"}
+
+
+def test_parse_locations_from_iterable():
+    assert _parse_locations_as_set(["cell"]) == {"cell"}
+    assert _parse_locations_as_set(("patch", "corner")) == {"patch", "corner"}
+    assert _parse_locations_as_set(("patch", "corner", "patch")) == {"patch", "corner"}
+    assert _parse_locations_as_set((" patch  ", "corner  ")) == {"patch", "corner"}
+
+
+def test_parse_locations_bad_value():
+    with pytest.raises(ValueError, match=r"^unknown location "):
+        _parse_locations_as_set("foo")
+    with pytest.raises(ValueError, match=r"^unknown locations "):
+        _parse_locations_as_set("cells,nodes")
+
+
+@pytest.mark.parametrize("at", ["node", "link", "patch", "corner", "face", "cell"])
+def test_plot_graph(at):
+    grid = RasterModelGrid((3, 4))
+    ax = plot_graph(grid, at=at)
+
+    assert ax.get_ylim() == (-0.5, 2.5)
+    assert ax.get_xlim() == (-0.5, 3.5)
+
+    if at in ("patch", "cell"):
+        assert len(ax.patches) == grid.number_of_elements(at)
+    elif at in ("link", "face"):
+        assert len(_axes_arrows(ax)) == grid.number_of_elements(at)
+    else:
+        assert len(ax.lines) == grid.number_of_elements(at)


### PR DESCRIPTION
This pull request addresses the feature request described in #1425 as well as a few other bits. In particular,
* The *with_id* keyword now accepts a comma-separated list of grid elements (in the same way as for the *at* keyword) to include ids for.
* Patches and cells are filled in.
* Fixed a bug where -1 values were not being ignored in *corners_at_cell* and *nodes_at_patch*. This caused patches/cells with fewer links/faces than the maximum to include the last node/corner as part of their element