### PR TITLE
Add "at" keyword for imshow and other enhancements

### DIFF
--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -19,6 +19,7 @@ from ..core.utils import add_module_functions_to_class
 from ..field.graph_field import GraphFields
 from ..layers.eventlayers import EventLayersMixIn
 from ..layers.materiallayers import MaterialLayersMixIn
+from ..plot.imshow import ModelGridPlotterMixIn
 from ..utils.decorators import cache_result_in_object
 from . import grid_funcs as gfuncs
 from .decorators import (
@@ -257,7 +258,9 @@ def find_true_vector_from_link_vector_pair(L1, L2, b1x, b1y, b2x, b2y):
     return ax, ay
 
 
-class ModelGrid(GraphFields, EventLayersMixIn, MaterialLayersMixIn):
+class ModelGrid(
+    GraphFields, EventLayersMixIn, MaterialLayersMixIn, ModelGridPlotterMixIn
+):
 
     """Base class for 2D structured or unstructured grids for numerical models.
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -6,8 +6,6 @@ Do NOT add new documentation here. Grid documentation is now built in a
 semi- automated fashion. To modify the text seen on the web, edit the
 files `docs/text_for_[gridfile].py.txt`.
 """
-import warnings
-
 import numpy as np
 import xarray as xr
 
@@ -62,47 +60,6 @@ def _node_has_boundary_neighbor(mg, id, method="d8"):
 _node_has_boundary_neighbor = np.vectorize(_node_has_boundary_neighbor, excluded=["mg"])
 
 
-class RasterModelGridPlotter(object):
-
-    """MixIn that provides plotting functionality.
-
-    Inhert from this class to provide a ModelDataFields object with the
-    method function, ``imshow``, that plots a data field.
-    """
-
-    def imshow(self, *args, **kwds):
-        """Plot a data field.
-
-        This is a wrapper for `plot.imshow_grid`, and can take the same
-        keywords. See that function for full documentation.
-
-        Parameters
-        ----------
-        values : str, or array-like
-            Name of a field or an array of values to plot.
-
-        See Also
-        --------
-        landlab.plot.imshow_grid
-
-        LLCATS: GINF
-        """
-        from landlab.plot import imshow_grid
-
-        if len(args) == 1:
-            values = args[0]
-        elif len(args) == 2:
-            at, values = args
-            warnings.warn(f"use grid.imshow(values, at={at!r})", DeprecationWarning)
-            if at != kwds.get("at", at):
-                raise ValueError(f"multiple locations provided ({at}, {kwds['at']})")
-            kwds["at"] = at
-        else:
-            raise TypeError(f"imshow expected 1 or 2 arguments, got {len(args)}")
-
-        imshow_grid(self, values, **kwds)
-
-
 def grid_edge_is_closed_from_dict(boundary_conditions):
     """Get a list of closed-boundary status at grid edges.
 
@@ -143,9 +100,7 @@ def grid_edge_is_closed_from_dict(boundary_conditions):
     ]
 
 
-class RasterModelGrid(
-    DiagonalsMixIn, DualUniformRectilinearGraph, ModelGrid, RasterModelGridPlotter
-):
+class RasterModelGrid(DiagonalsMixIn, DualUniformRectilinearGraph, ModelGrid):
 
     """A 2D uniform rectilinear grid.
 

--- a/landlab/grid/raster.py
+++ b/landlab/grid/raster.py
@@ -6,6 +6,7 @@ Do NOT add new documentation here. Grid documentation is now built in a
 semi- automated fashion. To modify the text seen on the web, edit the
 files `docs/text_for_[gridfile].py.txt`.
 """
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -69,7 +70,7 @@ class RasterModelGridPlotter(object):
     method function, ``imshow``, that plots a data field.
     """
 
-    def imshow(self, group, var_name, **kwds):
+    def imshow(self, *args, **kwds):
         """Plot a data field.
 
         This is a wrapper for `plot.imshow_grid`, and can take the same
@@ -77,10 +78,8 @@ class RasterModelGridPlotter(object):
 
         Parameters
         ----------
-        group : str
-            Name of group.
-        var_name : str
-            Name of field
+        values : str, or array-like
+            Name of a field or an array of values to plot.
 
         See Also
         --------
@@ -90,8 +89,18 @@ class RasterModelGridPlotter(object):
         """
         from landlab.plot import imshow_grid
 
-        kwds["values_at"] = group
-        imshow_grid(self, var_name, **kwds)
+        if len(args) == 1:
+            values = args[0]
+        elif len(args) == 2:
+            at, values = args
+            warnings.warn(f"use grid.imshow(values, at={at!r})", DeprecationWarning)
+            if at != kwds.get("at", at):
+                raise ValueError(f"multiple locations provided ({at}, {kwds['at']})")
+            kwds["at"] = at
+        else:
+            raise TypeError(f"imshow expected 1 or 2 arguments, got {len(args)}")
+
+        imshow_grid(self, values, **kwds)
 
 
 def grid_edge_is_closed_from_dict(boundary_conditions):

--- a/landlab/plot/__init__.py
+++ b/landlab/plot/__init__.py
@@ -1,9 +1,5 @@
-from .imshow import (
-    imshow_grid,
-    imshow_grid_at_node,
-    imshowhs_grid,
-    imshowhs_grid_at_node,
-)
+from .imshow import imshow_grid, imshow_grid_at_node
+from .imshowhs import imshowhs_grid, imshowhs_grid_at_node
 from .network_sediment_transporter import plot_network_and_parcels
 from .layers import plot_layers
 

--- a/landlab/plot/event_handler.py
+++ b/landlab/plot/event_handler.py
@@ -3,8 +3,6 @@
 
 from pprint import pprint
 
-from landlab import RasterModelGrid
-
 
 def query_grid_on_button_press(event, grid):
     """Print and returns node information using an imshow plot.
@@ -29,7 +27,9 @@ def query_grid_on_button_press(event, grid):
     query_results :
         Dictionary containing grid query results.
     """
-    if type(grid) is not RasterModelGrid:
+    from ..grid.raster import RasterModelGrid
+
+    if not isinstance(grid, RasterModelGrid):
         raise TypeError("Only raster grids can be queried.")
 
     if all([event.xdata, event.ydata]):

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -7,21 +7,16 @@ Plotting functions
 .. autosummary::
 
     ~landlab.plot.imshow.imshow_grid
-    ~landlab.plot.imshow.imshowhs_grid
     ~landlab.plot.imshow.imshow_grid_at_cell
     ~landlab.plot.imshow.imshow_grid_at_node
-    ~landlab.plot.imshow.imshowhs_grid_at_node
 """
 from warnings import warn
 
 import numpy as np
-from matplotlib.colors import LightSource
-from mpl_toolkits.axes_grid1.inset_locator import inset_axes
-
-from landlab.grid.raster import RasterModelGrid
-from landlab.plot.event_handler import query_grid_on_button_press
 
 from ..field import FieldError
+from .event_handler import query_grid_on_button_press
+
 
 try:
     import matplotlib.pyplot as plt
@@ -31,6 +26,45 @@ except ImportError:
     import warnings
 
     warnings.warn("matplotlib not found", ImportWarning)
+
+
+class ModelGridPlotterMixIn:
+
+    """MixIn that provides plotting functionality.
+
+    Inhert from this class to provide a ModelDataFields object with the
+    method function, ``imshow``, that plots a data field.
+    """
+
+    def imshow(self, *args, **kwds):
+        """Plot a data field.
+
+        This is a wrapper for `plot.imshow_grid`, and can take the same
+        keywords. See that function for full documentation.
+
+        Parameters
+        ----------
+        values : str, or array-like
+            Name of a field or an array of values to plot.
+
+        See Also
+        --------
+        landlab.plot.imshow_grid
+
+        LLCATS: GINF
+        """
+        if len(args) == 1:
+            values = args[0]
+        elif len(args) == 2:
+            at, values = args
+            warn(f"use grid.imshow(values, at={at!r})", DeprecationWarning)
+            if at != kwds.get("at", at):
+                raise ValueError(f"multiple locations provided ({at}, {kwds['at']})")
+            kwds["at"] = at
+        else:
+            raise TypeError(f"imshow expected 1 or 2 arguments, got {len(args)}")
+
+        imshow_grid(self, values, **kwds)
 
 
 def imshow_grid_at_node(grid, values, **kwds):
@@ -119,12 +153,7 @@ def imshow_grid_at_node(grid, values, **kwds):
         grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node
     )
 
-    if isinstance(grid, RasterModelGrid):
-        shape = grid.shape
-    else:
-        shape = (-1,)
-
-    _imshow_grid_values(grid, values_at_node.reshape(shape), **kwds)
+    _imshow_grid_values(grid, values_at_node, **kwds)
 
     if isinstance(values, str):
         plt.title(values)
@@ -132,192 +161,6 @@ def imshow_grid_at_node(grid, values, **kwds):
     plt.gcf().canvas.mpl_connect(
         "button_press_event", lambda event: query_grid_on_button_press(event, grid)
     )
-
-
-def imshowhs_grid_at_node(grid, values, **kwds):
-    """Prepare a map view of data over all nodes in the grid using a hillshade
-    topography map in the background.
-
-    Data is plotted as cells shaded with the value at the node at its center.
-    Outer edges of perimeter cells are extrapolated. Closed elements are
-    colored uniformly (default black, overridden with kwd 'color_for_closed');
-    other open boundary nodes get their actual values.
-
-    *values* can be a field name, a regular array, or a masked array. If a
-    masked array is provided, masked entries will be treated as if they were
-    Landlab BC_NODE_IS_CLOSED. Used together with the color_at_closed=None
-    keyword (i.e., "transparent"), this can allow for construction of overlay
-    layers in a figure (e.g., only defining values in a river network, and
-    overlaying it on another landscape).
-
-    Use matplotlib functions like xlim, ylim to modify your plot after calling
-    :func:`imshowhs_grid`, as desired.
-
-    Node coordinates are printed when a mouse button is pressed on a cell in
-    the plot.
-
-    For now, this function only works with regular grids.
-    Developed by: Benjamin Campforts
-
-    Parameters
-    ----------
-    grid : ModelGrid
-        Grid containing the field to plot, or describing the geometry of the
-        provided array.
-    values : array_like, masked_array, or str
-        Node values, or a field name as a string from which to draw the data.
-    plot_name : str, optional
-        String to put as the plot title.
-    var_name : str, optional
-        Variable name, to use as a colorbar label.
-    var_name_two : str, optional
-        Variable name of second layer, to use as a colorbar label.
-    var_units : str, optional
-        Units for the variable being plotted, for the colorbar.
-    grid_units : tuple of str, optional
-        Units for y, and x dimensions. If None, component will look to the
-        gri property `axis_units` for this information. If no units are
-        specified there, no entry is made.
-    symmetric_cbar : bool
-        Make the colormap symetric about 0.
-    cmap : str
-        Name of a colormap
-    limits : tuple of float
-        Minimum and maximum of the colorbar.
-    vmin, vmax: floats
-        Alternatives to limits.
-    norm : matplotlib.colors.Normalize
-        The normalizing object which scales data, typically into the interval
-        [0, 1]. Ignore in most cases.
-    ticks_km : bool, optional
-        Display ticks in km instead of m
-        Default: False
-    allow_colorbar : bool
-        If True, include the colorbar.
-    shrink : float
-        Fraction by which to shrink the colorbar.
-    color_for_closed : str or None
-        Color to use for closed nodes (default 'black'). If None, closed
-        (or masked) nodes will be transparent.
-    color_for_background : color str or other color declaration, or None
-        Color to use for closed elements (default None). If None, the
-        background will be transparent, and appear white.
-    output : None, string, or bool
-        If None (or False), the image is sent to the imaging buffer to await
-        an explicit call to show() or savefig() from outside this function.
-        If a string, the string should be the path to a save location, and the
-        filename (with file extension). The function will then call
-        plt.savefig([string]) itself. If True, the function will call
-        plt.show() itself once plotting is complete.
-    fontweight_xlabel : str, optional
-        weight of x label. The default is 'bold'.
-    fontweight_ylabel : str, optional
-        weight of y label. The default is 'bold'.
-    plot_type : str, optional
-        There are four options:
-        * 'DEM': Display a digital elevation map underlain by a shaded relief,
-        based on the same DEM ('topographic__elevation')
-        * 'Hillshade': Display the shaded relief, of the provided DEM ('topographic__elevation')
-        * 'Drape1': Display any kind of provided layer on top of a shaded
-        relief provided in the 'topographic__elevation' field
-        * 'Drape2': Display two layers on top of a shaded relief provided in
-        the 'topographic__elevation' field
-        The default is "DEM".
-    drape1 : array_like, masked_array
-        Node values to plot on top of a hillshade map. The default is None.
-    drape2 : array_like, masked_array
-        Node values to plot on top of drape1 and a hillshade map. The default is None.
-    cmap2 : str
-        Name of a colormap for drape 2. The default is None.
-    vertical_exa : float, optional
-        vertical exageration of hillshade map. The default is None.
-    azdeg : float, optional
-        azimuth of light source. The default is 315.
-    altdeg : float, optional
-        elevation of light source. The default is 65.
-    thres_drape1 : float, optional
-        threshold below which drape1 is made transparant. The default is None.
-    alpha : float (0-1), optional
-        transparency of DEM/Drape1 . The default is None.
-    thres_drape2 : float, optional
-        threshold below which drape2 is made transparant. The default is None.
-    alpha2 : float (0-1), optional
-        transparency of Drape2 . The default is None.
-    add_double_colorbar : bool, optional
-        add a double colorbar when two drapes are plotted. The default is False.
-    plt_contour : bool, optional
-        Add contour lines to elevation plot . The default is False.
-    contour_nb : int, optional
-        number of contour lines. The default is 50.
-    default_fontsize : float, optional
-        Default font size of plot labels. The default is 10.
-    cbar_height : percentage, optional
-        height of colorbar in percentage of figure. The default is "5%".
-    cbar_width : percentage, optional
-        width of colorbar in percentage of figure. The default is "30%".
-    cbar_or : str, optional
-        orientation of colorbar. The default is "horizontal".
-    cbar_loc : str, optional
-        location of colorbar. The default is "lower right".
-    bbox_to_anchor : vector, optional
-        bbox to anchor. The default is (0, 0, 1, 1).
-    cbar_ticks_position : str, optional
-        location of colorbar ticks (below or on top of the colorbar). The default is "top".
-    cbar_ticks_position2 : str, optional
-        location of colorbar ticks for colorbar of Drape2 (below or on top of the colorbar). The default is "bottom".
-    colorbar_label_y : float, optional
-        location of colorbar label with respect to the colorbar in y direction. The default is -40.
-    colorbar_label_x : float , optional
-        location of colorbar label with respect to the colorbar in x direction. The default is 0.5.
-    cbar_tick_size : float, optional
-        colorbar tick size. The default is 10.
-    cbar_label_color : str, optional
-        colorbar label color. The default is 'black'.
-    cbar_ticks_color : str, optional
-        colorbar tick color. The default is 'black'.
-    cbar_label_fontweight : str, optional
-        colorbar font weight. The default is 'bold'.
-    add_label_bbox : bool, optional
-        Add a bbox surrounding the colorbar label. The default is False.
-    y_label_offSet_var_1 : float, optional
-        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is 3.0.
-    y_label_offSet_var_2 : float, optional
-        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is -1.25.
-
-    Returns
-    -------
-    ax : figure ax
-        return ax if output == True.
-    """
-    if isinstance(values, str):
-        values_at_node = grid.at_node[values]
-    else:
-        values_at_node = values.reshape((-1,))
-
-    if values_at_node.size != grid.number_of_nodes:
-        raise ValueError("number of values does not match number of nodes")
-
-    values_at_node = np.ma.masked_where(
-        grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node
-    )
-
-    if isinstance(grid, RasterModelGrid):
-        shape = grid.shape
-    else:
-        raise NotImplementedError(
-            "For now, only RasterModelGrids are supported in the imshowhs functions"
-        )
-
-    ax = _imshowhs_grid_values(grid, values_at_node.reshape(shape), **kwds)
-
-    if isinstance(values, str):
-        plt.title(values)
-
-    plt.gcf().canvas.mpl_connect(
-        "button_press_event", lambda event: query_grid_on_button_press(event, grid)
-    )
-    # plt.show()
-    return ax
 
 
 def imshow_grid_at_cell(grid, values, **kwds):
@@ -407,9 +250,6 @@ def imshow_grid_at_cell(grid, values, **kwds):
     values_at_node[grid.node_at_cell] = values_at_cell
     values_at_node.mask[grid.node_at_cell] = False
 
-    if isinstance(grid, RasterModelGrid):
-        values_at_node = values_at_node.reshape(grid.shape)
-
     myimage = _imshow_grid_values(grid, values_at_node, **kwds)
 
     if isinstance(values, str):
@@ -439,6 +279,8 @@ def _imshow_grid_values(
     show_elements=False,
     output=None,
 ):
+    from ..grid.raster import RasterModelGrid
+
     cmap = plt.get_cmap(cmap)
 
     if color_for_closed is not None:
@@ -447,6 +289,8 @@ def _imshow_grid_values(
         cmap.set_bad(alpha=0.0)
 
     if isinstance(grid, RasterModelGrid):
+        values = values.reshape(grid.shape)
+
         if values.ndim != 2:
             raise ValueError("values must have ndim == 2")
 
@@ -488,6 +332,8 @@ def _imshow_grid_values(
     else:
         import matplotlib.cm as cmx
         import matplotlib.colors as colors
+
+        values = values.reshape(-1)
 
         if limits is not None:
             (vmin, vmax) = (limits[0], limits[1])
@@ -579,557 +425,6 @@ def _imshow_grid_values(
             plt.clf()
         elif output:
             plt.show()
-
-
-def _imshowhs_grid_values(
-    grid,
-    values,
-    plot_name=None,
-    var_name=None,
-    var_name_two=None,
-    var_units=None,
-    fontweight_xlabel="bold",
-    fontweight_ylabel="bold",
-    grid_units=(None, None),
-    symmetric_cbar=False,
-    cmap="pink",
-    limits=None,
-    allow_colorbar=True,
-    vmin=None,
-    vmax=None,
-    norm=None,
-    ticks_km=False,
-    shrink=1.0,
-    color_for_closed=None,
-    color_for_background=None,
-    output=None,
-    plot_type="DEM",
-    drape1=None,
-    drape2=None,
-    cmap2=None,
-    vertical_exa=None,
-    azdeg=315,
-    altdeg=65,
-    thres_drape1=None,
-    alpha=None,
-    thres_drape2=None,
-    alpha2=None,
-    add_double_colorbar=False,
-    plt_contour=False,
-    contour_nb=50,
-    default_fontsize=10,
-    cbar_height="5%",
-    cbar_width="30%",
-    cbar_or="horizontal",
-    cbar_loc="lower right",
-    bbox_to_anchor=(0, 0, 1, 1),
-    cbar_ticks_position="top",
-    cbar_ticks_position2="bottom",
-    colorbar_label_y=-40,
-    colorbar_label_x=0.5,
-    cbar_tick_size=10,
-    cbar_label_color="black",
-    cbar_tick_color="black",
-    cbar_label_fontweight="bold",
-    add_label_bbox=False,
-    y_label_offSet_var_1=3,
-    y_label_offSet_var_2=-1.25,
-):
-    plot_type_options = ["DEM", "Hillshade", "Drape1", "Drape2"]
-    if plot_type not in plot_type_options:
-        raise ValueError(
-            "plot_type should be one of the following: "
-            + ", ".join(map(str, plot_type_options))
-        )
-    if plot_type == "Drape1" and drape1 is None:
-        raise ValueError(
-            "if plot_type is Drape1, 'drape1' input argument cannot be None. \
-                         Provide at least one array with the size of the number of grid nodes as drape1='field_to_be_plotted'"
-        )
-    if plot_type == "Drape2" and (drape1 is None or drape2 is None):
-        raise ValueError(
-            "if plot_type is Drape2, 'drape1' and 'drape2' input arguments cannot be None. \
-                         Provide an array for both with the size of the number of grid nodes as drape1='field1_to_be_plotted' and drape2='field2_to_be_plotted' "
-        )
-
-    # Poperties of bounding box of colorbar label, if used:
-    if add_label_bbox:
-        bbox_prop = dict(
-            boxstyle="round", pad=0.1, facecolor="white", alpha=0.7, edgecolor="white"
-        )
-    else:
-        bbox_prop = None
-
-    cmap = plt.get_cmap(cmap)
-
-    if color_for_closed is not None:
-        cmap.set_bad(color=color_for_closed)
-    else:
-        cmap.set_bad(alpha=0.0)
-
-    if isinstance(grid, RasterModelGrid):
-        # somethingToPlot is a flag indicating if any pixels should be plotted.
-        somethingToPlot = True
-
-        if values.ndim != 2:
-            raise ValueError("values must have ndim == 2")
-
-        y = (
-            np.arange(values.shape[0] + 1) * grid.dy
-            - grid.dy * 0.5
-            + grid.xy_of_lower_left[1]
-        )
-        x = (
-            np.arange(values.shape[1] + 1) * grid.dx
-            - grid.dx * 0.5
-            + grid.xy_of_lower_left[0]
-        )
-
-        ls = LightSource(azdeg=azdeg, altdeg=altdeg)
-        if cmap is None:
-            cmap = plt.cm.terrain
-
-        dx = x[1] - x[0]
-        dy = y[1] - y[0]
-
-        if vertical_exa is not None:
-            ve = vertical_exa
-        else:
-            ve = 3
-        extent = np.array([x[0] - dx, x[-1] + dx, y[-1] + dy, y[0] - dy])
-        if ticks_km:
-            extent /= 1e3
-
-        ax1 = plt.gca()
-        if alpha is None:
-            alpha = 1
-        if alpha2 is None:
-            alpha2 = 1
-        blend_modes = ["hsv", "overlay", "soft"]
-        if plot_type == "DEM":
-
-            kwds = dict(cmap=cmap)
-            (kwds["vmin"], kwds["vmax"]) = (values.min(), values.max())
-            if (limits is None) and ((vmin is None) and (vmax is None)):
-                if symmetric_cbar:
-                    (var_min, var_max) = (values.min(), values.max())
-                    limit = max(abs(var_min), abs(var_max))
-                    (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
-            elif limits is not None:
-                (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
-            else:
-                if vmin is not None:
-                    kwds["vmin"] = vmin
-                if vmax is not None:
-                    kwds["vmax"] = vmax
-
-            val = values.data
-            rgb = ls.shade(
-                val,
-                cmap=cmap,
-                blend_mode=blend_modes[0],
-                vert_exag=ve,
-                dx=dx,
-                dy=dy,
-                fraction=0.4,
-            )
-            ima = ax1.imshow(rgb, extent=extent, **kwds)
-
-        elif plot_type == "Hillshade":
-            ima = plt.imshow(
-                ls.hillshade(values, vert_exag=ve, dx=dx, dy=dy),
-                cmap="gray",
-                extent=extent,
-            )
-            allow_colorbar = False
-
-        elif plot_type == "Drape1" or plot_type == "Drape2":
-            # Process values from first drape
-            if isinstance(drape1, str):
-                values_at_node_drape1 = grid.at_node[drape1]
-            else:
-                values_at_node_drape1 = drape1.reshape((-1,))
-
-            if values_at_node_drape1.size != grid.number_of_nodes:
-                raise ValueError("number of values does not match number of nodes")
-
-            values_at_node_drape1 = np.ma.masked_where(
-                grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node_drape1
-            )
-
-            # Add mask if thres_drape1 is given
-            if thres_drape1 is not None:
-                # check if any value exceeds threshold
-                if not np.any(values_at_node_drape1 > thres_drape1):
-                    somethingToPlot = False
-
-                values_at_node_drape1 = np.ma.masked_where(
-                    values_at_node_drape1 < thres_drape1, values_at_node_drape1
-                )
-
-            if isinstance(grid, RasterModelGrid):
-                shape = grid.shape
-            else:
-                shape = (-1,)
-            val1 = values_at_node_drape1.reshape(shape)
-
-            kwds = dict(cmap=cmap)
-            (kwds["vmin"], kwds["vmax"]) = (val1.min(), val1.max())
-            if (limits is None) and ((vmin is None) and (vmax is None)):
-                if symmetric_cbar:
-                    (var_min, var_max) = (val1.min(), val1.max())
-                    limit = max(abs(var_min), abs(var_max))
-                    (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
-            elif limits is not None:
-                (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
-            else:
-                if vmin is not None:
-                    kwds["vmin"] = vmin
-                if vmax is not None:
-                    kwds["vmax"] = vmax
-            plt.imshow(
-                ls.hillshade(values, vert_exag=ve, dx=dx, dy=dy),
-                cmap="gray",
-                extent=extent,
-            )
-            ima = ax1.imshow(val1, extent=extent, alpha=alpha, **kwds)
-            if plt_contour:
-                plt.contour(
-                    x[0:-1] * 1e-3,
-                    y[0:-1] * 1e-3,
-                    val1,
-                    contour_nb,
-                    colors="black",
-                    linewidths=0.2,
-                )
-        if somethingToPlot:
-            # To cartezian  coordinates   (not if other layers has to be plotted on top!)
-            if plot_type != "Drape2":
-                ax1.invert_yaxis()
-            plt.xticks(fontsize=default_fontsize)
-            plt.yticks(fontsize=default_fontsize)
-
-            # if Drape2, default behavior is to add colorbar of first layer if add_double_colorbar == False
-            if allow_colorbar and (
-                plot_type == "DEM"
-                or plot_type == "Drape1"
-                or (plot_type == "Drape2" and not add_double_colorbar)
-            ):
-
-                cb_or = cbar_or
-                cb_ticks_position = cbar_ticks_position
-
-                axins1 = inset_axes(
-                    ax1,
-                    width=cbar_width,  # width = 50% of parent_bbox width
-                    height=cbar_height,  # height : 5%
-                    loc=cbar_loc,
-                    bbox_transform=ax1.transAxes,
-                    borderpad=0,
-                    bbox_to_anchor=bbox_to_anchor,
-                )
-
-                maxV = kwds["vmax"]
-                minV = kwds["vmin"]
-                cb_length = maxV - minV
-                if maxV <= 10:
-                    cb = plt.colorbar(
-                        ima,
-                        ax=ax1,
-                        cax=axins1,
-                        orientation=cb_or,
-                        ticks=[
-                            np.round(minV + 0.2 * cb_length, 1),
-                            np.round(minV + 0.8 * cb_length, 1),
-                        ],
-                    )
-                elif maxV <= 100:
-                    cb = plt.colorbar(
-                        ima,
-                        ax=ax1,
-                        cax=axins1,
-                        orientation=cb_or,
-                        ticks=[
-                            np.round(minV + 0.2 * cb_length, 0),
-                            np.round(minV + 0.8 * cb_length, 0),
-                        ],
-                    )
-                else:
-                    cb = plt.colorbar(
-                        ima,
-                        ax=ax1,
-                        cax=axins1,
-                        orientation=cb_or,
-                        ticks=[
-                            np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
-                            np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
-                        ],
-                    )
-                axins1.xaxis.set_ticks_position(cb_ticks_position)
-                cb.ax.tick_params(
-                    labelsize=cbar_tick_size,
-                    color=cbar_tick_color,
-                    labelcolor=cbar_tick_color,
-                )
-
-                # if colorbar_label:
-                #     cb.set_label(colorbar_label, rotation=270)
-                #     # ax1.xaxis.set_label_coords(0,2.5)
-
-            if plot_type == "Drape2":
-
-                # Process values from first drape
-
-                if isinstance(drape2, str):
-                    values_at_node_drape2 = grid.at_node[drape2]
-                else:
-                    values_at_node_drape2 = drape2.reshape((-1,))
-
-                if values_at_node_drape2.size != grid.number_of_nodes:
-                    raise ValueError("number of values does not match number of nodes")
-
-                values_at_node_drape2 = np.ma.masked_where(
-                    grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node_drape2
-                )
-
-                # Add mask if thres_drape1 is given
-                if thres_drape2 is not None:
-                    values_at_node_drape2 = np.ma.masked_where(
-                        values_at_node_drape2 < thres_drape2, values_at_node_drape2
-                    )
-
-                if isinstance(grid, RasterModelGrid):
-                    shape = grid.shape
-                else:
-                    shape = (-1,)
-                val2 = values_at_node_drape2.reshape(shape)
-
-                if cmap2 is None:
-                    cmap2 = plt.cm.terrain
-                kwds = dict(cmap=cmap2)
-                (kwds["vmin"], kwds["vmax"]) = (val2.min(), val2.max())
-                if (limits is None) and ((vmin is None) and (vmax is None)):
-                    if symmetric_cbar:
-                        (var_min, var_max) = (val2.min(), val2.max())
-                        limit = max(abs(var_min), abs(var_max))
-                        (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
-                elif limits is not None:
-                    (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
-                else:
-                    if vmin is not None:
-                        kwds["vmin"] = vmin
-                    if vmax is not None:
-                        kwds["vmax"] = vmax
-
-                ima2 = ax1.imshow(val2, extent=extent, alpha=alpha2, **kwds)
-                ax1.invert_yaxis()
-
-                # Add colorbars
-                if add_double_colorbar:
-                    axins1 = inset_axes(
-                        ax1,
-                        width=cbar_width,  # width = 50% of parent_bbox width
-                        height=cbar_height,  # height : 5%
-                        loc=cbar_loc,
-                        bbox_to_anchor=(-0.005, 0.25, 1, 1),
-                        bbox_transform=ax1.transAxes,
-                        borderpad=0,
-                    )
-
-                    cb_or = cbar_or
-                    cb_ticks_position = cbar_ticks_position
-                    maxV = np.max(val1)
-                    minV = np.min(val1)
-                    cb_length = maxV - minV
-                    if maxV <= 10:
-                        cb = plt.colorbar(
-                            ima,
-                            ax=ax1,
-                            cax=axins1,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(minV + 0.2 * cb_length, 1),
-                                np.round(minV + 0.8 * cb_length, 1),
-                            ],
-                        )
-                    elif maxV <= 100:
-                        cb = plt.colorbar(
-                            ima,
-                            ax=ax1,
-                            cax=axins1,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(minV + 0.2 * cb_length, 0),
-                                np.round(minV + 0.8 * cb_length, 0),
-                            ],
-                        )
-                    else:
-                        cb = plt.colorbar(
-                            ima,
-                            ax=ax1,
-                            cax=axins1,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
-                                np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
-                            ],
-                        )
-                    cb.ax.tick_params(
-                        labelsize=cbar_tick_size,
-                        color=cbar_tick_color,
-                        labelcolor=cbar_tick_color,
-                    )
-                    axins1.xaxis.set_ticks_position(cb_ticks_position)
-
-                    axins1.set_xlabel(
-                        var_name,
-                        usetex=True,
-                        fontsize=default_fontsize,
-                        rotation=0,
-                        color=cbar_label_color,
-                        fontweight=cbar_label_fontweight,
-                        bbox=bbox_prop,
-                    )
-                    axins1.xaxis.set_label_coords(0.5, y_label_offSet_var_1)
-
-                    axins2 = inset_axes(
-                        ax1,
-                        width=cbar_width,  # width = 50% of parent_bbox width
-                        height=cbar_height,  # height : 5%
-                        loc=cbar_loc,
-                        bbox_to_anchor=(-0.005, 0.15, 1, 1),
-                        bbox_transform=ax1.transAxes,
-                        borderpad=0,
-                    )
-                    cb_or = cbar_or
-                    cb_ticks_position = cbar_ticks_position2
-                    maxV = np.max(val2)
-                    minV = np.min(val2)
-                    cb_length = maxV - minV
-                    if maxV <= 10:
-                        cb = plt.colorbar(
-                            ima2,
-                            ax=ax1,
-                            cax=axins2,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(minV + 0.2 * cb_length, 1),
-                                np.round(minV + 0.8 * cb_length, 1),
-                            ],
-                        )
-                    elif maxV <= 100:
-                        cb = plt.colorbar(
-                            ima2,
-                            ax=ax1,
-                            cax=axins2,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(minV + 0.2 * cb_length, 0),
-                                np.round(minV + 0.8 * cb_length, 0),
-                            ],
-                        )
-                    else:
-                        cb = plt.colorbar(
-                            ima2,
-                            ax=ax1,
-                            cax=axins2,
-                            orientation=cb_or,
-                            ticks=[
-                                np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
-                                np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
-                            ],
-                        )
-                    cb.ax.tick_params(
-                        labelsize=cbar_tick_size,
-                        color=cbar_tick_color,
-                        labelcolor=cbar_tick_color,
-                    )
-
-                    axins2.xaxis.set_ticks_position(cb_ticks_position)
-                    axins2.set_xlabel(
-                        var_name_two,
-                        usetex=True,
-                        fontsize=default_fontsize,
-                        rotation=0,
-                        color=cbar_label_color,
-                        fontweight=cbar_label_fontweight,
-                        bbox=bbox_prop,
-                    )
-                    axins2.xaxis.set_label_coords(0.5, y_label_offSet_var_2)
-
-    if grid_units[1] is None and grid_units[0] is None:
-        grid_units = grid.axis_units
-        if grid_units[1] == "-" and grid_units[0] == "-":
-            ax1.set_xlabel(
-                "Easting", fontweight=fontweight_xlabel, fontsize=default_fontsize
-            )
-            ax1.set_ylabel(
-                "Northing", fontweight=fontweight_ylabel, fontsize=default_fontsize
-            )
-        else:
-            ax1.set_xlabel(
-                "Easting, %s" % grid_units[1],
-                fontweight=fontweight_xlabel,
-                fontsize=default_fontsize,
-            )
-            ax1.set_ylabel(
-                "Northing, %s" % grid_units[1],
-                fontweight=fontweight_ylabel,
-                fontsize=default_fontsize,
-            )
-    else:
-        ax1.set_xlabel(
-            "Easting, %s" % grid_units[1],
-            fontweight=fontweight_xlabel,
-            fontsize=default_fontsize,
-        )
-        ax1.set_ylabel(
-            "Northing, %s" % grid_units[1],
-            fontweight=fontweight_ylabel,
-            fontsize=default_fontsize,
-        )
-
-    if plot_name is not None:
-        plt.title("%s" % (plot_name))
-
-    if (
-        somethingToPlot
-        and (var_name is not None or var_units is not None)
-        and plot_type != "Drape2"
-    ):
-        if var_name is not None:
-            assert type(var_name) is str
-            if var_units is not None:
-                assert type(var_units) is str
-                colorbar_label = var_name + " (" + var_units + ")"
-            else:
-                colorbar_label = var_name
-        else:
-            assert type(var_units) is str
-            colorbar_label = "(" + var_units + ")"
-        assert type(colorbar_label) is str
-        if allow_colorbar:
-            cb.set_label(
-                colorbar_label,
-                fontsize=default_fontsize,
-                labelpad=colorbar_label_y,
-                color=cbar_label_color,
-                x=colorbar_label_x,
-                fontweight=cbar_label_fontweight,
-                bbox=bbox_prop,
-            )
-
-    if color_for_background is not None:
-        plt.gca().set_facecolor(color_for_background)
-
-    if output is not None:
-        if type(output) is str:
-            plt.savefig(output)
-            plt.clf()
-        elif output:
-            plt.show()
-
-    return ax1
 
 
 def imshow_grid(grid, values, **kwds):
@@ -1290,173 +585,3 @@ def _guess_location_from_size(
         if values.size == grid.number_of_elements(location):
             return location
     return None
-
-
-def imshowhs_grid(grid, values, **kwds):
-    """Prepare a map view of data over all nodes in the grid using a hillshade
-    topography map in the background.
-
-    Data is plotted as cells shaded with the value at the node at its center.
-    Outer edges of perimeter cells are extrapolated. Closed elements are
-    colored uniformly (default black, overridden with kwd 'color_for_closed');
-    other open boundary nodes get their actual values.
-
-    *values* can be a field name, a regular array, or a masked array. If a
-    masked array is provided, masked entries will be treated as if they were
-    Landlab BC_NODE_IS_CLOSED. Used together with the color_at_closed=None
-    keyword (i.e., "transparent"), this can allow for construction of overlay
-    layers in a figure (e.g., only defining values in a river network, and
-    overlaying it on another landscape).
-
-    Use matplotlib functions like xlim, ylim to modify your plot after calling
-    :func:`imshowhs_grid`, as desired.
-
-    Node coordinates are printed when a mouse button is pressed on a cell in
-    the plot.
-
-    For now, this function only works with regular grids.
-
-    Parameters
-    ----------
-    grid : ModelGrid
-        Grid containing the field to plot, or describing the geometry of the
-        provided array.
-    values : array_like, masked_array, or str
-        Node values, or a field name as a string from which to draw the data.
-    plot_name : str, optional
-        String to put as the plot title.
-    var_name : str, optional
-        Variable name, to use as a colorbar label.
-    var_name_two : str, optional
-        Variable name of second layer, to use as a colorbar label.
-    var_units : str, optional
-        Units for the variable being plotted, for the colorbar.
-    grid_units : tuple of str, optional
-        Units for y, and x dimensions. If None, component will look to the
-        gri property `axis_units` for this information. If no units are
-        specified there, no entry is made.
-    symmetric_cbar : bool
-        Make the colormap symetric about 0.
-    cmap : str
-        Name of a colormap
-    limits : tuple of float
-        Minimum and maximum of the colorbar.
-    vmin, vmax: floats
-        Alternatives to limits.
-    norm : matplotlib.colors.Normalize
-        The normalizing object which scales data, typically into the interval
-        [0, 1]. Ignore in most cases.
-    ticks_km : bool, optional
-        Display ticks in km instead of m
-    allow_colorbar : bool
-        If True, include the colorbar.
-    shrink : float
-        Fraction by which to shrink the colorbar.
-    color_for_closed : str or None
-        Color to use for closed nodes (default 'black'). If None, closed
-        (or masked) nodes will be transparent.
-    color_for_background : color str or other color declaration, or None
-        Color to use for closed elements (default None). If None, the
-        background will be transparent, and appear white.
-    output : None, string, or bool
-        If None (or False), the image is sent to the imaging buffer to await
-        an explicit call to show() or savefig() from outside this function.
-        If a string, the string should be the path to a save location, and the
-        filename (with file extension). The function will then call
-        plt.savefig([string]) itself. If True, the function will call
-        plt.show() itself once plotting is complete.
-    fontweight_xlabel : str, optional
-        weight of x label. The default is 'bold'.
-    fontweight_ylabel : str, optional
-        weight of y label. The default is 'bold'.
-    plot_type : str, optional
-        The type of plot that will be plotted.
-        There are four options:
-        * 'DEM': Display a digital elevation map underlain by a shaded relief,
-        based on the same DEM ('topographic__elevation')
-        * 'Hillshade': Display the shaded relief, of the provided DEM ('topographic__elevation')
-        * 'Drape1': Display any kind of provided layer on top of a shaded
-        relief provided in the 'topographic__elevation' field
-        * 'Drape2': Display two layers on top of a shaded relief provided in
-        the 'topographic__elevation' field
-        The default is "DEM".
-    drape1 : array_like, masked_array
-        Node values to plot on top of a hillshade map. The default is None.
-    drape2 : array_like, masked_array
-        Node values to plot on top of drape1 and a hillshade map. The default is None.
-    cmap2 : str
-        Name of a colormap for drape 2. The default is None.
-    vertical_exa : float, optional
-        vertical exageration of hillshade map. The default is None.
-    azdeg : float, optional
-        azimuth of light source. The default is 315.
-    altdeg : float, optional
-        elevation of light source. The default is 65.
-    thres_drape1 : float, optional
-        threshold below which drape1 is made transparant. The default is None.
-    alpha : float (0-1), optional
-        transparency of DEM/Drape1 . The default is None.
-    thres_drape2 : float, optional
-        threshold below which drape2 is made transparant. The default is None.
-    alpha2 : float (0-1), optional
-        transparency of Drape2 . The default is None.
-    add_double_colorbar : bool, optional
-        add a double colorbar when two drapes are plotted. The default is False.
-    plt_contour : bool, optional
-        Add contour lines to elevation plot . The default is False.
-    contour_nb : int, optional
-        number of contour lines. The default is 50.
-    default_fontsize : float, optional
-        Default font size of plot labels. The default is 10.
-    cbar_height : percentage, optional
-        height of colorbar in percentage of figure. The default is "5%".
-    cbar_width : percentage, optional
-        width of colorbar in percentage of figure. The default is "30%".
-    cbar_or : str, optional
-        orientation of colorbar. The default is "horizontal".
-    cbar_loc : str, optional
-        location of colorbar. The default is "lower right".
-    bbox_to_anchor : vector, optional
-        bbox to anchor. The default is (0, 0, 1, 1).
-    cbar_ticks_position : str, optional
-        location of colorbar ticks (below or on top of the colorbar). The default is "top".
-    cbar_ticks_position2 : str, optional
-        location of colorbar ticks for colorbar of Drape2 (below or on top of the colorbar). The default is "bottom".
-    colorbar_label_y : float, optional
-        location of colorbar label with respect to the colorbar in y direction. The default is -40.
-    colorbar_label_x : float , optional
-        location of colorbar label with respect to the colorbar in x direction. The default is 0.5.
-    cbar_tick_size : float, optional
-        colorbar tick size. The default is 10.
-    cbar_label_color : str, optional
-        colorbar tick color. The default is 'black'.
-    cbar_label_fontweight : str, optional
-        colorbar font weight. The default is 'bold'.
-    add_label_bbox : bool, optional
-        Add a bbox surrounding the colorbar label. The default is False.
-    y_label_offSet_var_1 : float, optional
-        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is 3.0.
-    y_label_offSet_var_2 : float, optional
-        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is -1.25.
-
-    Returns
-    -------
-    ax : figure ax
-        return ax if output == True.
-    """
-    values_at = kwds.pop("values_at", "node")
-    values_at = kwds.pop("at", values_at)
-
-    if isinstance(values, str):
-        values = grid.field_values(values_at, values)
-
-    if values_at == "node":
-        ax = imshowhs_grid_at_node(grid, values, **kwds)
-    elif values_at == "cell":
-        raise NotImplementedError(
-            "For now, only values at nodes can be displayed using the in the imshowhs functions"
-        )
-    else:
-        raise TypeError("value location %s not understood" % values_at)
-
-    return ax

--- a/landlab/plot/imshowhs.py
+++ b/landlab/plot/imshowhs.py
@@ -1,0 +1,924 @@
+"""Methods to plot data defined on Landlab grids.
+
+Plotting functions
+++++++++++++++++++
+
+.. autosummary::
+
+    ~landlab.plot.imshow.imshowhs_grid
+    ~landlab.plot.imshow.imshowhs_grid_at_node
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.colors import LightSource
+from mpl_toolkits.axes_grid1.inset_locator import inset_axes
+
+from ..grid.raster import RasterModelGrid
+from .event_handler import query_grid_on_button_press
+
+
+def imshowhs_grid(grid, values, **kwds):
+    """Prepare a map view of data over all nodes in the grid using a hillshade
+    topography map in the background.
+
+    Data is plotted as cells shaded with the value at the node at its center.
+    Outer edges of perimeter cells are extrapolated. Closed elements are
+    colored uniformly (default black, overridden with kwd 'color_for_closed');
+    other open boundary nodes get their actual values.
+
+    *values* can be a field name, a regular array, or a masked array. If a
+    masked array is provided, masked entries will be treated as if they were
+    Landlab BC_NODE_IS_CLOSED. Used together with the color_at_closed=None
+    keyword (i.e., "transparent"), this can allow for construction of overlay
+    layers in a figure (e.g., only defining values in a river network, and
+    overlaying it on another landscape).
+
+    Use matplotlib functions like xlim, ylim to modify your plot after calling
+    :func:`imshowhs_grid`, as desired.
+
+    Node coordinates are printed when a mouse button is pressed on a cell in
+    the plot.
+
+    For now, this function only works with regular grids.
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        Grid containing the field to plot, or describing the geometry of the
+        provided array.
+    values : array_like, masked_array, or str
+        Node values, or a field name as a string from which to draw the data.
+    plot_name : str, optional
+        String to put as the plot title.
+    var_name : str, optional
+        Variable name, to use as a colorbar label.
+    var_name_two : str, optional
+        Variable name of second layer, to use as a colorbar label.
+    var_units : str, optional
+        Units for the variable being plotted, for the colorbar.
+    grid_units : tuple of str, optional
+        Units for y, and x dimensions. If None, component will look to the
+        gri property `axis_units` for this information. If no units are
+        specified there, no entry is made.
+    symmetric_cbar : bool
+        Make the colormap symetric about 0.
+    cmap : str
+        Name of a colormap
+    limits : tuple of float
+        Minimum and maximum of the colorbar.
+    vmin, vmax: floats
+        Alternatives to limits.
+    norm : matplotlib.colors.Normalize
+        The normalizing object which scales data, typically into the interval
+        [0, 1]. Ignore in most cases.
+    ticks_km : bool, optional
+        Display ticks in km instead of m
+    allow_colorbar : bool
+        If True, include the colorbar.
+    shrink : float
+        Fraction by which to shrink the colorbar.
+    color_for_closed : str or None
+        Color to use for closed nodes (default 'black'). If None, closed
+        (or masked) nodes will be transparent.
+    color_for_background : color str or other color declaration, or None
+        Color to use for closed elements (default None). If None, the
+        background will be transparent, and appear white.
+    output : None, string, or bool
+        If None (or False), the image is sent to the imaging buffer to await
+        an explicit call to show() or savefig() from outside this function.
+        If a string, the string should be the path to a save location, and the
+        filename (with file extension). The function will then call
+        plt.savefig([string]) itself. If True, the function will call
+        plt.show() itself once plotting is complete.
+    fontweight_xlabel : str, optional
+        weight of x label. The default is 'bold'.
+    fontweight_ylabel : str, optional
+        weight of y label. The default is 'bold'.
+    plot_type : str, optional
+        The type of plot that will be plotted.
+        There are four options:
+        * 'DEM': Display a digital elevation map underlain by a shaded relief,
+        based on the same DEM ('topographic__elevation')
+        * 'Hillshade': Display the shaded relief, of the provided DEM ('topographic__elevation')
+        * 'Drape1': Display any kind of provided layer on top of a shaded
+        relief provided in the 'topographic__elevation' field
+        * 'Drape2': Display two layers on top of a shaded relief provided in
+        the 'topographic__elevation' field
+        The default is "DEM".
+    drape1 : array_like, masked_array
+        Node values to plot on top of a hillshade map. The default is None.
+    drape2 : array_like, masked_array
+        Node values to plot on top of drape1 and a hillshade map. The default is None.
+    cmap2 : str
+        Name of a colormap for drape 2. The default is None.
+    vertical_exa : float, optional
+        vertical exageration of hillshade map. The default is None.
+    azdeg : float, optional
+        azimuth of light source. The default is 315.
+    altdeg : float, optional
+        elevation of light source. The default is 65.
+    thres_drape1 : float, optional
+        threshold below which drape1 is made transparant. The default is None.
+    alpha : float (0-1), optional
+        transparency of DEM/Drape1 . The default is None.
+    thres_drape2 : float, optional
+        threshold below which drape2 is made transparant. The default is None.
+    alpha2 : float (0-1), optional
+        transparency of Drape2 . The default is None.
+    add_double_colorbar : bool, optional
+        add a double colorbar when two drapes are plotted. The default is False.
+    plt_contour : bool, optional
+        Add contour lines to elevation plot . The default is False.
+    contour_nb : int, optional
+        number of contour lines. The default is 50.
+    default_fontsize : float, optional
+        Default font size of plot labels. The default is 10.
+    cbar_height : percentage, optional
+        height of colorbar in percentage of figure. The default is "5%".
+    cbar_width : percentage, optional
+        width of colorbar in percentage of figure. The default is "30%".
+    cbar_or : str, optional
+        orientation of colorbar. The default is "horizontal".
+    cbar_loc : str, optional
+        location of colorbar. The default is "lower right".
+    bbox_to_anchor : vector, optional
+        bbox to anchor. The default is (0, 0, 1, 1).
+    cbar_ticks_position : str, optional
+        location of colorbar ticks (below or on top of the colorbar). The default is "top".
+    cbar_ticks_position2 : str, optional
+        location of colorbar ticks for colorbar of Drape2 (below or on top of the colorbar). The default is "bottom".
+    colorbar_label_y : float, optional
+        location of colorbar label with respect to the colorbar in y direction. The default is -40.
+    colorbar_label_x : float , optional
+        location of colorbar label with respect to the colorbar in x direction. The default is 0.5.
+    cbar_tick_size : float, optional
+        colorbar tick size. The default is 10.
+    cbar_label_color : str, optional
+        colorbar tick color. The default is 'black'.
+    cbar_label_fontweight : str, optional
+        colorbar font weight. The default is 'bold'.
+    add_label_bbox : bool, optional
+        Add a bbox surrounding the colorbar label. The default is False.
+    y_label_offSet_var_1 : float, optional
+        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is 3.0.
+    y_label_offSet_var_2 : float, optional
+        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is -1.25.
+
+    Returns
+    -------
+    ax : figure ax
+        return ax if output == True.
+    """
+    values_at = kwds.pop("values_at", "node")
+    values_at = kwds.pop("at", values_at)
+
+    if isinstance(values, str):
+        values = grid.field_values(values_at, values)
+
+    if values_at == "node":
+        ax = imshowhs_grid_at_node(grid, values, **kwds)
+    elif values_at == "cell":
+        raise NotImplementedError(
+            "For now, only values at nodes can be displayed using the in the imshowhs functions"
+        )
+    else:
+        raise TypeError("value location %s not understood" % values_at)
+
+    return ax
+
+
+def imshowhs_grid_at_node(grid, values, **kwds):
+    """Prepare a map view of data over all nodes in the grid using a hillshade
+    topography map in the background.
+
+    Data is plotted as cells shaded with the value at the node at its center.
+    Outer edges of perimeter cells are extrapolated. Closed elements are
+    colored uniformly (default black, overridden with kwd 'color_for_closed');
+    other open boundary nodes get their actual values.
+
+    *values* can be a field name, a regular array, or a masked array. If a
+    masked array is provided, masked entries will be treated as if they were
+    Landlab BC_NODE_IS_CLOSED. Used together with the color_at_closed=None
+    keyword (i.e., "transparent"), this can allow for construction of overlay
+    layers in a figure (e.g., only defining values in a river network, and
+    overlaying it on another landscape).
+
+    Use matplotlib functions like xlim, ylim to modify your plot after calling
+    :func:`imshowhs_grid`, as desired.
+
+    Node coordinates are printed when a mouse button is pressed on a cell in
+    the plot.
+
+    For now, this function only works with regular grids.
+    Developed by: Benjamin Campforts
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        Grid containing the field to plot, or describing the geometry of the
+        provided array.
+    values : array_like, masked_array, or str
+        Node values, or a field name as a string from which to draw the data.
+    plot_name : str, optional
+        String to put as the plot title.
+    var_name : str, optional
+        Variable name, to use as a colorbar label.
+    var_name_two : str, optional
+        Variable name of second layer, to use as a colorbar label.
+    var_units : str, optional
+        Units for the variable being plotted, for the colorbar.
+    grid_units : tuple of str, optional
+        Units for y, and x dimensions. If None, component will look to the
+        gri property `axis_units` for this information. If no units are
+        specified there, no entry is made.
+    symmetric_cbar : bool
+        Make the colormap symetric about 0.
+    cmap : str
+        Name of a colormap
+    limits : tuple of float
+        Minimum and maximum of the colorbar.
+    vmin, vmax: floats
+        Alternatives to limits.
+    norm : matplotlib.colors.Normalize
+        The normalizing object which scales data, typically into the interval
+        [0, 1]. Ignore in most cases.
+    ticks_km : bool, optional
+        Display ticks in km instead of m
+        Default: False
+    allow_colorbar : bool
+        If True, include the colorbar.
+    shrink : float
+        Fraction by which to shrink the colorbar.
+    color_for_closed : str or None
+        Color to use for closed nodes (default 'black'). If None, closed
+        (or masked) nodes will be transparent.
+    color_for_background : color str or other color declaration, or None
+        Color to use for closed elements (default None). If None, the
+        background will be transparent, and appear white.
+    output : None, string, or bool
+        If None (or False), the image is sent to the imaging buffer to await
+        an explicit call to show() or savefig() from outside this function.
+        If a string, the string should be the path to a save location, and the
+        filename (with file extension). The function will then call
+        plt.savefig([string]) itself. If True, the function will call
+        plt.show() itself once plotting is complete.
+    fontweight_xlabel : str, optional
+        weight of x label. The default is 'bold'.
+    fontweight_ylabel : str, optional
+        weight of y label. The default is 'bold'.
+    plot_type : str, optional
+        There are four options:
+        * 'DEM': Display a digital elevation map underlain by a shaded relief,
+        based on the same DEM ('topographic__elevation')
+        * 'Hillshade': Display the shaded relief, of the provided DEM ('topographic__elevation')
+        * 'Drape1': Display any kind of provided layer on top of a shaded
+        relief provided in the 'topographic__elevation' field
+        * 'Drape2': Display two layers on top of a shaded relief provided in
+        the 'topographic__elevation' field
+        The default is "DEM".
+    drape1 : array_like, masked_array
+        Node values to plot on top of a hillshade map. The default is None.
+    drape2 : array_like, masked_array
+        Node values to plot on top of drape1 and a hillshade map. The default is None.
+    cmap2 : str
+        Name of a colormap for drape 2. The default is None.
+    vertical_exa : float, optional
+        vertical exageration of hillshade map. The default is None.
+    azdeg : float, optional
+        azimuth of light source. The default is 315.
+    altdeg : float, optional
+        elevation of light source. The default is 65.
+    thres_drape1 : float, optional
+        threshold below which drape1 is made transparant. The default is None.
+    alpha : float (0-1), optional
+        transparency of DEM/Drape1 . The default is None.
+    thres_drape2 : float, optional
+        threshold below which drape2 is made transparant. The default is None.
+    alpha2 : float (0-1), optional
+        transparency of Drape2 . The default is None.
+    add_double_colorbar : bool, optional
+        add a double colorbar when two drapes are plotted. The default is False.
+    plt_contour : bool, optional
+        Add contour lines to elevation plot . The default is False.
+    contour_nb : int, optional
+        number of contour lines. The default is 50.
+    default_fontsize : float, optional
+        Default font size of plot labels. The default is 10.
+    cbar_height : percentage, optional
+        height of colorbar in percentage of figure. The default is "5%".
+    cbar_width : percentage, optional
+        width of colorbar in percentage of figure. The default is "30%".
+    cbar_or : str, optional
+        orientation of colorbar. The default is "horizontal".
+    cbar_loc : str, optional
+        location of colorbar. The default is "lower right".
+    bbox_to_anchor : vector, optional
+        bbox to anchor. The default is (0, 0, 1, 1).
+    cbar_ticks_position : str, optional
+        location of colorbar ticks (below or on top of the colorbar). The default is "top".
+    cbar_ticks_position2 : str, optional
+        location of colorbar ticks for colorbar of Drape2 (below or on top of the colorbar). The default is "bottom".
+    colorbar_label_y : float, optional
+        location of colorbar label with respect to the colorbar in y direction. The default is -40.
+    colorbar_label_x : float , optional
+        location of colorbar label with respect to the colorbar in x direction. The default is 0.5.
+    cbar_tick_size : float, optional
+        colorbar tick size. The default is 10.
+    cbar_label_color : str, optional
+        colorbar label color. The default is 'black'.
+    cbar_ticks_color : str, optional
+        colorbar tick color. The default is 'black'.
+    cbar_label_fontweight : str, optional
+        colorbar font weight. The default is 'bold'.
+    add_label_bbox : bool, optional
+        Add a bbox surrounding the colorbar label. The default is False.
+    y_label_offSet_var_1 : float, optional
+        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is 3.0.
+    y_label_offSet_var_2 : float, optional
+        Offset of ylabel on colorbar of first variable in plot with two overlaying plots. The default is -1.25.
+
+    Returns
+    -------
+    ax : figure ax
+        return ax if output == True.
+    """
+    if isinstance(values, str):
+        values_at_node = grid.at_node[values]
+    else:
+        values_at_node = values.reshape((-1,))
+
+    if values_at_node.size != grid.number_of_nodes:
+        raise ValueError("number of values does not match number of nodes")
+
+    values_at_node = np.ma.masked_where(
+        grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node
+    )
+
+    if isinstance(grid, RasterModelGrid):
+        shape = grid.shape
+    else:
+        raise NotImplementedError(
+            "For now, only RasterModelGrids are supported in the imshowhs functions"
+        )
+
+    ax = _imshowhs_grid_values(grid, values_at_node.reshape(shape), **kwds)
+
+    if isinstance(values, str):
+        plt.title(values)
+
+    plt.gcf().canvas.mpl_connect(
+        "button_press_event", lambda event: query_grid_on_button_press(event, grid)
+    )
+    # plt.show()
+    return ax
+
+
+def _imshowhs_grid_values(
+    grid,
+    values,
+    plot_name=None,
+    var_name=None,
+    var_name_two=None,
+    var_units=None,
+    fontweight_xlabel="bold",
+    fontweight_ylabel="bold",
+    grid_units=(None, None),
+    symmetric_cbar=False,
+    cmap="pink",
+    limits=None,
+    allow_colorbar=True,
+    vmin=None,
+    vmax=None,
+    norm=None,
+    ticks_km=False,
+    shrink=1.0,
+    color_for_closed=None,
+    color_for_background=None,
+    output=None,
+    plot_type="DEM",
+    drape1=None,
+    drape2=None,
+    cmap2=None,
+    vertical_exa=None,
+    azdeg=315,
+    altdeg=65,
+    thres_drape1=None,
+    alpha=None,
+    thres_drape2=None,
+    alpha2=None,
+    add_double_colorbar=False,
+    plt_contour=False,
+    contour_nb=50,
+    default_fontsize=10,
+    cbar_height="5%",
+    cbar_width="30%",
+    cbar_or="horizontal",
+    cbar_loc="lower right",
+    bbox_to_anchor=(0, 0, 1, 1),
+    cbar_ticks_position="top",
+    cbar_ticks_position2="bottom",
+    colorbar_label_y=-40,
+    colorbar_label_x=0.5,
+    cbar_tick_size=10,
+    cbar_label_color="black",
+    cbar_tick_color="black",
+    cbar_label_fontweight="bold",
+    add_label_bbox=False,
+    y_label_offSet_var_1=3,
+    y_label_offSet_var_2=-1.25,
+):
+    plot_type_options = ["DEM", "Hillshade", "Drape1", "Drape2"]
+    if plot_type not in plot_type_options:
+        raise ValueError(
+            "plot_type should be one of the following: "
+            + ", ".join(map(str, plot_type_options))
+        )
+    if plot_type == "Drape1" and drape1 is None:
+        raise ValueError(
+            "if plot_type is Drape1, 'drape1' input argument cannot be None. \
+                         Provide at least one array with the size of the number of grid nodes as drape1='field_to_be_plotted'"
+        )
+    if plot_type == "Drape2" and (drape1 is None or drape2 is None):
+        raise ValueError(
+            "if plot_type is Drape2, 'drape1' and 'drape2' input arguments cannot be None. \
+                         Provide an array for both with the size of the number of grid nodes as drape1='field1_to_be_plotted' and drape2='field2_to_be_plotted' "
+        )
+
+    # Poperties of bounding box of colorbar label, if used:
+    if add_label_bbox:
+        bbox_prop = dict(
+            boxstyle="round", pad=0.1, facecolor="white", alpha=0.7, edgecolor="white"
+        )
+    else:
+        bbox_prop = None
+
+    cmap = plt.get_cmap(cmap)
+
+    if color_for_closed is not None:
+        cmap.set_bad(color=color_for_closed)
+    else:
+        cmap.set_bad(alpha=0.0)
+
+    if isinstance(grid, RasterModelGrid):
+        # somethingToPlot is a flag indicating if any pixels should be plotted.
+        somethingToPlot = True
+
+        if values.ndim != 2:
+            raise ValueError("values must have ndim == 2")
+
+        y = (
+            np.arange(values.shape[0] + 1) * grid.dy
+            - grid.dy * 0.5
+            + grid.xy_of_lower_left[1]
+        )
+        x = (
+            np.arange(values.shape[1] + 1) * grid.dx
+            - grid.dx * 0.5
+            + grid.xy_of_lower_left[0]
+        )
+
+        ls = LightSource(azdeg=azdeg, altdeg=altdeg)
+        if cmap is None:
+            cmap = plt.cm.terrain
+
+        dx = x[1] - x[0]
+        dy = y[1] - y[0]
+
+        if vertical_exa is not None:
+            ve = vertical_exa
+        else:
+            ve = 3
+        extent = np.array([x[0] - dx, x[-1] + dx, y[-1] + dy, y[0] - dy])
+        if ticks_km:
+            extent /= 1e3
+
+        ax1 = plt.gca()
+        if alpha is None:
+            alpha = 1
+        if alpha2 is None:
+            alpha2 = 1
+        blend_modes = ["hsv", "overlay", "soft"]
+        if plot_type == "DEM":
+
+            kwds = dict(cmap=cmap)
+            (kwds["vmin"], kwds["vmax"]) = (values.min(), values.max())
+            if (limits is None) and ((vmin is None) and (vmax is None)):
+                if symmetric_cbar:
+                    (var_min, var_max) = (values.min(), values.max())
+                    limit = max(abs(var_min), abs(var_max))
+                    (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
+            elif limits is not None:
+                (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
+            else:
+                if vmin is not None:
+                    kwds["vmin"] = vmin
+                if vmax is not None:
+                    kwds["vmax"] = vmax
+
+            val = values.data
+            rgb = ls.shade(
+                val,
+                cmap=cmap,
+                blend_mode=blend_modes[0],
+                vert_exag=ve,
+                dx=dx,
+                dy=dy,
+                fraction=0.4,
+            )
+            ima = ax1.imshow(rgb, extent=extent, **kwds)
+
+        elif plot_type == "Hillshade":
+            ima = plt.imshow(
+                ls.hillshade(values, vert_exag=ve, dx=dx, dy=dy),
+                cmap="gray",
+                extent=extent,
+            )
+            allow_colorbar = False
+
+        elif plot_type == "Drape1" or plot_type == "Drape2":
+            # Process values from first drape
+            if isinstance(drape1, str):
+                values_at_node_drape1 = grid.at_node[drape1]
+            else:
+                values_at_node_drape1 = drape1.reshape((-1,))
+
+            if values_at_node_drape1.size != grid.number_of_nodes:
+                raise ValueError("number of values does not match number of nodes")
+
+            values_at_node_drape1 = np.ma.masked_where(
+                grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node_drape1
+            )
+
+            # Add mask if thres_drape1 is given
+            if thres_drape1 is not None:
+                # check if any value exceeds threshold
+                if not np.any(values_at_node_drape1 > thres_drape1):
+                    somethingToPlot = False
+
+                values_at_node_drape1 = np.ma.masked_where(
+                    values_at_node_drape1 < thres_drape1, values_at_node_drape1
+                )
+
+            if isinstance(grid, RasterModelGrid):
+                shape = grid.shape
+            else:
+                shape = (-1,)
+            val1 = values_at_node_drape1.reshape(shape)
+
+            kwds = dict(cmap=cmap)
+            (kwds["vmin"], kwds["vmax"]) = (val1.min(), val1.max())
+            if (limits is None) and ((vmin is None) and (vmax is None)):
+                if symmetric_cbar:
+                    (var_min, var_max) = (val1.min(), val1.max())
+                    limit = max(abs(var_min), abs(var_max))
+                    (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
+            elif limits is not None:
+                (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
+            else:
+                if vmin is not None:
+                    kwds["vmin"] = vmin
+                if vmax is not None:
+                    kwds["vmax"] = vmax
+            plt.imshow(
+                ls.hillshade(values, vert_exag=ve, dx=dx, dy=dy),
+                cmap="gray",
+                extent=extent,
+            )
+            ima = ax1.imshow(val1, extent=extent, alpha=alpha, **kwds)
+            if plt_contour:
+                plt.contour(
+                    x[0:-1] * 1e-3,
+                    y[0:-1] * 1e-3,
+                    val1,
+                    contour_nb,
+                    colors="black",
+                    linewidths=0.2,
+                )
+        if somethingToPlot:
+            # To cartezian  coordinates   (not if other layers has to be plotted on top!)
+            if plot_type != "Drape2":
+                ax1.invert_yaxis()
+            plt.xticks(fontsize=default_fontsize)
+            plt.yticks(fontsize=default_fontsize)
+
+            # if Drape2, default behavior is to add colorbar of first layer if add_double_colorbar == False
+            if allow_colorbar and (
+                plot_type == "DEM"
+                or plot_type == "Drape1"
+                or (plot_type == "Drape2" and not add_double_colorbar)
+            ):
+
+                cb_or = cbar_or
+                cb_ticks_position = cbar_ticks_position
+
+                axins1 = inset_axes(
+                    ax1,
+                    width=cbar_width,  # width = 50% of parent_bbox width
+                    height=cbar_height,  # height : 5%
+                    loc=cbar_loc,
+                    bbox_transform=ax1.transAxes,
+                    borderpad=0,
+                    bbox_to_anchor=bbox_to_anchor,
+                )
+
+                maxV = kwds["vmax"]
+                minV = kwds["vmin"]
+                cb_length = maxV - minV
+                if maxV <= 10:
+                    cb = plt.colorbar(
+                        ima,
+                        ax=ax1,
+                        cax=axins1,
+                        orientation=cb_or,
+                        ticks=[
+                            np.round(minV + 0.2 * cb_length, 1),
+                            np.round(minV + 0.8 * cb_length, 1),
+                        ],
+                    )
+                elif maxV <= 100:
+                    cb = plt.colorbar(
+                        ima,
+                        ax=ax1,
+                        cax=axins1,
+                        orientation=cb_or,
+                        ticks=[
+                            np.round(minV + 0.2 * cb_length, 0),
+                            np.round(minV + 0.8 * cb_length, 0),
+                        ],
+                    )
+                else:
+                    cb = plt.colorbar(
+                        ima,
+                        ax=ax1,
+                        cax=axins1,
+                        orientation=cb_or,
+                        ticks=[
+                            np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
+                            np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
+                        ],
+                    )
+                axins1.xaxis.set_ticks_position(cb_ticks_position)
+                cb.ax.tick_params(
+                    labelsize=cbar_tick_size,
+                    color=cbar_tick_color,
+                    labelcolor=cbar_tick_color,
+                )
+
+                # if colorbar_label:
+                #     cb.set_label(colorbar_label, rotation=270)
+                #     # ax1.xaxis.set_label_coords(0,2.5)
+
+            if plot_type == "Drape2":
+
+                # Process values from first drape
+
+                if isinstance(drape2, str):
+                    values_at_node_drape2 = grid.at_node[drape2]
+                else:
+                    values_at_node_drape2 = drape2.reshape((-1,))
+
+                if values_at_node_drape2.size != grid.number_of_nodes:
+                    raise ValueError("number of values does not match number of nodes")
+
+                values_at_node_drape2 = np.ma.masked_where(
+                    grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node_drape2
+                )
+
+                # Add mask if thres_drape1 is given
+                if thres_drape2 is not None:
+                    values_at_node_drape2 = np.ma.masked_where(
+                        values_at_node_drape2 < thres_drape2, values_at_node_drape2
+                    )
+
+                if isinstance(grid, RasterModelGrid):
+                    shape = grid.shape
+                else:
+                    shape = (-1,)
+                val2 = values_at_node_drape2.reshape(shape)
+
+                if cmap2 is None:
+                    cmap2 = plt.cm.terrain
+                kwds = dict(cmap=cmap2)
+                (kwds["vmin"], kwds["vmax"]) = (val2.min(), val2.max())
+                if (limits is None) and ((vmin is None) and (vmax is None)):
+                    if symmetric_cbar:
+                        (var_min, var_max) = (val2.min(), val2.max())
+                        limit = max(abs(var_min), abs(var_max))
+                        (kwds["vmin"], kwds["vmax"]) = (-limit, limit)
+                elif limits is not None:
+                    (kwds["vmin"], kwds["vmax"]) = (limits[0], limits[1])
+                else:
+                    if vmin is not None:
+                        kwds["vmin"] = vmin
+                    if vmax is not None:
+                        kwds["vmax"] = vmax
+
+                ima2 = ax1.imshow(val2, extent=extent, alpha=alpha2, **kwds)
+                ax1.invert_yaxis()
+
+                # Add colorbars
+                if add_double_colorbar:
+                    axins1 = inset_axes(
+                        ax1,
+                        width=cbar_width,  # width = 50% of parent_bbox width
+                        height=cbar_height,  # height : 5%
+                        loc=cbar_loc,
+                        bbox_to_anchor=(-0.005, 0.25, 1, 1),
+                        bbox_transform=ax1.transAxes,
+                        borderpad=0,
+                    )
+
+                    cb_or = cbar_or
+                    cb_ticks_position = cbar_ticks_position
+                    maxV = np.max(val1)
+                    minV = np.min(val1)
+                    cb_length = maxV - minV
+                    if maxV <= 10:
+                        cb = plt.colorbar(
+                            ima,
+                            ax=ax1,
+                            cax=axins1,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(minV + 0.2 * cb_length, 1),
+                                np.round(minV + 0.8 * cb_length, 1),
+                            ],
+                        )
+                    elif maxV <= 100:
+                        cb = plt.colorbar(
+                            ima,
+                            ax=ax1,
+                            cax=axins1,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(minV + 0.2 * cb_length, 0),
+                                np.round(minV + 0.8 * cb_length, 0),
+                            ],
+                        )
+                    else:
+                        cb = plt.colorbar(
+                            ima,
+                            ax=ax1,
+                            cax=axins1,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
+                                np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
+                            ],
+                        )
+                    cb.ax.tick_params(
+                        labelsize=cbar_tick_size,
+                        color=cbar_tick_color,
+                        labelcolor=cbar_tick_color,
+                    )
+                    axins1.xaxis.set_ticks_position(cb_ticks_position)
+
+                    axins1.set_xlabel(
+                        var_name,
+                        usetex=True,
+                        fontsize=default_fontsize,
+                        rotation=0,
+                        color=cbar_label_color,
+                        fontweight=cbar_label_fontweight,
+                        bbox=bbox_prop,
+                    )
+                    axins1.xaxis.set_label_coords(0.5, y_label_offSet_var_1)
+
+                    axins2 = inset_axes(
+                        ax1,
+                        width=cbar_width,  # width = 50% of parent_bbox width
+                        height=cbar_height,  # height : 5%
+                        loc=cbar_loc,
+                        bbox_to_anchor=(-0.005, 0.15, 1, 1),
+                        bbox_transform=ax1.transAxes,
+                        borderpad=0,
+                    )
+                    cb_or = cbar_or
+                    cb_ticks_position = cbar_ticks_position2
+                    maxV = np.max(val2)
+                    minV = np.min(val2)
+                    cb_length = maxV - minV
+                    if maxV <= 10:
+                        cb = plt.colorbar(
+                            ima2,
+                            ax=ax1,
+                            cax=axins2,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(minV + 0.2 * cb_length, 1),
+                                np.round(minV + 0.8 * cb_length, 1),
+                            ],
+                        )
+                    elif maxV <= 100:
+                        cb = plt.colorbar(
+                            ima2,
+                            ax=ax1,
+                            cax=axins2,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(minV + 0.2 * cb_length, 0),
+                                np.round(minV + 0.8 * cb_length, 0),
+                            ],
+                        )
+                    else:
+                        cb = plt.colorbar(
+                            ima2,
+                            ax=ax1,
+                            cax=axins2,
+                            orientation=cb_or,
+                            ticks=[
+                                np.round(0.1 * (minV + 0.2 * cb_length)) * 10,
+                                np.round(0.1 * (minV + 0.8 * cb_length)) * 10,
+                            ],
+                        )
+                    cb.ax.tick_params(
+                        labelsize=cbar_tick_size,
+                        color=cbar_tick_color,
+                        labelcolor=cbar_tick_color,
+                    )
+
+                    axins2.xaxis.set_ticks_position(cb_ticks_position)
+                    axins2.set_xlabel(
+                        var_name_two,
+                        usetex=True,
+                        fontsize=default_fontsize,
+                        rotation=0,
+                        color=cbar_label_color,
+                        fontweight=cbar_label_fontweight,
+                        bbox=bbox_prop,
+                    )
+                    axins2.xaxis.set_label_coords(0.5, y_label_offSet_var_2)
+
+    if grid_units[1] is None and grid_units[0] is None:
+        grid_units = grid.axis_units
+        if grid_units[1] == "-" and grid_units[0] == "-":
+            ax1.set_xlabel(
+                "Easting", fontweight=fontweight_xlabel, fontsize=default_fontsize
+            )
+            ax1.set_ylabel(
+                "Northing", fontweight=fontweight_ylabel, fontsize=default_fontsize
+            )
+        else:
+            ax1.set_xlabel(
+                "Easting, %s" % grid_units[1],
+                fontweight=fontweight_xlabel,
+                fontsize=default_fontsize,
+            )
+            ax1.set_ylabel(
+                "Northing, %s" % grid_units[1],
+                fontweight=fontweight_ylabel,
+                fontsize=default_fontsize,
+            )
+    else:
+        ax1.set_xlabel(
+            "Easting, %s" % grid_units[1],
+            fontweight=fontweight_xlabel,
+            fontsize=default_fontsize,
+        )
+        ax1.set_ylabel(
+            "Northing, %s" % grid_units[1],
+            fontweight=fontweight_ylabel,
+            fontsize=default_fontsize,
+        )
+
+    if plot_name is not None:
+        plt.title("%s" % (plot_name))
+
+    if (
+        somethingToPlot
+        and (var_name is not None or var_units is not None)
+        and plot_type != "Drape2"
+    ):
+        if var_name is not None:
+            assert type(var_name) is str
+            if var_units is not None:
+                assert type(var_units) is str
+                colorbar_label = var_name + " (" + var_units + ")"
+            else:
+                colorbar_label = var_name
+        else:
+            assert type(var_units) is str
+            colorbar_label = "(" + var_units + ")"
+        assert type(colorbar_label) is str
+        if allow_colorbar:
+            cb.set_label(
+                colorbar_label,
+                fontsize=default_fontsize,
+                labelpad=colorbar_label_y,
+                color=cbar_label_color,
+                x=colorbar_label_x,
+                fontweight=cbar_label_fontweight,
+                bbox=bbox_prop,
+            )
+
+    if color_for_background is not None:
+        plt.gca().set_facecolor(color_for_background)
+
+    if output is not None:
+        if type(output) is str:
+            plt.savefig(output)
+            plt.clf()
+        elif output:
+            plt.show()
+
+    return ax1

--- a/landlab/plot/imshowhs.py
+++ b/landlab/plot/imshowhs.py
@@ -13,7 +13,6 @@ import numpy as np
 from matplotlib.colors import LightSource
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
-from ..grid.raster import RasterModelGrid
 from .event_handler import query_grid_on_button_press
 
 
@@ -354,14 +353,7 @@ def imshowhs_grid_at_node(grid, values, **kwds):
         grid.status_at_node == grid.BC_NODE_IS_CLOSED, values_at_node
     )
 
-    if isinstance(grid, RasterModelGrid):
-        shape = grid.shape
-    else:
-        raise NotImplementedError(
-            "For now, only RasterModelGrids are supported in the imshowhs functions"
-        )
-
-    ax = _imshowhs_grid_values(grid, values_at_node.reshape(shape), **kwds)
+    ax = _imshowhs_grid_values(grid, values_at_node, **kwds)
 
     if isinstance(values, str):
         plt.title(values)
@@ -427,6 +419,13 @@ def _imshowhs_grid_values(
     y_label_offSet_var_1=3,
     y_label_offSet_var_2=-1.25,
 ):
+    from ..grid.raster import RasterModelGrid
+
+    if not isinstance(grid, RasterModelGrid):
+        raise NotImplementedError(
+            "For now, only RasterModelGrids are supported in the imshowhs functions"
+        )
+
     plot_type_options = ["DEM", "Hillshade", "Drape1", "Drape2"]
     if plot_type not in plot_type_options:
         raise ValueError(
@@ -458,6 +457,8 @@ def _imshowhs_grid_values(
         cmap.set_bad(color=color_for_closed)
     else:
         cmap.set_bad(alpha=0.0)
+
+    values.shape = grid.shape
 
     if isinstance(grid, RasterModelGrid):
         # somethingToPlot is a flag indicating if any pixels should be plotted.

--- a/news/1424.feature
+++ b/news/1424.feature
@@ -1,0 +1,3 @@
+Added the ``at`` keyword to the ``imshow_grid`` functions so that they now
+use the same pattern as many other *landlab* functions.
+

--- a/news/1430.feature
+++ b/news/1430.feature
@@ -1,0 +1,3 @@
+Added an ``imshow`` method to all *landlab* model grids that is a wrapper for
+the ``imshow_grid`` function.
+

--- a/notebooks/tutorials/boundary_conds/set_BCs_from_xy.ipynb
+++ b/notebooks/tutorials/boundary_conds/set_BCs_from_xy.ipynb
@@ -28,7 +28,6 @@
    "source": [
     "from landlab import RasterModelGrid\n",
     "import numpy as np\n",
-    "from landlab.plot.imshow import imshow_grid_at_node\n",
     "from matplotlib.pyplot import show\n",
     "\n",
     "%matplotlib inline"
@@ -118,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid_at_node(mg, z)"
+    "mg.imshow(z, at=\"node\")"
    ]
   },
   {
@@ -131,7 +130,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -145,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/boundary_conds/set_BCs_on_raster_perimeter.ipynb
+++ b/notebooks/tutorials/boundary_conds/set_BCs_on_raster_perimeter.ipynb
@@ -27,10 +27,7 @@
    "outputs": [],
    "source": [
     "from landlab import RasterModelGrid\n",
-    "from landlab.plot.imshow import imshow_grid\n",
-    "import numpy as np\n",
-    "\n",
-    "%matplotlib inline"
+    "import numpy as np"
    ]
   },
   {
@@ -90,7 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, mg.status_at_node)"
+    "mg.imshow(mg.status_at_node)"
    ]
   },
   {
@@ -99,7 +96,7 @@
    "source": [
     "Now let's choose one node on the perimeter to be closed.  \n",
     "\n",
-    "Note that `imshow_grid` by default does not illustrate values for closed nodes, so we override that below and show them in blue."
+    "Note that `imshow` by default does not illustrate values for closed nodes, so we override that below and show them in blue."
    ]
   },
   {
@@ -109,7 +106,7 @@
    "outputs": [],
    "source": [
     "mg.status_at_node[2] = mg.BC_NODE_IS_CLOSED\n",
-    "imshow_grid(mg, mg.status_at_node, color_for_closed=\"blue\")"
+    "mg.imshow(mg.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -141,7 +138,7 @@
     ")\n",
     "# the same thing could be done as ...\n",
     "# mg.set_status_at_node_on_edges(right=4, top=1, left=4, bottom=1)\n",
-    "imshow_grid(mg, mg.status_at_node, color_for_closed=\"blue\")"
+    "mg.imshow(mg.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -166,7 +163,7 @@
    "source": [
     "mg1 = RasterModelGrid((4, 4), 1.0)\n",
     "mg1.set_closed_boundaries_at_grid_edges(True, False, True, False)\n",
-    "imshow_grid(mg1, mg1.status_at_node, color_for_closed=\"blue\")"
+    "mg1.imshow(mg1.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -188,7 +185,7 @@
    "source": [
     "mg2 = RasterModelGrid((4, 4), 1.0)\n",
     "mg2.set_looped_boundaries(True, False)\n",
-    "imshow_grid(mg2, mg2.status_at_node)"
+    "mg2.imshow(mg2.status_at_node)"
    ]
   },
   {
@@ -207,7 +204,7 @@
    "outputs": [],
    "source": [
     "mg2.set_closed_boundaries_at_grid_edges(True, False, True, False)\n",
-    "imshow_grid(mg2, mg2.status_at_node, color_for_closed=\"Blue\")"
+    "mg2.imshow(mg2.status_at_node, color_for_closed=\"Blue\")"
    ]
   },
   {
@@ -229,7 +226,7 @@
     "mg3 = RasterModelGrid((4, 4), 1.0)\n",
     "mg3.status_at_node[mg3.y_of_node == 0] = mg.BC_NODE_IS_FIXED_GRADIENT\n",
     "mg3.status_at_node[mg3.y_of_node == 3] = mg.BC_NODE_IS_FIXED_GRADIENT\n",
-    "imshow_grid(mg3, mg3.status_at_node, color_for_closed=\"Blue\")\n",
+    "mg3.imshow(mg3.status_at_node, color_for_closed=\"Blue\")\n",
     "# there are no closed boundaries so we didn't need the color_for_closed option,\n",
     "# but no problem if you accidentally include it!"
    ]
@@ -244,7 +241,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -258,7 +255,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/boundary_conds/set_BCs_on_voronoi.ipynb
+++ b/notebooks/tutorials/boundary_conds/set_BCs_on_voronoi.ipynb
@@ -27,10 +27,7 @@
    "outputs": [],
    "source": [
     "from landlab import VoronoiDelaunayGrid\n",
-    "from landlab.plot.imshow import imshow_grid\n",
-    "import numpy as np\n",
-    "\n",
-    "%matplotlib inline"
+    "import numpy as np"
    ]
   },
   {
@@ -92,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(vg, vg.status_at_node, cmap=\"cool\", show_elements=True)"
+    "vg.imshow(vg.status_at_node, cmap=\"cool\", show_elements=True)"
    ]
   },
   {
@@ -113,8 +110,7 @@
     "vg.status_at_node[\n",
     "    vg.status_at_node == vg.BC_NODE_IS_FIXED_GRADIENT\n",
     "] = vg.BC_NODE_IS_CLOSED\n",
-    "imshow_grid(\n",
-    "    vg,\n",
+    "vg.imshow(\n",
     "    vg.status_at_node,\n",
     "    cmap=\"cool\",\n",
     "    limits=(-0.01, 4),\n",
@@ -159,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(vg2, vg2.at_node[\"topographic__elevation\"], cmap=\"cool\", show_elements=True)\n",
+    "vg2.imshow(vg2.at_node[\"topographic__elevation\"], cmap=\"cool\", show_elements=True)\n",
     "vg2.at_node[\"topographic__elevation\"]"
    ]
   },
@@ -167,7 +163,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can illustrate the grid and see at least some of the closed elements by using the imshow_grid option color_for_closed.  Again remember that some of the nodes that are plotting in white areas are closed as well - that is, the ones that have an x value less than 0.5 are closed."
+    "Now we can illustrate the grid and see at least some of the closed elements by using the `imshow` option color_for_closed.  Again remember that some of the nodes that are plotting in white areas are closed as well - that is, the ones that have an x value less than 0.5 are closed."
    ]
   },
   {
@@ -177,8 +173,7 @@
    "outputs": [],
    "source": [
     "vg2.set_nodata_nodes_to_closed(vg2.at_node[\"topographic__elevation\"], -1.0)\n",
-    "imshow_grid(\n",
-    "    vg2,\n",
+    "vg2.imshow(\n",
     "    vg2.status_at_node,\n",
     "    color_for_closed=\"red\",\n",
     "    cmap=\"cool\",\n",
@@ -205,7 +200,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -219,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/boundary_conds/set_watershed_BCs_raster.ipynb
+++ b/notebooks/tutorials/boundary_conds/set_watershed_BCs_raster.ipynb
@@ -35,10 +35,7 @@
    "outputs": [],
    "source": [
     "from landlab import RasterModelGrid\n",
-    "import numpy as np\n",
-    "from landlab.plot.imshow import imshow_grid\n",
-    "\n",
-    "%matplotlib inline"
+    "import numpy as np"
    ]
   },
   {
@@ -88,7 +85,7 @@
    "metadata": {},
    "source": [
     "- Check to see that node status were set correctly.\n",
-    "- imshow_grid will default to not plot the value of BC_NODE_IS_CLOSED nodes, which is why we override this below with the option color_for_closed"
+    "- `imshow` will default to not plot the value of BC_NODE_IS_CLOSED nodes, which is why we override this below with the option color_for_closed"
    ]
   },
   {
@@ -97,7 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg1, mg1.status_at_node, color_for_closed=\"blue\")"
+    "mg1.imshow(mg1.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -152,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg2, mg2.status_at_node, color_for_closed=\"blue\")"
+    "mg2.imshow(mg2.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -206,7 +203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg3, mg3.status_at_node, color_for_closed=\"blue\")"
+    "mg3.imshow(mg3.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -243,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(grid_bijou, z_bijou)"
+    "grid_bijou.imshow(z_bijou)"
    ]
   },
   {
@@ -276,7 +273,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(grid_bijou, grid_bijou.status_at_node, color_for_closed=\"blue\")"
+    "grid_bijou.imshow(grid_bijou.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -285,7 +282,7 @@
    "source": [
     "- This looks sensible.\n",
     "- Now that the boundary conditions ae set, we can also look at the topography. \n",
-    "- imshow_grid will default to show boundaries as black, as illustrated below.  But that can be overwridden as we have been doing all along."
+    "- `imshow` will default to show boundaries as black, as illustrated below.  But that can be overwridden as we have been doing all along."
    ]
   },
   {
@@ -294,13 +291,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(grid_bijou, z_bijou)"
+    "grid_bijou.imshow(z_bijou)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -314,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/ecohydrology/cellular_automaton_vegetation_DEM/cellular_automaton_vegetation_DEM.ipynb
+++ b/notebooks/tutorials/ecohydrology/cellular_automaton_vegetation_DEM/cellular_automaton_vegetation_DEM.ipynb
@@ -205,7 +205,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from landlab.plot import imshow_grid\n",
     "import matplotlib as mpl\n",
     "\n",
     "cmap = mpl.colors.ListedColormap([\"green\", \"red\", \"black\", \"white\", \"red\", \"black\"])\n",
@@ -213,10 +212,9 @@
     "norm = mpl.colors.BoundaryNorm(bounds, cmap.N)\n",
     "description = \"green: grass; red: shrub; black: tree; white: bare\"\n",
     "plt.figure(101)\n",
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"vegetation__plant_functional_type\",\n",
-    "    values_at=\"cell\",\n",
+    "    at=\"cell\",\n",
     "    cmap=cmap,\n",
     "    grid_units=(\"m\", \"m\"),\n",
     "    norm=norm,\n",
@@ -491,7 +489,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -505,7 +503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/ecohydrology/cellular_automaton_vegetation_flat_surface/cellular_automaton_vegetation_flat_domain.ipynb
+++ b/notebooks/tutorials/ecohydrology/cellular_automaton_vegetation_flat_surface/cellular_automaton_vegetation_flat_domain.ipynb
@@ -215,7 +215,6 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
-    "from landlab.plot import imshow_grid\n",
     "import matplotlib as mpl\n",
     "\n",
     "cmap = mpl.colors.ListedColormap([\"green\", \"red\", \"black\", \"white\", \"red\", \"black\"])\n",
@@ -223,10 +222,9 @@
     "norm = mpl.colors.BoundaryNorm(bounds, cmap.N)\n",
     "description = \"green: grass; red: shrub; black: tree; white: bare\"\n",
     "plt.figure(101)\n",
-    "imshow_grid(\n",
-    "    grid1,\n",
+    "grid1.imshow(\n",
     "    \"vegetation__plant_functional_type\",\n",
-    "    values_at=\"cell\",\n",
+    "    at=\"cell\",\n",
     "    cmap=cmap,\n",
     "    grid_units=(\"m\", \"m\"),\n",
     "    norm=norm,\n",
@@ -494,7 +492,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -508,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/flexure/lots_of_loads.ipynb
+++ b/notebooks/tutorials/flexure/lots_of_loads.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "We are going to build a uniform rectilinear grid with a node spacing of 10 km in the *y*-direction and 20 km in the *x*-direction on which we will solve the flexure equation.\n",
     "\n",
-    "First we need to import `RasterModelGrid`.  We also import the Landlab plotting function `imshow_grid` to view the grids."
+    "First we need to import `RasterModelGrid`."
    ]
   },
   {
@@ -58,8 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from landlab import RasterModelGrid\n",
-    "from landlab.plot.imshow import imshow_grid"
+    "from landlab import RasterModelGrid"
    ]
   },
   {
@@ -224,8 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"lithosphere__overlying_pressure_increment\",\n",
     "    symmetric_cbar=True,\n",
     "    cmap=\"nipy_spectral\",\n",
@@ -267,7 +265,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now plot these deflections with the `imshow_grid` method, which is available to all landlab components."
+    "We now plot these deflections with the `imshow` method, which is available to all landlab components."
    ]
   },
   {
@@ -278,8 +276,7 @@
    },
    "outputs": [],
    "source": [
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"lithosphere_surface__elevation_increment\",\n",
     "    symmetric_cbar=True,\n",
     "    cmap=\"nipy_spectral\",\n",
@@ -301,8 +298,7 @@
    "source": [
     "flex.eet *= 2.0\n",
     "flex.update()\n",
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"lithosphere_surface__elevation_increment\",\n",
     "    symmetric_cbar=True,\n",
     "    cmap=\"nipy_spectral\",\n",
@@ -325,8 +321,7 @@
     "load[np.where(np.logical_and(grid.node_x > 3000000, grid.node_x < 5000000))] = (\n",
     "    load[np.where(np.logical_and(grid.node_x > 3000000, grid.node_x < 5000000))] + 1e7\n",
     ")\n",
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"lithosphere__overlying_pressure_increment\",\n",
     "    symmetric_cbar=True,\n",
     "    cmap=\"nipy_spectral\",\n",
@@ -340,8 +335,7 @@
    "outputs": [],
    "source": [
     "flex.update()\n",
-    "imshow_grid(\n",
-    "    grid,\n",
+    "grid.imshow(\n",
     "    \"lithosphere_surface__elevation_increment\",\n",
     "    symmetric_cbar=True,\n",
     "    cmap=\"nipy_spectral\",\n",
@@ -365,7 +359,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -379,7 +373,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/lithology/lithology_and_litholayers.ipynb
+++ b/notebooks/tutorials/lithology/lithology_and_litholayers.ipynb
@@ -59,8 +59,7 @@
     "    LinearDiffuser,\n",
     "    Lithology,\n",
     "    LithoLayers,\n",
-    ")\n",
-    "from landlab.plot import imshow_grid"
+    ")"
    ]
   },
   {
@@ -192,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "LithoLayers will make sure that the model grid has at-node grid fields with the layer attribute names. In this case, this means that the model grid will now include a grid field called `'K_sp'` and a field called `'rock_type__id'`. We can plot these with the Landlab [imshow_grid](http://landlab.readthedocs.io/en/release/landlab.plot.html#landlab.plot.imshow.imshow_grid) function. "
+    "LithoLayers will make sure that the model grid has at-node grid fields with the layer attribute names. In this case, this means that the model grid will now include a grid field called `'K_sp'` and a field called `'rock_type__id'`. We can plot these with the Landlab [imshow](http://landlab.readthedocs.io/en/release/landlab.plot.html#landlab.plot.imshow.imshow_grid) function. "
    ]
   },
   {
@@ -201,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, \"rock_type__id\", cmap=\"viridis\")"
+    "mg.imshow(\"rock_type__id\", cmap=\"viridis\")"
    ]
   },
   {
@@ -240,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, \"rock_type__id\", cmap=\"viridis\")"
+    "mg.imshow(\"rock_type__id\", cmap=\"viridis\")"
    ]
   },
   {
@@ -280,7 +279,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, \"rock_type__id\", cmap=\"viridis\", vmin=0, vmax=3)"
+    "mg.imshow(\"rock_type__id\", cmap=\"viridis\", vmin=0, vmax=3)"
    ]
   },
   {
@@ -307,7 +306,7 @@
     "lith.rock_id = spatially_variable_rock_id\n",
     "\n",
     "lith.run_one_step()\n",
-    "imshow_grid(mg, \"rock_type__id\", cmap=\"viridis\", vmin=0, vmax=3)"
+    "mg.imshow(\"rock_type__id\", cmap=\"viridis\", vmin=0, vmax=3)"
    ]
   },
   {
@@ -558,7 +557,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, \"K_sp\")"
+    "mg.imshow(\"K_sp\")"
    ]
   },
   {
@@ -722,7 +721,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg, \"topographic__elevation\", cmap=\"viridis\")"
+    "mg.imshow(\"topographic__elevation\", cmap=\"viridis\")"
    ]
   },
   {
@@ -884,7 +883,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(mg2, \"topographic__elevation\", cmap=\"viridis\")"
+    "mg2.imshow(\"topographic__elevation\", cmap=\"viridis\")"
    ]
   },
   {
@@ -916,7 +915,7 @@
     "lith2.rock_id = 1\n",
     "lith2.run_one_step()\n",
     "\n",
-    "imshow_grid(mg2, volcanic_deposits)"
+    "mg2.imshow(volcanic_deposits)"
    ]
   },
   {
@@ -962,7 +961,7 @@
    },
    "outputs": [],
    "source": [
-    "imshow_grid(mg2, \"topographic__elevation\", cmap=\"viridis\")"
+    "mg2.imshow(\"topographic__elevation\", cmap=\"viridis\")"
    ]
   },
   {
@@ -1022,7 +1021,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1036,7 +1035,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/marine_sediment_transport/simple_submarine_diffuser_tutorial.ipynb
+++ b/notebooks/tutorials/marine_sediment_transport/simple_submarine_diffuser_tutorial.ipynb
@@ -81,6 +81,7 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "from landlab import RasterModelGrid\n",
     "from landlab.components import SimpleSubmarineDiffuser"
    ]
   },

--- a/notebooks/tutorials/marine_sediment_transport/simple_submarine_diffuser_tutorial.ipynb
+++ b/notebooks/tutorials/marine_sediment_transport/simple_submarine_diffuser_tutorial.ipynb
@@ -81,7 +81,6 @@
    "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "from landlab import RasterModelGrid, imshow_grid\n",
     "from landlab.components import SimpleSubmarineDiffuser"
    ]
   },
@@ -214,7 +213,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(grid, z, cmap=\"coolwarm\", vmin=-10)"
+    "grid.imshow(z, cmap=\"coolwarm\", vmin=-10)"
    ]
   },
   {
@@ -259,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(grid, z, cmap=\"coolwarm\", vmin=-10)"
+    "grid.imshow(z, cmap=\"coolwarm\", vmin=-10)"
    ]
   },
   {
@@ -282,7 +281,7 @@
    "outputs": [],
    "source": [
     "# Show the donut-shaped deposit and associated erosion pattern\n",
-    "imshow_grid(grid, cum_depo)\n",
+    "grid.imshow(cum_depo)\n",
     "\n",
     "# And show that mass balances (the sum is basically zero, apart\n",
     "# from a tiny roundoff error)\n",
@@ -299,7 +298,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -313,7 +312,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/plotting/landlab-plotting.ipynb
+++ b/notebooks/tutorials/plotting/landlab-plotting.ipynb
@@ -45,7 +45,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From Landlab, we'll need a grid on which to plot data, and a plotting function. We'll start with just `imshow_grid`, but be aware that similar but more specifically named functions like `imshow_grid_at_node` are also available. These all wrap the same basic Landlab functionality, so we're taking the most general method. "
+    "From Landlab, we'll need a grid on which to plot data, and a plotting function. We'll start with just `imshow_grid`, but be aware that similar but more specifically named functions like `imshow_grid_at_node` are also available. These all wrap the same basic Landlab functionality, so we're taking the most general method.\n",
+    "\n",
+    "Note that you can use `imshow_grid` as a function or as a method of any *landlab* grid. For example, the following two usages can be used interchangably,\n",
+    "```python\n",
+    ">>> grid.imshow(values)\n",
+    "```\n",
+    "```python\n",
+    ">>> imshow_grid(grid, values)\n",
+    "```"
    ]
   },
   {
@@ -70,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib.pyplot import title, show, figure, plot, subplot, xlabel, ylabel"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -84,9 +92,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `imshow_grid` plotter is Landlab's primary function for plotting data distributed across the grid. It's pretty powerful, and comes with a fairly extensive suite of options to control the appearance of your output. You can see the full list of options in the `imshow_grid` documentation.\n",
+    "The `imshow` plotter method is Landlab's primary function for plotting data distributed across the grid. It's pretty powerful, and comes with a fairly extensive suite of options to control the appearance of your output. You can see the full list of options in the `imshow_grid` documentation.\n",
     "\n",
-    "However, most simply, it just takes `imshow_grid(grid, data)`. Data can be either a field name string, or an array of the data itself."
+    "However, most simply, it just takes `grid.imshow(data)`. Data can be either a field name string, or an array of the data itself."
    ]
   },
   {
@@ -97,8 +105,8 @@
    "source": [
     "%matplotlib inline\n",
     "rmg = RasterModelGrid((50, 50), 1.0)\n",
-    "imshow_grid(rmg, rmg.x_of_node)  # plot the x distances at nodes\n",
-    "show()"
+    "rmg.imshow(rmg.x_of_node)  # plot the x distances at nodes\n",
+    "plt.show()"
    ]
   },
   {
@@ -118,10 +126,10 @@
    "source": [
     "rmg.axis_units = (\"km\", \"km\")\n",
     "_ = rmg.add_field(\n",
-    "    \"myfield\", (rmg.x_of_node ** 2 + rmg.y_of_node ** 2) ** 0.5, at=\"node\", clobber=True\n",
+    "    \"myfield\", (rmg.x_of_node**2 + rmg.y_of_node**2) ** 0.5, at=\"node\", clobber=True\n",
     ")\n",
-    "imshow_grid(rmg, \"myfield\", cmap=\"bone\")\n",
-    "show()"
+    "rmg.imshow(\"myfield\", cmap=\"bone\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -138,20 +146,20 @@
    "outputs": [],
    "source": [
     "radmg = RadialModelGrid(n_rings=10, spacing=10.0)\n",
-    "subplot(121)\n",
-    "imshow_grid(rmg, rmg.y_of_node, allow_colorbar=False, plot_name=\"regular grid\")\n",
-    "subplot(122)\n",
-    "imshow_grid(radmg, radmg.x_of_node, allow_colorbar=False, plot_name=\"irregular grid\")\n",
-    "show()"
+    "plt.subplot(121)\n",
+    "rmg.imshow(rmg.y_of_node, allow_colorbar=False, plot_name=\"regular grid\")\n",
+    "plt.subplot(122)\n",
+    "radmg.imshow(radmg.x_of_node, allow_colorbar=False, plot_name=\"irregular grid\")\n",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's look at some of the other more advanced options `imshow_grid` can provide.\n",
+    "Now, let's look at some of the other more advanced options `imshow` can provide.\n",
     "\n",
-    "`ishow_grid` offers plenty of keyword options for modifying the colorbar, including `var_name`, `var_units`, `symmetric_cbar`, `vmin`, `vmax`, and `shrink`. We've already seen `allow_colorbar`, which lets you suppress the bar entirely. Let's see some in action."
+    "`imshow` offers plenty of keyword options for modifying the colorbar, including `var_name`, `var_units`, `symmetric_cbar`, `vmin`, `vmax`, and `shrink`. We've already seen `allow_colorbar`, which lets you suppress the bar entirely. Let's see some in action."
    ]
   },
   {
@@ -160,11 +168,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "radz = (radmg.x_of_node ** 2 + radmg.y_of_node ** 2) ** 0.5\n",
+    "radz = (radmg.x_of_node**2 + radmg.y_of_node**2) ** 0.5\n",
     "radz = radz.max() - radz - 0.75 * radz.mean()\n",
     "# let's plot these elevations truncated at radz >= 0\n",
-    "imshow_grid(\n",
-    "    radmg,\n",
+    "radmg.imshow(\n",
     "    radz,\n",
     "    grid_units=(\"m\", \"m\"),\n",
     "    vmin=0.0,\n",
@@ -172,7 +179,7 @@
     "    var_name=\"radz\",\n",
     "    var_units=\"no units\",\n",
     ")\n",
-    "show()"
+    "plt.show()"
    ]
   },
   {
@@ -188,8 +195,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imshow_grid(radmg, radmg.y_of_node, color_for_background=\"0.3\")\n",
-    "show()"
+    "radmg.imshow(radmg.y_of_node, color_for_background=\"0.3\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -208,7 +215,7 @@
     "rmg2 = RasterModelGrid((50, 50), (1.0, 2.0))\n",
     "myvals = ((rmg2.x_of_node - 50.0) ** 2 + (rmg2.y_of_node - 25.0) ** 2) ** 0.5\n",
     "rmg2.status_at_node[myvals > 30.0] = rmg2.BC_NODE_IS_CLOSED\n",
-    "imshow_grid(rmg2, myvals, color_for_closed=\"blue\", shrink=0.6)"
+    "rmg2.imshow(myvals, color_for_closed=\"blue\", shrink=0.6)"
    ]
   },
   {
@@ -228,9 +235,9 @@
     "mymask_2ndcondition = np.logical_or(rmg.y_of_node < 15, rmg.y_of_node > 35)\n",
     "mymask = np.logical_or(mymask_1stcondition, mymask_2ndcondition)\n",
     "overlay_data = np.ma.array(rmg.y_of_node, mask=mymask, copy=False)\n",
-    "imshow_grid(rmg, rmg.x_of_node)\n",
-    "imshow_grid(rmg, overlay_data, color_for_closed=None, cmap=\"winter\")\n",
-    "show()"
+    "rmg.imshow(rmg.x_of_node)\n",
+    "rmg.imshow(overlay_data, color_for_closed=None, cmap=\"winter\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -259,16 +266,16 @@
     "# will be added to the component library.\n",
     "\n",
     "mg = RasterModelGrid((30, 30))\n",
-    "z = (mg.x_of_node ** 2 + mg.y_of_node ** 2) ** 0.5\n",
+    "z = (mg.x_of_node**2 + mg.y_of_node**2) ** 0.5\n",
     "z = z.max() - z\n",
     "z_raster = z.reshape(mg.shape)\n",
     "x_raster = mg.x_of_node.reshape(mg.shape)\n",
     "for i in range(0, 30, 5):\n",
-    "    plot(x_raster[i, :], z_raster[i, :])\n",
-    "title(\"east-west cross sections though z\")\n",
-    "xlabel(\"x (m)\")\n",
-    "ylabel(\"z (m)\")\n",
-    "show()"
+    "    plt.plot(x_raster[i, :], z_raster[i, :])\n",
+    "plt.title(\"east-west cross sections though z\")\n",
+    "plt.xlabel(\"x (m)\")\n",
+    "plt.ylabel(\"z (m)\")\n",
+    "plt.show()"
    ]
   },
   {
@@ -307,13 +314,13 @@
     ")\n",
     "prf.run_one_step()\n",
     "\n",
-    "figure(1)\n",
+    "plt.figure(1)\n",
     "prf.plot_profiles()\n",
-    "show()\n",
+    "plt.show()\n",
     "\n",
-    "figure(1)\n",
+    "plt.figure(1)\n",
     "prf.plot_profiles_in_map_view()\n",
-    "show()"
+    "plt.show()"
    ]
   },
   {
@@ -326,7 +333,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -340,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/tutorials/reading_dem_into_landlab/reading_dem_into_landlab.ipynb
+++ b/notebooks/tutorials/reading_dem_into_landlab/reading_dem_into_landlab.ipynb
@@ -92,17 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from landlab.plot.imshow import imshow_grid"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%matplotlib inline\n",
-    "imshow_grid(mg, \"topographic__elevation\")"
+    "mg.imshow(\"topographic__elevation\")"
    ]
   },
   {
@@ -111,7 +101,7 @@
    "source": [
     "This plot illustrates the shape of the watershed, but we can't see the topography because the nodata values have a value of zero, which skews the colormap.  We can change the range of the colormap but first we need to figure out what the range of data values are. \n",
     "\n",
-    "(Note: uncomment the commented line below if you want to see all the options available in imshow_grid)"
+    "(Note: uncomment the commented line below if you want to see all the options available in ``imshow``)"
    ]
   },
   {
@@ -124,8 +114,8 @@
     "\n",
     "min_z = np.min(z[np.where(z > 0)])\n",
     "max_z = np.max(z[np.where(z > 0)])\n",
-    "# help(imshow_grid)\n",
-    "imshow_grid(mg, \"topographic__elevation\", limits=(min_z, max_z))"
+    "# help(mg.imshow)\n",
+    "mg.imshow(\"topographic__elevation\", limits=(min_z, max_z))"
    ]
   },
   {
@@ -175,7 +165,7 @@
    "outputs": [],
    "source": [
     "mg.set_watershed_boundary_condition(z, 0)\n",
-    "imshow_grid(mg, mg.status_at_node, color_for_closed=\"blue\")"
+    "mg.imshow(mg.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -232,7 +222,7 @@
    "outputs": [],
    "source": [
     "(mg1, z1) = read_esri_ascii(\"synthetic_landscape.asc\", name=\"topographic__elevation\")\n",
-    "imshow_grid(mg1, z1)"
+    "mg1.imshow(z1)"
    ]
   },
   {
@@ -253,7 +243,7 @@
    "outputs": [],
    "source": [
     "mg1.set_closed_boundaries_at_grid_edges(True, True, True, False)\n",
-    "imshow_grid(mg1, mg1.status_at_node, color_for_closed=\"blue\")"
+    "mg1.imshow(mg1.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -274,7 +264,7 @@
     "(mg2, z2) = read_esri_ascii(\n",
     "    \"synthetic_landscape.asc\", name=\"topographic__elevation\", halo=1\n",
     ")\n",
-    "imshow_grid(mg2, z2)"
+    "mg2.imshow(z2)"
    ]
   },
   {
@@ -298,7 +288,7 @@
     "\n",
     "mg2.status_at_node[15] = mg2.BC_NODE_IS_FIXED_VALUE\n",
     "mg2.status_at_node[19] = mg2.BC_NODE_IS_FIXED_VALUE\n",
-    "imshow_grid(mg2, mg2.status_at_node, color_for_closed=\"blue\")"
+    "mg2.imshow(mg2.status_at_node, color_for_closed=\"blue\")"
    ]
   },
   {
@@ -311,7 +301,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -325,7 +315,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/tests/plot/test_imshow_grid.py
+++ b/tests/plot/test_imshow_grid.py
@@ -4,6 +4,7 @@ import pytest
 from matplotlib.backends.backend_pdf import PdfPages
 
 import landlab
+from landlab.plot.imshow import _guess_location_from_name, _guess_location_from_size
 
 
 @pytest.mark.slow
@@ -13,13 +14,13 @@ def test_imshow_grid():
     pp = PdfPages("test.pdf")
 
     values = np.arange(rmg.number_of_nodes)
-    landlab.plot.imshow_grid(rmg, values, values_at="node", limits=(0, 20))
+    landlab.plot.imshow_grid(rmg, values, at="node", limits=(0, 20))
     pp.savefig()
 
     plt.clf()
     rmg.status_at_node[7] = rmg.BC_NODE_IS_CLOSED
     values = np.arange(rmg.number_of_cells)
-    landlab.plot.imshow_grid(rmg, values, values_at="cell", symmetric_cbar=True)
+    landlab.plot.imshow_grid(rmg, values, at="cell", symmetric_cbar=True)
     pp.savefig()
     pp.close()
 
@@ -28,14 +29,14 @@ def test_imshow_grid_input():
     rmg = landlab.RasterModelGrid((4, 5))
     values = np.arange(rmg.number_of_nodes - 1)
     with pytest.raises(ValueError):
-        _ = landlab.plot.imshow_grid(rmg, values, values_at="node", limits=(0, 20))
+        _ = landlab.plot.imshow_grid(rmg, values, at="node", limits=(0, 20))
 
 
 def test_imshowhs_grid_input():
     rmg = landlab.RasterModelGrid((4, 5))
     values = np.arange(rmg.number_of_nodes - 1)
     with pytest.raises(ValueError):
-        _ = landlab.plot.imshowhs_grid(rmg, values, values_at="node", limits=(0, 20))
+        _ = landlab.plot.imshowhs_grid(rmg, values, at="node", limits=(0, 20))
 
 
 def test_imshowhs_grid_input_Layer1():
@@ -616,3 +617,71 @@ def test_at_other():
     _ = mg.add_field("topographic__elevation", np.zeros((24,)), at="corner")
     with pytest.raises(TypeError):
         _ = landlab.plot.imshowhs_grid(mg, "topographic__elevation", at="corner")
+
+
+@pytest.mark.parametrize("at", ["node", "cell"])
+def test_imshow_grid_guess_from_name(at):
+    grid = landlab.RasterModelGrid((3, 4))
+    grid.add_zeros("z", at=at)
+    landlab.plot.imshow_grid(grid, "z")
+
+
+@pytest.mark.parametrize("at", ["node", "cell"])
+def test_imshow_grid_guess_from_size(at):
+    grid = landlab.RasterModelGrid((3, 4))
+    values = grid.zeros(at=at)
+    landlab.plot.imshow_grid(grid, values)
+
+
+def test_imshow_grid_unknown_location():
+    expected = "unable to determine location of values, use 'at' keyword"
+    grid = landlab.RasterModelGrid((5, 3))
+    values = np.empty(grid.number_of_links + 1)
+    with pytest.raises(TypeError, match=expected):
+        landlab.plot.imshow_grid(grid, values)
+    with pytest.raises(TypeError, match=expected):
+        landlab.plot.imshow_grid(grid, "foo")
+
+
+@pytest.mark.parametrize("at", ["link", "patch", "corner", "face"])
+def test_imshow_grid_unsupported_location(at):
+    expected = "value location, \\'[a-z]+\\', is not supported \\(must be one of 'node', 'cell'\\)"
+    grid = landlab.RasterModelGrid((5, 3))
+    grid.add_zeros("z", at=at)
+    with pytest.raises(TypeError, match=expected):
+        landlab.plot.imshow_grid(grid, "z")
+    with pytest.raises(TypeError, match=expected):
+        landlab.plot.imshow_grid(grid, grid[at]["z"])
+
+
+def test_values_at_is_deprecated():
+    grid = landlab.RasterModelGrid((5, 3))
+    grid.add_zeros("topographic__elevation", at="node")
+    with pytest.deprecated_call(
+        match="the 'values_at' keyword is deprecated, use the 'at' keyword instead"
+    ):
+        landlab.plot.imshow_grid(grid, "topographic__elevation", values_at="node")
+
+
+@pytest.mark.parametrize("at", ["node", "link", "patch", "corner", "face", "cell"])
+def test_guess_location(at):
+    grid = landlab.RasterModelGrid((3, 4))
+    values = grid.add_zeros("z", at=at)
+
+    assert _guess_location_from_name(grid, "z") == at
+    assert _guess_location_from_name(grid, "foo") is None
+
+    guess = _guess_location_from_size(grid, np.empty_like(values))
+    assert grid.number_of_elements(guess) == values.size
+    assert _guess_location_from_size(grid, np.empty(grid.number_of_links + 1)) is None
+
+
+@pytest.mark.parametrize("actual", ["node", "cell"])
+@pytest.mark.parametrize("at", ["link", "patch", "corner", "face"])
+def test_location_node_cell_first(actual, at):
+    grid = landlab.RasterModelGrid((3, 4))
+    values = grid.add_zeros("z", at=actual)
+    grid.add_zeros("z", at=at)
+
+    assert _guess_location_from_name(grid, "z") == actual
+    assert _guess_location_from_size(grid, np.empty_like(values)) == actual


### PR DESCRIPTION
This pull request addresses #1424 but adding an *at* keyword to *imshow* when used as a *ModelGrid* method. There are also a couple other changes:
* *imshow* is now available to all *ModelGrids*
* *imshow* can now guess at a location to plot values if the *at* keyword is not given. This allows things like: `grid.imshow(values)` and `grid.imshow("topographic__elevation")`.
* deprecates the *values_at* keyword
* deprecates usages like `imshow("node", "topographic__elevation")`