### PR TITLE
Exclude tests folder from installed packages

### DIFF
--- a/landlab/components/gravel_river_transporter/gravel_river_transporter.py
+++ b/landlab/components/gravel_river_transporter/gravel_river_transporter.py
@@ -7,7 +7,7 @@ from scipy.sparse.linalg import spsolve
 def make_empty_matrix_and_rhs(grid):
     from scipy.sparse import csc_matrix
 
-    mat = csc_matrix((grid.number_of_core_nodes, grid.number_of_core_nodes),)
+    mat = csc_matrix((grid.number_of_core_nodes, grid.number_of_core_nodes))
     rhs = np.zeros(grid.number_of_core_nodes)
     return mat, rhs
 
@@ -341,7 +341,7 @@ class GravelRiverTransporter(Component):
             width_fac
             * self._discharge
             * self._slope ** (7.0 / 6.0)
-            / (grain_diameter ** 1.5)
+            / (grain_diameter**1.5)
         )
         return width
 
@@ -369,7 +369,7 @@ class GravelRiverTransporter(Component):
             self._trans_coef
             * self._intermittency_factor
             * self._discharge
-            * self._slope ** self._SEVEN_SIXTHS
+            * self._slope**self._SEVEN_SIXTHS
         )
 
     def calc_abrasion_rate(self):
@@ -496,7 +496,7 @@ class GravelRiverTransporter(Component):
         """
         prefac = (
             self._trans_coef * self._intermittency_factor * self._porosity_factor * dt
-        ) / self.grid.dx ** 2
+        ) / self.grid.dx**2
         a = prefac * (1.0 / self.grid.dx + self._abrasion_coef / 2)
         b = prefac * (1.0 / self.grid.dx - self._abrasion_coef / 2)
         f = self._discharge * (self._slope ** (self._ONE_SIXTH))

--- a/news/1445.bugfix
+++ b/news/1445.bugfix
@@ -1,0 +1,3 @@
+Fixed a bug where the *tests* folder was also being installed in
+*site-packages*.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,8 @@ landlab = [
 ]
 [tool.setuptools.packages.find]
 where = ["."]
+include = ["landlab*"]
+exclude = ["tests*"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "AUTHORS.rst", "CHANGES.rst"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ landlab = [
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["landlab*"]
-exclude = ["tests*"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "AUTHORS.rst", "CHANGES.rst"]}

--- a/tests/components/gravel_river_transporter/test_gravel_river_transporter.py
+++ b/tests/components/gravel_river_transporter/test_gravel_river_transporter.py
@@ -124,7 +124,7 @@ def test_analytical_solution_four_cells_basic_solver():
     fa = FlowAccumulator(grid, runoff_rate=bankfull_runoff_rate)
     fa.run_one_step()
     transporter = GravelRiverTransporter(
-        grid, abrasion_coefficient=abrasion_coef, solver="explicit",
+        grid, abrasion_coefficient=abrasion_coef, solver="explicit"
     )
 
     for i in range(nsteps):
@@ -170,7 +170,7 @@ def test_analytical_solution_four_cells_matrix_solver():
     fa = FlowAccumulator(grid, runoff_rate=bankfull_runoff_rate)
     fa.run_one_step()
     transporter = GravelRiverTransporter(
-        grid, abrasion_coefficient=abrasion_coef, solver="matrix",
+        grid, abrasion_coefficient=abrasion_coef, solver="matrix"
     )
 
     for i in range(nsteps):


### PR DESCRIPTION
This pull request addresses conda-forge/landlab-feedstock#48. I've modified *pyproject.toml* to only include *landlab* ~and exclude the *tests* folder. This is overkill as just including `landlab*` would work just fine—no need to also exclude `tests*`.~