### PR TITLE
Add CI check for news fragments

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,26 @@
+name: Check
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, reopened, synchronize]
+
+jobs:
+  check-changelog-entry:
+    name: changelog entry
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # `towncrier check` runs `git diff --name-only origin/main...`, which
+          # needs a non-shallow clone.
+          fetch-depth: 0
+
+      - name: Check changelog
+        if: "!contains(github.event.pull_request.labels.*.name, 'Skip Changelog')"
+        run: |
+          if ! pipx run towncrier check --compare-with origin/${{ github.base_ref }}; then
+          echo "Please see https://landlab.readthedocs.io/en/master/development/contribution/index.html?highlight=towncrier#news-entries for guidance."
+            false
+          fi
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 Release Notes
 =============
 
+.. towncrier-draft-entries:: Not yet released
+
 .. towncrier release notes start
 
 2.5.0 (2022-04-15)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,10 +12,13 @@
 # serve to show the default.
 
 import os
+import pathlib
 import sys
 from datetime import date
 
 import landlab
+
+docs_dir = os.path.dirname(__file__)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -40,6 +43,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
+    "sphinxcontrib.towncrier",
 ]
 
 if os.getenv("READTHEDOCS"):
@@ -361,3 +365,9 @@ napoleon_numpy_docstring = True
 napoleon_google_docstring = False
 napoleon_include_init_with_doc = True
 napoleon_include_special_with_doc = True
+
+# -- Options for towncrier_draft extension --------------------------------------------
+
+towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = pathlib.Path(docs_dir).parent.parent

--- a/news/1433.misc
+++ b/news/1433.misc
@@ -1,0 +1,3 @@
+Added  *water_surface__elevation* as a field in the
+``LinearDiffusionOverlandFlowRouter``.
+

--- a/news/1439.component
+++ b/news/1439.component
@@ -1,0 +1,3 @@
+Added a new component, ``GravelRiverTransporter``, that models
+gravel transport and abrasion in a gridded network of river segments.
+

--- a/news/1439.notebook
+++ b/news/1439.notebook
@@ -1,0 +1,2 @@
+Added a tutorial notebook that demonstrates use of the new ``GravelRiverTransporter`` component.
+

--- a/news/1442.bugfix
+++ b/news/1442.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue related to flow re-routing on an irregular Voronoi-Delaunay grid.
+

--- a/news/1444.bugfix
+++ b/news/1444.bugfix
@@ -1,0 +1,3 @@
+Fixed the ABM tutorial notebooks that were using an older syntax for the
+*Mesa* *remove_agent* method.
+

--- a/news/1446.misc
+++ b/news/1446.misc
@@ -1,0 +1,3 @@
+Added a GitHub Actions workflow to the continuous integration that checks to
+see if a pull request contains a news fragment.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
   "entrypoints",
   "nbsphinx>=0.2.12",
   "sphinxcontrib_github_alt",
+  "sphinxcontrib.towncrier",
 ]
 testing = [
   "coveralls",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,6 +8,7 @@ nbsphinx>=0.2.12
 pandoc
 sphinx>=4
 sphinx_rtd_theme
+sphinxcontrib.towncrier
 sphinxcontrib_github_alt
 tabulate
 tornado


### PR DESCRIPTION
This pull request:
* adds a GitHub Actions workflow that checks if a pull request contains a news fragment
* adds missing news fragments for some recent pull requests.

It looks like the following issues/pull requests are missing news fragments,
* [x] #1444
* [x] #1442
* [x] #1433
* [x] #1439
