### PR TITLE
Exclude the failing opentopography notebook from testing

### DIFF
--- a/notebooks/exclude.yml
+++ b/notebooks/exclude.yml
@@ -10,3 +10,5 @@
   reason: "stalls travis builds"
 - file: test_networkcreator_otherDEMs.ipynb
   reason: "wip"
+- file:  run_network_generator_OpenTopoDEM.ipynb
+  reason: change to rasterio


### PR DESCRIPTION
This pull request excludes the failing notebook, *run_network_generator_OpenTopoDEM.ipynb* from our testing (see #1447).