### PR TITLE
Bc/space var erodibility

### DIFF
--- a/landlab/components/space/ext/calc_sequential_ero_depo.pyx
+++ b/landlab/components/space/ext/calc_sequential_ero_depo.pyx
@@ -31,11 +31,11 @@ def _sequential_ero_depo(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud_sel,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] H,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] br,
                     np.ndarray[DTYPE_FLOAT_t, ndim=1] sed_erosion_term,                    
-                    np.ndarray[DTYPE_FLOAT_t, ndim=1] bed_erosion_term,
+                    np.ndarray[DTYPE_FLOAT_t, ndim=1] bed_erosion_term,                                    
+                    np.ndarray[DTYPE_FLOAT_t, ndim=1] K_sed,
                     DTYPE_FLOAT_t v,
                     DTYPE_FLOAT_t phi,
-                    DTYPE_FLOAT_t F_f,                    
-                    DTYPE_FLOAT_t K_sed,
+                    DTYPE_FLOAT_t F_f,        
                     DTYPE_FLOAT_t H_star,
                     DTYPE_FLOAT_t dt,                    
                     DTYPE_FLOAT_t thickness_lim):
@@ -64,7 +64,7 @@ def _sequential_ero_depo(np.ndarray[DTYPE_INT_t, ndim=1] stack_flip_ud_sel,
             H_loc += (depo_rate / (1 - phi) - sed_erosion_loc/ (1 - phi)) * dt        
         else:              
             # Blowup
-            if (depo_rate == (K_sed * Q_to_the_m[node_id] * slope_loc)) :                        
+            if (depo_rate == (K_sed[node_id] * Q_to_the_m[node_id] * slope_loc)) :                        
                 H_loc = H_loc * log(
                     ((sed_erosion_loc/ (1 - phi)) / H_star)
                     * dt

--- a/landlab/components/space/space_large_scale_eroder.py
+++ b/landlab/components/space/space_large_scale_eroder.py
@@ -524,10 +524,7 @@ class SpaceLargeScaleEroder(Component):
 
         self.sediment_influx[:] = 0
 
-        if np.isscalar(self._K_sed):
-            K_sed_vector = np.ones_like(self._q) * self._K_sed
-        else:
-            K_sed_vector = self._K_sed
+        K_sed_vector = np.broadcast_to(self._K_sed, self._q.shape)
 
         vol_SSY_riv = _sequential_ero_depo(
             stack_flip_ud_sel,

--- a/landlab/components/space/space_large_scale_eroder.py
+++ b/landlab/components/space/space_large_scale_eroder.py
@@ -524,6 +524,11 @@ class SpaceLargeScaleEroder(Component):
 
         self.sediment_influx[:] = 0
 
+        if np.isscalar(self._K_sed):
+            K_sed_vector = np.ones_like(self._q) * self._K_sed
+        else:
+            K_sed_vector = self._K_sed
+
         vol_SSY_riv = _sequential_ero_depo(
             stack_flip_ud_sel,
             r,
@@ -539,10 +544,10 @@ class SpaceLargeScaleEroder(Component):
             br,
             self._sed_erosion_term,
             self._br_erosion_term,
+            K_sed_vector,
             self._v_s,
             self._phi,
             self._F_f,
-            self._K_sed,
             self._H_star,
             dt,
             self._thickness_lim,

--- a/news/1477.bugfix
+++ b/news/1477.bugfix
@@ -1,1 +1,2 @@
-Fixed a bug where the *SpaceLargeScaleEroder* now allows for the user to pass a node-based array of erodibility coefficients.
+Fixed a bug where the ``SpaceLargeScaleEroder`` was only able to accept a scalar value for the erodibility coefficient.
+Now it is able to accept either a scalar or an array.

--- a/news/1477.bugfix
+++ b/news/1477.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where the *SpaceLargeScaleEroder* now allows for the user to pass a node-based array of erodibility coefficients

--- a/news/1477.bugfix
+++ b/news/1477.bugfix
@@ -1,1 +1,1 @@
-Fixed a bug where the *SpaceLargeScaleEroder* now allows for the user to pass a node-based array of erodibility coefficients
+Fixed a bug where the *SpaceLargeScaleEroder* now allows for the user to pass a node-based array of erodibility coefficients.

--- a/tests/components/space/test_space_large_scale_eroder.py
+++ b/tests/components/space/test_space_large_scale_eroder.py
@@ -341,7 +341,7 @@ def test_matches_detachment_solution():
     # Instantiate the SpaceLargeScaleEroder component...
     sp = SpaceLargeScaleEroder(
         mg,
-        K_sed=0.00001,
+        K_sed=0.00001 * np.ones_like(z),
         K_br=K_br,
         F_f=F_f,
         phi=0.1,

--- a/tests/components/space/test_space_large_scale_eroder.py
+++ b/tests/components/space/test_space_large_scale_eroder.py
@@ -296,8 +296,8 @@ def test_br_field_already_on_grid():
     )
 
 
-# %%
-def test_matches_detachment_solution():
+@pytest.mark.parametrize("k_sed", (0.00001, [0.00001] * 25))
+def test_matches_detachment_solution(k_sed):
     # %%
     """
     Test that model matches the detachment-limited analytical solution
@@ -341,7 +341,7 @@ def test_matches_detachment_solution():
     # Instantiate the SpaceLargeScaleEroder component...
     sp = SpaceLargeScaleEroder(
         mg,
-        K_sed=0.00001 * np.ones_like(z),
+        K_sed=k_sed,
         K_br=K_br,
         F_f=F_f,
         phi=0.1,


### PR DESCRIPTION
This pull request addresses  issue #1472 and allows for the user to pass a node-based array of erodibility coefficients in the SpaceLargeScaleEroder. 
@mcflugen, @leonhardt11, this should fix the issue. I did some quick tests and it looks as expected. 