### PR TITLE
Fix #1480; limit towncrier version to less than v22.8

### DIFF
--- a/news/1480.misc
+++ b/news/1480.misc
@@ -1,0 +1,4 @@
+Fixed an issue that prevented the docs from building due to a compatibility
+issue with *sphinxcontrib.towncrier* and *towncrier* v22.8.
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ docs = [
   "sphinxcontrib.towncrier",
   "sphinx-jinja",
   "sphinx-inline-tabs",
+  "towncrier<22.8",
 ]
 testing = [
   "coveralls",

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -6,10 +6,12 @@ jupyter_client
 nbformat
 nbsphinx>=0.2.12
 pandoc
+sphinx-inline-tabs
+sphinx-jinja
 sphinx>=4
 sphinx_rtd_theme
 sphinxcontrib.towncrier
 sphinxcontrib_github_alt
-sphinx-inline-tabs
 tabulate
 tornado
+towncrier<22.8


### PR DESCRIPTION
This pull request fixes #1480 by limiting *towncrier* to versions less than 22.8. The next release of *sphinxcontrib.towncrier* should fix this, at which point the changes in this pull request should be undone.