### PR TITLE
Bc/space le erodibility issue

### DIFF
--- a/news/1490.bugfix
+++ b/news/1490.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug in the tutorial notebook for the BedrockLandslider. The topographic__elevation field in the``HyLandsTutorial``
+was not correctly updated. Now it is. 

--- a/news/1490.bugfix
+++ b/news/1490.bugfix
@@ -1,2 +1,2 @@
-Fixed a bug in the tutorial notebook for the BedrockLandslider. The topographic__elevation field in the``HyLandsTutorial``
-was not correctly updated. Now it is. 
+Fixed a bug in the *HyLandsTutorial* notebook where the *BedrockLandslider*'s
+*topographic__elevation* field was not being updated correctly.

--- a/notebooks/tutorials/landscape_evolution/hylands/HyLandsTutorial.ipynb
+++ b/notebooks/tutorials/landscape_evolution/hylands/HyLandsTutorial.ipynb
@@ -15,10 +15,8 @@
     "\n",
     "This notebook provides a brief introduction and user's guide to the HyLands Hybrid Landscape Evolution model. The model simulates both continuous fluvial incision and sediment transport using the Landlab Space component as well as stochastic deep-seated bedrock landsliding using the Landlab BedrockLandslider component. This notebook combines two documents, a User's Manual and a notebook-based example, written Benjamin Campforts to accompany the following publications:\n",
     "\n",
-    "* Campforts B., Shobe C.M., Overeem I., Tucker, G. E.,  in review\n",
-    "* Campforts B., Shobe C.M., Steer P., Vanmaercke M., Lague D., Braun J. (2020) HyLands 1.0: a hybrid landscape evolution model to simulate the impact of landslides and landslide-derived sediment on landscape evolution. Geosci Model Dev: 13(9):3863–86, [doi.org/10.5194/gmd-13-3863-2020](https://doi.org/10.5194/gmd-13-3863-2020).\n",
-    "* Shobe, C. M., Tucker, G. E., & Barnhart, K. R. (2017). The SPACE 1.0 model: a Landlab component for 2-D calculation of sediment transport, bedrock erosion, and landscape evolution. Geoscientific Model Development, 10(12), 4577-4604, [https://doi.org/10.5194/gmd-10-4577-2017](https://doi.org/10.5194/gmd-10-4577-2017).\n",
-    "\n"
+    "* Campforts, B., Shobe, C. M., Overeem, I., & Tucker, G. E. (2022). The Art of Landslides: How Stochastic Mass Wasting Shapes Topography and Influences Landscape Dynamics. Journal of Geophysical Research: Earth Surface, 127(8), 1–16. [doi: 10.1029/2022JF006745](https://doi.org/10.1029/2022JF006745)\n",
+    "* Campforts B., Shobe C.M., Steer P., Vanmaercke M., Lague D., Braun J. (2020) HyLands 1.0: a hybrid landscape evolution model to simulate the impact of landslides and landslide-derived sediment on landscape evolution. Geosci Model Dev: 13(9):3863–86, [doi: 10.5194/gmd-13-3863-2020](https://doi.org/10.5194/gmd-13-3863-2020)."
    ]
   },
   {
@@ -107,6 +105,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -162,6 +161,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -287,6 +287,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -317,7 +318,7 @@
     "\n",
     "    # Insert uplift at core nodes\n",
     "    mg.at_node[\"bedrock__elevation\"][mg.core_nodes] += U * timestep\n",
-    "    mg.at_node[\"topographic__elevation\"] = (\n",
+    "    mg.at_node[\"topographic__elevation\"][:] = (\n",
     "        mg.at_node[\"bedrock__elevation\"] + mg.at_node[\"soil__depth\"]\n",
     "    )\n",
     "\n",
@@ -357,6 +358,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
+    "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
     }
@@ -456,7 +458,7 @@
     "for i in range(10):\n",
     "    # Insert uplift at core nodes\n",
     "    mg.at_node[\"bedrock__elevation\"][mg.core_nodes] += U * timestep\n",
-    "    mg.at_node[\"topographic__elevation\"] = (\n",
+    "    mg.at_node[\"topographic__elevation\"][:] = (\n",
     "        mg.at_node[\"bedrock__elevation\"] + mg.at_node[\"soil__depth\"]\n",
     "    )\n",
     "\n",
@@ -554,7 +556,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Description

This pull request solves a bug in the HyLands  notebook tutorial where the `topographic__elevation` field was not updated correctly. This PR addresses issue #1490. Besides, a reference to the published paper using this model was added.  @mcflugen this should be a nice and small PR to check. 

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [x] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
- [x] All tests have passed?
- [x] Formatted code with black?
- [x] Removed lint reported by flake8?
- [x] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->

