### PR TITLE
Fix gdal version error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
   "pandas",
   "xarray >= 0.16",
   "richdem ; sys_platform != 'win32' or python_version < '3.10'",
+  "gdal < 3.5.2",
 ]
 dynamic = ["readme", "version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Requirements extracted from pyproject.toml
 # [project.dependencies]
 bmipy
+gdal < 3.5.2
 matplotlib
 netcdf4
 numpy


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

This pull request is a bandaid to try to fix #1498 by requiring an older version of *gdal*.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [ ] All tests have passed?
- [ ] Formatted code with black?
- [ ] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->

