### PR TITLE
Gt/generic ls sed xporter

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -1,3 +1,4 @@
+from .area_slope_transporter import AreaSlopeTransporter
 from .bedrock_landslider import BedrockLandslider
 from .carbonate import CarbonateProducer
 from .chi_index import ChiFinder
@@ -69,6 +70,7 @@ from .vegetation_dynamics import Vegetation
 from .weathering import ExponentialWeatherer, ExponentialWeathererIntegrated
 
 COMPONENTS = [
+    AreaSlopeTransporter,
     BedrockLandslider,
     CarbonateProducer,
     ChannelProfiler,

--- a/landlab/components/area_slope_transporter/__init__.py
+++ b/landlab/components/area_slope_transporter/__init__.py
@@ -1,0 +1,3 @@
+from .area_slope_transporter import AreaSlopeTransporter
+
+__all__ = ["AreaSlopeTransporter"]

--- a/landlab/components/area_slope_transporter/area_slope_transporter.py
+++ b/landlab/components/area_slope_transporter/area_slope_transporter.py
@@ -129,7 +129,11 @@ class AreaSlopeTransporter(Component):
     }
 
     def __init__(
-        self, grid, transport_coefficient=0.0055, area_exponent=1.4, slope_exponent=2.1,
+        self,
+        grid,
+        transport_coefficient=0.0055,
+        area_exponent=1.4,
+        slope_exponent=2.1,
     ):
         """Initialize AreaSlopeTransporter."""
 
@@ -173,8 +177,8 @@ class AreaSlopeTransporter(Component):
         """
         self._sediment_outflux[:] = (
             self._trans_coef
-            * self._area ** self._area_exponent
-            * self._slope ** self._slope_exponent
+            * self._area**self._area_exponent
+            * self._slope**self._slope_exponent
         )
 
     def calc_sediment_rate_of_change(self):

--- a/landlab/components/area_slope_transporter/area_slope_transporter.py
+++ b/landlab/components/area_slope_transporter/area_slope_transporter.py
@@ -1,0 +1,244 @@
+import numpy as np
+
+from landlab import Component, HexModelGrid
+
+
+class AreaSlopeTransporter(Component):
+    """Model drainage network evolution for a network of transport-limited
+    rivers in which sediment transport rate is calculated as a power-law
+    function of drainage area and local streamwise slope gradient.
+
+    AreaSlopeTransporter is designed to operate together with a flow-routing
+    component such as PriorityFloodFlowRouter, so that each grid node has
+    a defined flow direction toward one of its neighbor nodes. Each core node
+    is assumed to contain one outgoing fluvial channel, and (depending on
+    the drainage structure) zero, one, or more incoming channels. These channels are
+    treated as effectively sub-grid-scale features that are embedded in valleys
+    that have a width of one grid cell. The rate of sediment transport out of
+    a given node is calculated as a generic power function of drainage area,
+    local slope, and a user-specified transport coefficient.
+    Similar power-law formulations have been used, for example, by
+    Willgoose et al. (1991a,b,c, and many papers following that use the
+    SIBERIA model) and Howard (1994, in Water Resources Research).
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        A Landlab model grid object
+    transport_coefficient : float (default 0.0055)
+        Dimensional transport efficiency factor
+    area_exponent : float (default 1.4)
+        Exponent on effective total discharge
+    slope_exponent : float (default 2.1)
+        Exponent on local streamwise slope gradient
+
+    Examples
+    --------
+    >>> from landlab import RasterModelGrid
+    >>> from landlab.components import FlowAccumulator
+    >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
+    >>> elev = grid.add_zeros("topographic__elevation", at="node")
+    >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+    >>> grid.status_at_node[5] = grid.BC_NODE_IS_FIXED_VALUE
+    >>> fa = FlowAccumulator(grid)
+    >>> fa.run_one_step()
+    >>> transporter = AreaSlopeTransporter(grid)
+    >>> for _ in range(200):
+    ...     fa.run_one_step()
+    ...     elev[grid.core_nodes] += 1.0
+    ...     transporter.run_one_step(10000.0)
+    >>> int(round(elev[4] * 10000))
+    107
+    """
+
+    _name = "AreaSlopeTransporter"
+
+    _unit_agnostic = True
+
+    _info = {
+        "sediment__volume_influx": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**3/y",
+            "mapping": "node",
+            "doc": "Volumetric incoming streamwise sediment transport rate",
+        },
+        "sediment__volume_outflux": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**3/y",
+            "mapping": "node",
+            "doc": "Volumetric outgoing streamwise sediment transport rate",
+        },
+        "flow__link_to_receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "ID of link downstream of each node, which carries the discharge",
+        },
+        "flow__receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array of receivers (node that receives flow from current node)",
+        },
+        "flow__upstream_node_order": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array containing downstream-to-upstream ordered list of node IDs",
+        },
+        "sediment__rate_of_change": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m/y",
+            "mapping": "node",
+            "doc": "Time rate of change of sediment thickness",
+        },
+        "drainage_area": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "m**2",
+            "mapping": "node",
+            "doc": "Drainage area",
+        },
+        "topographic__elevation": {
+            "dtype": float,
+            "intent": "inout",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Land surface topographic elevation",
+        },
+        "topographic__steepest_slope": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "The steepest *downhill* slope",
+        },
+    }
+
+    def __init__(
+        self,
+        grid,
+        transport_coefficient=0.0055,
+        area_exponent=1.4,
+        slope_exponent=2.1,
+    ):
+        """Initialize AreaSlopeTransporter."""
+
+        super().__init__(grid)
+
+        # Parameters
+        self._trans_coef = transport_coefficient
+        self._area_exponent = area_exponent
+        self._slope_exponent = slope_exponent
+
+        # Fields and arrays
+        self._elev = grid.at_node["topographic__elevation"]
+        self._area = grid.at_node["drainage_area"]
+        self._slope = grid.at_node["topographic__steepest_slope"]
+        self._receiver_node = grid.at_node["flow__receiver_node"]
+        self._receiver_link = grid.at_node["flow__link_to_receiver_node"]
+        super().initialize_output_fields()
+        self._sediment_influx = grid.at_node["sediment__volume_influx"]
+        self._sediment_outflux = grid.at_node["sediment__volume_outflux"]
+        self._dzdt = grid.at_node["sediment__rate_of_change"]
+
+    def calc_transport_capacity(self):
+        """Calculate and return bed-load transport capacity.
+
+        Calculation uses power-law approach, and provides
+        volume per time rate.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[3:] = 1.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = AreaSlopeTransporter(grid)
+        >>> transporter.calc_transport_capacity()
+        >>> round(transporter._sediment_outflux[4], 4)
+        0.019
+        """
+        self._sediment_outflux[:] = (
+            self._trans_coef
+            * self._discharge**self._area_exponent
+            * self._slope**self._slope_exponent
+        )
+
+    def calc_sediment_rate_of_change(self):
+        """Update the rate of thickness change of sediment at each core node.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = AreaSlopeTransporter(grid)
+        >>> transporter.calc_sediment_rate_of_change()
+        >>> np.round(transporter._sediment_outflux[4:7], 3)
+        array([ 0.   ,  0.038,  0.019])
+        >>> np.round(transporter._sediment_influx[4:7], 3)
+        array([ 0.038,  0.019,  0.   ])
+        >>> np.round(transporter._dzdt[5:7], 8)
+        array([ -2.93000000e-06,  -2.93000000e-06])
+        """
+        self.calc_transport_capacity()
+        if self._abrasion_coef > 0.0:
+            self.calc_abrasion_rate()
+        cores = self.grid.core_nodes
+        self._sediment_influx[:] = 0.0
+        for c in cores:  # send sediment downstream
+            r = self._receiver_node[c]
+            self._sediment_influx[r] += self._sediment_outflux[c]
+        self._dzdt[cores] = (
+            (self._sediment_influx[cores] - self._sediment_outflux[cores])
+            / self.grid.area_of_cell[self.grid.cell_at_node[cores]]
+        )
+
+    def run_one_step(self, dt):
+        """Advance solution by time interval dt.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = AreaSlopeTransporter(grid)
+        >>> transporter.run_one_step(1000.0)
+        >>> np.round(elev[4:7], 4)
+        array([ 0.    ,  0.9971,  1.9971])
+        """
+        self.calc_sediment_rate_of_change()
+        self._elev += self._dzdt * dt

--- a/landlab/components/area_slope_transporter/area_slope_transporter.py
+++ b/landlab/components/area_slope_transporter/area_slope_transporter.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from landlab import Component, HexModelGrid
+from landlab import Component
 
 
 class AreaSlopeTransporter(Component):
@@ -131,11 +129,7 @@ class AreaSlopeTransporter(Component):
     }
 
     def __init__(
-        self,
-        grid,
-        transport_coefficient=0.0055,
-        area_exponent=1.4,
-        slope_exponent=2.1,
+        self, grid, transport_coefficient=0.0055, area_exponent=1.4, slope_exponent=2.1,
     ):
         """Initialize AreaSlopeTransporter."""
 
@@ -179,8 +173,8 @@ class AreaSlopeTransporter(Component):
         """
         self._sediment_outflux[:] = (
             self._trans_coef
-            * self._area**self._area_exponent
-            * self._slope**self._slope_exponent
+            * self._area ** self._area_exponent
+            * self._slope ** self._slope_exponent
         )
 
     def calc_sediment_rate_of_change(self):
@@ -214,9 +208,8 @@ class AreaSlopeTransporter(Component):
             r = self._receiver_node[c]
             self._sediment_influx[r] += self._sediment_outflux[c]
         self._dzdt[cores] = (
-            (self._sediment_influx[cores] - self._sediment_outflux[cores])
-            / self.grid.area_of_cell[self.grid.cell_at_node[cores]]
-        )
+            self._sediment_influx[cores] - self._sediment_outflux[cores]
+        ) / self.grid.area_of_cell[self.grid.cell_at_node[cores]]
 
     def run_one_step(self, dt):
         """Advance solution by time interval dt.

--- a/landlab/components/area_slope_transporter/area_slope_transporter.py
+++ b/landlab/components/area_slope_transporter/area_slope_transporter.py
@@ -47,8 +47,8 @@ class AreaSlopeTransporter(Component):
     ...     fa.run_one_step()
     ...     elev[grid.core_nodes] += 1.0
     ...     transporter.run_one_step(10000.0)
-    >>> int(round(elev[4] * 10000))
-    107
+    >>> int(round(elev[4] * 100))
+    1068
     """
 
     _name = "AreaSlopeTransporter"
@@ -174,12 +174,12 @@ class AreaSlopeTransporter(Component):
         >>> fa.run_one_step()
         >>> transporter = AreaSlopeTransporter(grid)
         >>> transporter.calc_transport_capacity()
-        >>> round(transporter._sediment_outflux[4], 4)
-        0.019
+        >>> int(transporter._sediment_outflux[4] * 1000)
+        138
         """
         self._sediment_outflux[:] = (
             self._trans_coef
-            * self._discharge**self._area_exponent
+            * self._area**self._area_exponent
             * self._slope**self._slope_exponent
         )
 
@@ -201,15 +201,13 @@ class AreaSlopeTransporter(Component):
         >>> transporter = AreaSlopeTransporter(grid)
         >>> transporter.calc_sediment_rate_of_change()
         >>> np.round(transporter._sediment_outflux[4:7], 3)
-        array([ 0.   ,  0.038,  0.019])
+        array([ 0.   ,  0.365,  0.138])
         >>> np.round(transporter._sediment_influx[4:7], 3)
-        array([ 0.038,  0.019,  0.   ])
+        array([ 0.365,  0.138,  0.   ])
         >>> np.round(transporter._dzdt[5:7], 8)
-        array([ -2.93000000e-06,  -2.93000000e-06])
+        array([ -2.26400000e-05,  -1.38200000e-05])
         """
         self.calc_transport_capacity()
-        if self._abrasion_coef > 0.0:
-            self.calc_abrasion_rate()
         cores = self.grid.core_nodes
         self._sediment_influx[:] = 0.0
         for c in cores:  # send sediment downstream
@@ -236,9 +234,9 @@ class AreaSlopeTransporter(Component):
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
         >>> transporter = AreaSlopeTransporter(grid)
-        >>> transporter.run_one_step(1000.0)
+        >>> transporter.run_one_step(10000.0)
         >>> np.round(elev[4:7], 4)
-        array([ 0.    ,  0.9971,  1.9971])
+        array([ 0.    ,  0.7736,  1.8618])
         """
         self.calc_sediment_rate_of_change()
         self._elev += self._dzdt * dt

--- a/notebooks/tutorials/landscape_evolution/area_slope_transporter/einstein-brown.ipynb
+++ b/notebooks/tutorials/landscape_evolution/area_slope_transporter/einstein-brown.ipynb
@@ -1,0 +1,502 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "246222ae",
+   "metadata": {},
+   "source": [
+    "# Unit tests and parameterization for `AreaSlopeTransporter`\n",
+    "\n",
+    "*(Greg Tucker, University of Colorado Boulder, October 2022)*\n",
+    "\n",
+    "This notebook gives background on the default parameters for the `AreaSlopeTransporter` component, and also provides the calculations for a set of unit tests that are used in the code.\n",
+    "\n",
+    "## Parameters for the Einstein-Brown transport equation\n",
+    "\n",
+    "The `AreaSlopeTransporter` component calculates fluvial volumetric sediment flux, $Q_s$, from a generic area-slope power law:\n",
+    "\n",
+    "$$Q_s = k_s A^m S^n$$\n",
+    "\n",
+    "This section works out the transport parameters $k_s$, $m$, and $n$ for the Einstein-Brown law, based on Willgoose's 1991 appendix but adding the extra step of integrating across a channel of width $W = a Q^b$ to get total volumetric transport rate. These parameters are used as the default in the component."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c27c75ed",
+   "metadata": {},
+   "source": [
+    "### Converting to area-slope form\n",
+    "\n",
+    "(This follows Willgoose et al. (1991a WRR) appendix):\n",
+    "\n",
+    "Dimensionless transport rate:\n",
+    "\n",
+    "$$\\phi = 40 \\tau_*^3$$\n",
+    "\n",
+    "Definition of dimensionless xport rate:\n",
+    "\n",
+    "$$\\phi = \\frac{M_s}{\\rho_s F_1 \\sqrt{g(s - 1) D^3}}$$\n",
+    "\n",
+    "where $M_s$ sediment discharge in mass/time/width, $s$ is sed specific grav, $D$ is grain diameter. \n",
+    "\n",
+    "$\\tau_*$ is the usual:\n",
+    "\n",
+    "$$\\tau_* = \\frac{\\tau_b}{(\\rho_s - \\rho) g D}$$\n",
+    "\n",
+    "The weirdo factor is:\n",
+    "\n",
+    "$$F_1 = \\sqrt{\\frac{2}{3} + \\frac{36\\nu^2}{g D^3 (s-1)}}\n",
+    "- \\sqrt{\\frac{36\\nu^2}{gD^3(s-1)}}$$\n",
+    "\n",
+    "From plenty of other derivations, we can cast $\\tau_b$ in terms of discharge and slope. Here's one version using the Manning equation for a wide channel:\n",
+    "\n",
+    "$$\\tau_b = \\rho g H S$$\n",
+    "\n",
+    "$$Q = \\frac{1}{n} W H^{5/3} S^{1/2}$$\n",
+    "\n",
+    "$$H^{5/3} = \\frac{Qn}{WS^{1/2}}$$\n",
+    "\n",
+    "\n",
+    "$$H = \\frac{(Qn)^{3/5}}{W^{3/5}S^{3/10}}$$\n",
+    "\n",
+    "Check the units here... we have L$^{9/5 - 3/5 - 1/5}$ T$^{-3/5+3/5}$...ok.\n",
+    "\n",
+    "Plug in:\n",
+    "\n",
+    "$$\\tau_b = \\rho g \\frac{(Qn)^{3/5}}{W^{3/5}S^{3/10}} S$$\n",
+    "\n",
+    "Simplify\n",
+    "\n",
+    "$$\\tau_b = \\rho g n^{3/5} \\left(\\frac{Q}{W}\\right)^{3/5} S^{7/10}$$\n",
+    "\n",
+    "So then,\n",
+    "\n",
+    "$$\\phi = \\frac{40}{(\\rho_s - \\rho)^3 g^3 D^3} \\left(\\rho g n^{3/5} \\left(\\frac{Q}{W}\\right)^{3/5} S^{7/10}\\right)^3$$\n",
+    "\n",
+    "which converts to:\n",
+    "\n",
+    "$$\\phi = \\frac{40\\rho^3 g^3 n^{9/5}}{(\\rho_s - \\rho)^3 g^3 D^3} \\left( \\left(\\frac{Q}{W}\\right)^{3/5} S^{7/10}\\right)^3$$\n",
+    "\n",
+    "$$\\phi = \\frac{40 n^{9/5}}{(s - 1)^3 D^3} \\left(\\frac{Q}{W}\\right)^{1.8} S^{2.1}$$\n",
+    "\n",
+    "Check units again: L$^{-3/5 - 3 + 3.6 = 0}$, T$^{9/5 - 9/5 = 0}$.\n",
+    "\n",
+    "Now the annoying $\\phi$:\n",
+    "\n",
+    "$$q_s = \\frac{M_s}{\\rho_s} = F_1\\sqrt{g (s-1) D^3} \\frac{40 n^{9/5}}{(s - 1)^3 D^3} \\left(\\frac{Q}{W}\\right)^{1.8} S^{2.1}$$\n",
+    "\n",
+    "$$q_s = \\frac{M_s}{\\rho_s} = F_1\\sqrt{g} \\frac{40 n^{9/5}}{(s - 1)^{5/2} D^{3/2}} \\left(\\frac{Q}{W}\\right)^{1.8} S^{2.1}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32486ffe",
+   "metadata": {},
+   "source": [
+    "Now it's time to bring in the pesky channel-width issue:\n",
+    "\n",
+    "$$W = a Q^b$$\n",
+    "\n",
+    "$$q_s = \\frac{M_s}{\\rho_s} = F_1\\sqrt{g} \\frac{40 n^{9/5}}{(s - 1)^{5/2} D^{3/2}} \\left(\\frac{Q^{1-b}}{a}\\right)^{1.8} S^{2.1}$$\n",
+    "\n",
+    "$$q_s = \\frac{M_s}{\\rho_s} = F_1\\sqrt{g} \\frac{40 n^{9/5}}{(s - 1)^{5/2} D^{3/2}a^{9/5}} Q^{1.8(1-b)} S^{2.1}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dfb9286",
+   "metadata": {},
+   "source": [
+    "Using $b=1/2$, we have:\n",
+    "\n",
+    "$$q_s = F_1\\sqrt{g} \\frac{40 n^{9/5}}{(s - 1)^{5/2} D^{3/2}a^{9/5}} Q^{0.9} S^{2.1}$$\n",
+    "\n",
+    "Let's now cast in terms of total flux, again with $b=1/2$:\n",
+    "\n",
+    "$$Q_s = a F_1\\sqrt{g} \\frac{40 n^{9/5}}{(s - 1)^{5/2} D^{3/2}a^{9/5}} Q^{1.4} S^{2.1}$$\n",
+    "\n",
+    "That's instantaneous. Let's factor in an intermittency factor, $I$, and combine pieces,\n",
+    "\n",
+    "$$Q_s = k_{sq} I Q^{1.4} S^{2.1}$$\n",
+    "\n",
+    "For $F_1$, we need a grain diameter, densities, and kinematic viscosity. Using 0.05 m for grain diameter,"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08be70eb",
+   "metadata": {},
+   "source": [
+    "Next, we'll convert this into an area-slope formulation. Let's assume $Q_{bf} = RA$ (not ideal, given common sub-linear $A$ scaling, but let's run with it). Then,\n",
+    "\n",
+    "$$\\boxed{Q_s = k_s A^{1.4} S^{2.1}}$$\n",
+    "\n",
+    "where\n",
+    "\n",
+    "$$k_s = k_{sq} I R^{0.9}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "373665aa",
+   "metadata": {},
+   "source": [
+    "### Estimating a value for $k_s$\n",
+    "\n",
+    "Ok, now for some numbers. Let's use $n=0.01$ in SI units. For bankfull width, if we use $b = 1/2$ and $a = 5$ s$^{1/2}$/m, and a bankfull runoff rate of 10 m/y, what would we have for width?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "237aaef6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "a = 5.0\n",
+    "b = 0.5\n",
+    "\n",
+    "area = np.array([1.0e6, 10.0e6, 100.0e6, 1000.0e6])\n",
+    "discharge = 1.0e-7 * area\n",
+    "width = a * discharge**b\n",
+    "print('At a bankfull discharge of:', discharge, 'cms...')\n",
+    "print('...the corresponding bankfull width would be:', width)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c766fcd",
+   "metadata": {},
+   "source": [
+    "Note that this is just a rough guess at $a$. One should ideally interrogate hydraulic geometry, but here the purpose is simply to identify a value that is basically reasonable.\n",
+    "\n",
+    "Here's one example. Boulder Creek at Orodell has an annual peak (snow-melt) flow 500 cfs. How wide would it be at a = 1, 5, 10? Drainage area is 102 mi$^2$, or 264 km$^2$. The channel is roughly 20 m wide here (though possibly artifically narrowed by the road). If we assume the annual maximum flow is the bankfull event, how wide would the channel be if the coefficient were 5 and the exponent 1/2?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "905904d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Qbf = 500 * (0.3048**3)  # bankfull flow, converted to cms\n",
+    "w = 5 * Qbf**0.5  # predicted width, m\n",
+    "am2 = 102 * (5280*.3048)**2  # while we're at it, convert drainage area to m2\n",
+    "print('Peak discharge (cms):', Qbf)\n",
+    "print('Predicted width (m):', w)\n",
+    "print('Drainage area (km2):', am2/1e6)\n",
+    "print('Runoff rate (m/s):', Qbf/am2)\n",
+    "print('Runoff rate (m/y):', Qbf*3600*365.25*24/am2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a3189172",
+   "metadata": {},
+   "source": [
+    "The above turns out to be quite close to the estimated width of 20 m. Although this is just one example, and not a proper fit by any means, for our purposes it suffices to demonstrate that an $a$ value of 5 (in SI units) is not completely crazy.\n",
+    "\n",
+    "For the sake of estimating a default value for $k_s$, we'll choose values for the kinematic viscosity of water (which is temperature-dependent; the value $10^{-6}$  Pa$\\cdot$s applies to 20 $^\\circ$C), grain diameter (5 cm), and sediment immersed specific gravity (1.65, representing quartz). Clearly this means that the coefficient value depends in particular on grain diameter, and to a lesser extent on grain density.\n",
+    "\n",
+    "Next, the Einstein-Brown $F_1$ parameter:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c86d49b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nu = 1.0e-6  # kinematic viscosity of water, m2/s\n",
+    "D = 0.05  # grain diameter, m\n",
+    "sm1 = 1.65  # immersed specific gravity\n",
+    "g = 9.8\n",
+    "\n",
+    "term = (36. * nu**2) / (g * D**3 * sm1)\n",
+    "F1 = ((2./ 3.) + term)**0.5 - term**0.5\n",
+    "print('F1 =', F1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33b4e164",
+   "metadata": {},
+   "source": [
+    "This allows us to calculate $k_{sq}$, here with $n=0.01$ and $a=5$,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25ae9527",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 0.01  # Manning roughness coefficient in SI units\n",
+    "a = 5.0  # width-discharge factor, SI\n",
+    "\n",
+    "ksq = a * F1 * g**0.5 * ((40.0 * n**4.5) / (sm1**2.5 * D**1.5 * a**4.5))\n",
+    "print('ksq', ksq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a03862b",
+   "metadata": {},
+   "source": [
+    "Next, we'll calculate the corresponding $k_s$ by applying a bankfull runoff rate (2 m/y) and an intermittency factor (0.01):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cf7ba6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "R = 2.0  # bankfull runoff rate\n",
+    "I = 0.01 # intermittency factor\n",
+    "\n",
+    "ks = ksq * I * R**0.9\n",
+    "print('ks', ks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8af87e8c",
+   "metadata": {},
+   "source": [
+    "For landscape evolution, it makes sense to compute $Q_s$ in m$^3$/y rather than m$^3$/s, so we will factor a unit conversion into the coefficient:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d49dd79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert ks to time units of years:\n",
+    "ksy = ks * 365.25 * 24 * 3600.0\n",
+    "print('ksy', ksy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ee0ef71",
+   "metadata": {},
+   "source": [
+    "If we round this off, we have our default value for $k_s$: 0.0055, with length units of m and time units of years."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ab1d26b",
+   "metadata": {},
+   "source": [
+    "Now we're ready to do a sanity check by examining the slope-area relationship. Let sediment flux be erosion rate times drainage area (ignoring fines and dissolved load), $Q_s = EA$. Equilibrium means:\n",
+    "\n",
+    "$$EA = k_s A^{1.4} S^{2.1}$$\n",
+    "\n",
+    "$$S = \\left(\\frac{E}{k_s}\\right)^{1/2.1} A^{-0.4/2.1}$$\n",
+    "\n",
+    "$$S \\approx \\left(\\frac{E}{k_s}\\right)^{0.48} A^{-0.19}$$\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6532da6b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(1/2.1)\n",
+    "print(.4/2.1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b93e2aa",
+   "metadata": {},
+   "source": [
+    "What does this imply for gradients given $E=10^{-4}$ m/y, and $A\\in (10, 100, 1000) $km$^2$?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "646d55ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "E = 1.0e-4\n",
+    "A = np.array([10.0e6, 100.0e6, 1000.0e6])\n",
+    "\n",
+    "print('S=', (E / ksy)**0.48 * A**(-0.19))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a4c3c49",
+   "metadata": {},
+   "source": [
+    "These seem like reasonable values for gradient."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b7b352b",
+   "metadata": {},
+   "source": [
+    "## Unit tests\n",
+    "\n",
+    "### Default parameters\n",
+    "\n",
+    "Based on the derivation above, the default parameters will be $k_s = 0.0055$, $m=1.4$, $n=2.1$.\n",
+    "\n",
+    "### Slope-area for one grid cell\n",
+    "\n",
+    "Consider a grid cell 1000 x 1000 m with an uplift rate of $10^{-4}$ m/y. The sediment input rate is therefore 100 m$^3$/y. The resulting outflux should equal this:\n",
+    "\n",
+    "$$Q_s = 0.0055 (10^6)^{1.4} S^{2.1} = 100 m^3/y$$\n",
+    "\n",
+    "$$S = \\left( \\frac{(100)}{(0.0055)(10^6)^{1.4}}\\right)^{1/2.1}$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0da6a034",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Seq = (100.0 / (0.0055 * 1.0e6**1.4))**(1.0/2.1)\n",
+    "elev_eq = Seq * 1000.0\n",
+    "print('Equilibrium slope:', Seq)\n",
+    "print('Equilibrium elevation:', elev_eq)\n",
+    "\n",
+    "# test: elevation at the node should be 1,068 cm when rounded to the nearest cm.\n",
+    "print('Rounded elevation in cm:', int(round(elev_eq * 100)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0153b247",
+   "metadata": {},
+   "source": [
+    "### Transport capacity for a single cell\n",
+    "\n",
+    "Assume an elevation of 1.0 m, $\\Delta x = 100$ m. Drainage area therefore is 10,000 m$^2$ and slope is 0.01. Therefore with default parameters, the volumetric sediment discharge should be:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d79f056",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Qs = 0.0055 * (100 * 100)**1.4 * (0.01)**2.1\n",
+    "print('Qs:', Qs)\n",
+    "print('Qs in liters per year (to nearest liter):', int(Qs * 1000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2818fcb",
+   "metadata": {},
+   "source": [
+    "### Sediment rate of change\n",
+    "\n",
+    "Consider two core nodes flowing in one direction toward a single open boundary. Grid is raster with $\\Delta x = 100$ m. Slope is 0.01. Calculate $dz/dt$ at each grid node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f4475fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = 1.0e4 * np.array([3, 2, 1])  # drainage area (m2); flow is right to left\n",
+    "Qsout = np.zeros(len(A))\n",
+    "Qsin = np.zeros(len(A))\n",
+    "Qsout[1:] = 0.0055 * A[1:]**1.4 * 0.01**2.1  # sediment outflux from each node, m3/y\n",
+    "Qsin[:2] = Qsout[1:]  # sediment influx to each node, m3/y\n",
+    "dzdt = (Qsin - Qsout) / 1.0e4  # rate of elevation change, m/y\n",
+    "print(Qsin)\n",
+    "print(Qsout)\n",
+    "print(dzdt)\n",
+    "\n",
+    "# test: answer should be array([ 0.   ,  0.365,  0.138])\n",
+    "print(np.round(Qsout, 3))\n",
+    "\n",
+    "# test: answer should be array([ 0.365,  0.138,  0.   ])\n",
+    "print(np.round(Qsin, 3))\n",
+    "        \n",
+    "# test: answer should be array([ -2.26400000e-05,  -1.38200000e-05])\n",
+    "print(np.round(dzdt[1:], 8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdfe1534",
+   "metadata": {},
+   "source": [
+    "### `run_one_step`\n",
+    "\n",
+    "Running one time step of 10,000 years with the above case should lower the nodes as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9ef6b26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "elev = np.array([0.0, 1.0, 2.0])\n",
+    "elev[1:] += dzdt[1:] * 10000.0  # erode for one time step of 10,000 years\n",
+    "print(elev)\n",
+    "\n",
+    "# test: should be array([0.    , 0.7736, 1.8618])\n",
+    "np.round(elev, 4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18c80703",
+   "metadata": {},
+   "source": [
+    "These unit tests are embedded into the code as doctests."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tutorials/landscape_evolution/area_slope_transporter/einstein-brown.ipynb
+++ b/notebooks/tutorials/landscape_evolution/area_slope_transporter/einstein-brown.ipynb
@@ -161,8 +161,8 @@
     "area = np.array([1.0e6, 10.0e6, 100.0e6, 1000.0e6])\n",
     "discharge = 1.0e-7 * area\n",
     "width = a * discharge**b\n",
-    "print('At a bankfull discharge of:', discharge, 'cms...')\n",
-    "print('...the corresponding bankfull width would be:', width)"
+    "print(\"At a bankfull discharge of:\", discharge, \"cms...\")\n",
+    "print(\"...the corresponding bankfull width would be:\", width)"
    ]
   },
   {
@@ -184,12 +184,12 @@
    "source": [
     "Qbf = 500 * (0.3048**3)  # bankfull flow, converted to cms\n",
     "w = 5 * Qbf**0.5  # predicted width, m\n",
-    "am2 = 102 * (5280*.3048)**2  # while we're at it, convert drainage area to m2\n",
-    "print('Peak discharge (cms):', Qbf)\n",
-    "print('Predicted width (m):', w)\n",
-    "print('Drainage area (km2):', am2/1e6)\n",
-    "print('Runoff rate (m/s):', Qbf/am2)\n",
-    "print('Runoff rate (m/y):', Qbf*3600*365.25*24/am2)"
+    "am2 = 102 * (5280 * 0.3048) ** 2  # while we're at it, convert drainage area to m2\n",
+    "print(\"Peak discharge (cms):\", Qbf)\n",
+    "print(\"Predicted width (m):\", w)\n",
+    "print(\"Drainage area (km2):\", am2 / 1e6)\n",
+    "print(\"Runoff rate (m/s):\", Qbf / am2)\n",
+    "print(\"Runoff rate (m/y):\", Qbf * 3600 * 365.25 * 24 / am2)"
    ]
   },
   {
@@ -216,9 +216,9 @@
     "sm1 = 1.65  # immersed specific gravity\n",
     "g = 9.8\n",
     "\n",
-    "term = (36. * nu**2) / (g * D**3 * sm1)\n",
-    "F1 = ((2./ 3.) + term)**0.5 - term**0.5\n",
-    "print('F1 =', F1)"
+    "term = (36.0 * nu**2) / (g * D**3 * sm1)\n",
+    "F1 = ((2.0 / 3.0) + term) ** 0.5 - term**0.5\n",
+    "print(\"F1 =\", F1)"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "a = 5.0  # width-discharge factor, SI\n",
     "\n",
     "ksq = a * F1 * g**0.5 * ((40.0 * n**4.5) / (sm1**2.5 * D**1.5 * a**4.5))\n",
-    "print('ksq', ksq)"
+    "print(\"ksq\", ksq)"
    ]
   },
   {
@@ -259,10 +259,10 @@
    "outputs": [],
    "source": [
     "R = 2.0  # bankfull runoff rate\n",
-    "I = 0.01 # intermittency factor\n",
+    "I = 0.01  # intermittency factor\n",
     "\n",
     "ks = ksq * I * R**0.9\n",
-    "print('ks', ks)"
+    "print(\"ks\", ks)"
    ]
   },
   {
@@ -282,7 +282,7 @@
    "source": [
     "# Convert ks to time units of years:\n",
     "ksy = ks * 365.25 * 24 * 3600.0\n",
-    "print('ksy', ksy)"
+    "print(\"ksy\", ksy)"
    ]
   },
   {
@@ -316,8 +316,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(1/2.1)\n",
-    "print(.4/2.1)"
+    "print(1 / 2.1)\n",
+    "print(0.4 / 2.1)"
    ]
   },
   {
@@ -338,7 +338,7 @@
     "E = 1.0e-4\n",
     "A = np.array([10.0e6, 100.0e6, 1000.0e6])\n",
     "\n",
-    "print('S=', (E / ksy)**0.48 * A**(-0.19))"
+    "print(\"S=\", (E / ksy) ** 0.48 * A ** (-0.19))"
    ]
   },
   {
@@ -376,13 +376,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Seq = (100.0 / (0.0055 * 1.0e6**1.4))**(1.0/2.1)\n",
+    "Seq = (100.0 / (0.0055 * 1.0e6**1.4)) ** (1.0 / 2.1)\n",
     "elev_eq = Seq * 1000.0\n",
-    "print('Equilibrium slope:', Seq)\n",
-    "print('Equilibrium elevation:', elev_eq)\n",
+    "print(\"Equilibrium slope:\", Seq)\n",
+    "print(\"Equilibrium elevation:\", elev_eq)\n",
     "\n",
     "# test: elevation at the node should be 1,068 cm when rounded to the nearest cm.\n",
-    "print('Rounded elevation in cm:', int(round(elev_eq * 100)))"
+    "print(\"Rounded elevation in cm:\", int(round(elev_eq * 100)))"
    ]
   },
   {
@@ -402,9 +402,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Qs = 0.0055 * (100 * 100)**1.4 * (0.01)**2.1\n",
-    "print('Qs:', Qs)\n",
-    "print('Qs in liters per year (to nearest liter):', int(Qs * 1000))"
+    "Qs = 0.0055 * (100 * 100) ** 1.4 * (0.01) ** 2.1\n",
+    "print(\"Qs:\", Qs)\n",
+    "print(\"Qs in liters per year (to nearest liter):\", int(Qs * 1000))"
    ]
   },
   {
@@ -427,7 +427,7 @@
     "A = 1.0e4 * np.array([3, 2, 1])  # drainage area (m2); flow is right to left\n",
     "Qsout = np.zeros(len(A))\n",
     "Qsin = np.zeros(len(A))\n",
-    "Qsout[1:] = 0.0055 * A[1:]**1.4 * 0.01**2.1  # sediment outflux from each node, m3/y\n",
+    "Qsout[1:] = 0.0055 * A[1:] ** 1.4 * 0.01**2.1  # sediment outflux from each node, m3/y\n",
     "Qsin[:2] = Qsout[1:]  # sediment influx to each node, m3/y\n",
     "dzdt = (Qsin - Qsout) / 1.0e4  # rate of elevation change, m/y\n",
     "print(Qsin)\n",
@@ -439,7 +439,7 @@
     "\n",
     "# test: answer should be array([ 0.365,  0.138,  0.   ])\n",
     "print(np.round(Qsin, 3))\n",
-    "        \n",
+    "\n",
     "# test: answer should be array([ -2.26400000e-05,  -1.38200000e-05])\n",
     "print(np.round(dzdt[1:], 8))"
    ]

--- a/notebooks/tutorials/landscape_evolution/area_slope_transporter/transport-limited-LEM-example.ipynb
+++ b/notebooks/tutorials/landscape_evolution/area_slope_transporter/transport-limited-LEM-example.ipynb
@@ -65,8 +65,7 @@
     "import matplotlib.pyplot as plt\n",
     "import time\n",
     "from landlab import RasterModelGrid, imshow_grid\n",
-    "from landlab.components import (FlowAccumulator,\n",
-    "                                AreaSlopeTransporter)"
+    "from landlab.components import FlowAccumulator, AreaSlopeTransporter"
    ]
   },
   {
@@ -121,9 +120,9 @@
    "outputs": [],
    "source": [
     "# Create and initialize elevation field\n",
-    "elev = grid.add_zeros('topographic__elevation', at='node')\n",
-    "elev[grid.core_nodes] = (\n",
-    "    initial_height + noise_amplitude * np.random.rand(grid.number_of_core_nodes)\n",
+    "elev = grid.add_zeros(\"topographic__elevation\", at=\"node\")\n",
+    "elev[grid.core_nodes] = initial_height + noise_amplitude * np.random.rand(\n",
+    "    grid.number_of_core_nodes\n",
     ")"
    ]
   },
@@ -135,7 +134,7 @@
    "outputs": [],
    "source": [
     "# Instantiate components\n",
-    "fa = FlowAccumulator(grid, flow_director='FlowDirectorD8')\n",
+    "fa = FlowAccumulator(grid, flow_director=\"FlowDirectorD8\")\n",
     "ast = AreaSlopeTransporter(grid)"
    ]
   },
@@ -154,7 +153,7 @@
     "    elapsed_time += dt\n",
     "\n",
     "wall_time = time.time() - start\n",
-    "print('Wall time for run:', wall_time, 's')"
+    "print(\"Wall time for run:\", wall_time, \"s\")"
    ]
   },
   {

--- a/notebooks/tutorials/landscape_evolution/area_slope_transporter/transport-limited-LEM-example.ipynb
+++ b/notebooks/tutorials/landscape_evolution/area_slope_transporter/transport-limited-LEM-example.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9b421a81",
+   "metadata": {},
+   "source": [
+    "# Example of a transport-limited LEM using `AreaSlopeTransporter`\n",
+    "\n",
+    "*(Greg Tucker, University of Colorado Boulder, October 2022)*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff205964",
+   "metadata": {},
+   "source": [
+    "This tutorial notebook illustrates how to use the Landlab `AreaSlopeTransporter` component to create a simple transport-limited Landscape Evolution Model (LEM)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70d31294",
+   "metadata": {},
+   "source": [
+    "## Background\n",
+    "\n",
+    "The `AreaSlopeTransporter` is a landscape evolution component that models the time rate of change of elevation at a set of grid nodes, each of which has a defined contributing drainage area $A$ (field `drainage_area`) and a local steepest-descent slope gradient, $S$, defined from the node itself toward one of its neighboring nodes. The drainage area and slope can be computed with a drainage-routing component such as `FlowAccumulator` or `PriorityFloodFlowAccumulator`. The component is designed to function as an integral part of a transport-limited landscape evolution model in the spirit of Willgoose et al. (1991a,b,c,d).\n",
+    "\n",
+    "Once $A$ and $S$ have been calculated, the volumetric outgoing sediment flux at each grid node is calculated using\n",
+    "\n",
+    "$$Q_{out} = k_s A^m S^n$$\n",
+    "\n",
+    "The component's default parameters are $m=1.4$, $n=2.1$, and $k_s = 0.0055$ (with time units of years). These defaults are based on Willgoose et al. (1991a), who used the Einstein-Brown sediment transport formula as a basis, but here modified to include an empirical sub-grid-cell channel width. The derivation is provided in a separate notebook (see *einstein-brown.ipynb*). The essence of the odd-seeming exponent values is this: Einstein-Brown describes a cubic dependence on shear stress, which essentially has a 2/3 power dependence on slope gradient. That gets you the power 2; the extra 0.1 shows up because of the use of the Manning equation to describe roughness, in which the roughness factor has a slight depenence on flow depth. The 1.4 exponent on drainage area has a similar story, with one difference from Willgoose et al. (1991a) (who used a 1.8 power) being the assumption that bankfull width is proportional to the square root of discharge. The derivation in the *einstein-brown.ipynb* notebook describes how that leads to 1.4 power scaling. Note that Howard (1994) also used Einstein-Brown as the basis for an alluvial-channel element of an otherwise detachment-limited landscape evolution model.\n",
+    "\n",
+    "The time rate of change of elevation is calculated over a grid cell at node $i$ with surface area $\\Lambda_i$, such that mass continuity gives the time rate of elevation ($z_i$) change (in the absence of other processes) as:\n",
+    "\n",
+    "$$\\frac{dz_i}{dt} = \\frac{Q_{in} - Q_{out}}{\\Lambda_i}$$\n",
+    "\n",
+    "The sediment influx at each node is calculated as the sum of outflux of all upstream neighbor nodes that flow to it.\n",
+    "\n",
+    "Note that this is a no-frills component, at least as of this writing. It uses only drainage area (not discharge, even if calculated). It uses a very basic forward-Euler solution algorithm, and so it requires very small time steps. There is no adaptive solver. It is designed mainly for illustrative purposes: to show how a basic transport-limited area-slope LEM behaves. As with all Landlab components, the user should understand the theory and be familiar with the background literature!\n",
+    "\n",
+    "*This Landlab component is dedicated to the memory of two remarkable hydrologists: Garry Willgoose and Ignacio Rodriguez-Iturbe.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6cbe7a3",
+   "metadata": {},
+   "source": [
+    "## Example\n",
+    "\n",
+    "The example uses a very small (15 x 15) domain, initially uplifted 25 m above the baselevel, which is represented by a single node in one corner of the grid. The small domain and short run duration are meant to keep the total run time under a second or so, depending on the computer architecture. The user is encouraged to experiment with larger domains and longer run durations, but beware that in general the larger the domain, the smaller the time-step size will need to be to ensure numerical stability. (If the concept of numerical instability is unfamiliar, then consultation of a textbook and/or online resources on numerical methods for partial differential equations is highly recommended.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef70cf46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import time\n",
+    "from landlab import RasterModelGrid, imshow_grid\n",
+    "from landlab.components import (FlowAccumulator,\n",
+    "                                AreaSlopeTransporter)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3664da8e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "nrows = 15  # number of node rows\n",
+    "ncols = 15  # number of node columns\n",
+    "dx = 20.0  # grid node spacing, m\n",
+    "run_duration = 4000.0  # run duration, y\n",
+    "dt = 2.5  # time-step duration, y\n",
+    "noise_amplitude = 1.0  # amplitude of initial random noise, m\n",
+    "initial_height = 25.0  # initial plateau height, m\n",
+    "seed = 1  # random seed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf1867e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Control and derived parameters, and other setup\n",
+    "elapsed_time = 0.0\n",
+    "next_output = output_interval\n",
+    "np.random.seed(seed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "691db7bb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize grid and set boundary conditions\n",
+    "grid = RasterModelGrid((nrows, ncols), xy_spacing=dx)\n",
+    "grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED\n",
+    "grid.status_at_node[ncols - 1] = grid.BC_NODE_IS_FIXED_VALUE  # corner outlet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2291edd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create and initialize elevation field\n",
+    "elev = grid.add_zeros('topographic__elevation', at='node')\n",
+    "elev[grid.core_nodes] = (\n",
+    "    initial_height + noise_amplitude * np.random.rand(grid.number_of_core_nodes)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6fe14526",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate components\n",
+    "fa = FlowAccumulator(grid, flow_director='FlowDirectorD8')\n",
+    "ast = AreaSlopeTransporter(grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df427fce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Main loop\n",
+    "start = time.time()\n",
+    "while elapsed_time < run_duration:\n",
+    "    fa.run_one_step()\n",
+    "    ast.run_one_step(dt)\n",
+    "    elapsed_time += dt\n",
+    "\n",
+    "wall_time = time.time() - start\n",
+    "print('Wall time for run:', wall_time, 's')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0154ba1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the final topography in map view\n",
+    "imshow_grid(grid, elev)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ed48de9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Display the final topography in 3d surface view\n",
+    "X = np.arange(0, dx * ncols, dx)\n",
+    "Y = np.arange(0, dx * nrows, dx)\n",
+    "X, Y = np.meshgrid(X, Y)\n",
+    "\n",
+    "fig, ax = plt.subplots(subplot_kw={\"projection\": \"3d\"})\n",
+    "ax.plot_surface(X, Y, elev.reshape((nrows, ncols)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ae1a623",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    "\n",
+    "Howard, A. D. (1994). A detachment‐limited model of drainage basin evolution. Water resources research, 30(7), 2261-2285.\n",
+    "\n",
+    "Tucker, G. E., & Hancock, G. R. (2010). Modelling landscape evolution. Earth Surface Processes and Landforms, 35(1), 28-50.\n",
+    "\n",
+    "Willgoose, G. (2018). *Principles of soilscape and landscape evolution.* Cambridge University Press.\n",
+    "\n",
+    "Willgoose, G., Bras, R. L., & Rodriguez‐Iturbe, I. (1991a). A coupled channel network growth and hillslope evolution model: 1. Theory. Water Resources Research, 27(7), 1671-1684.\n",
+    "\n",
+    "Willgoose, G., Bras, R. L., & Rodriguez‐Iturbe, I. (1991b). A coupled channel network growth and hillslope evolution model: 2. Nondimensionalization and applications. Water Resources Research, 27(7), 1685-1696.\n",
+    "\n",
+    "Willgoose, G., Bras, R. L., & Rodriguez‐Iturbe, I. (1991c). A physical explanation of an observed link area‐slope relationship. Water Resources Research, 27(7), 1697-1702.\n",
+    "\n",
+    "Willgoose, G., Bras, R. L., & Rodriguez‐Iturbe, I. (1991d). Results from a new model of river basin evolution. Earth Surface Processes and Landforms, 16(3), 237-254.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Description

This PR introduces a new, bare-bones landscape evolution component called `AreaSlopeTransporter`. 

The `AreaSlopeTransporter` is a landscape evolution component that models the time rate of change of elevation at a set of grid nodes, each of which has a defined contributing drainage area $A$ (field `drainage_area`) and a local steepest-descent slope gradient, $S$, defined from the node itself toward one of its neighboring nodes. The drainage area and slope can be computed with a drainage-routing component such as `FlowAccumulator` or `PriorityFloodFlowAccumulator`. The component is designed to function as an integral part of a transport-limited landscape evolution model in the spirit of Willgoose et al. (1991a,b,c,d).

Once $A$ and $S$ have been calculated, the volumetric outgoing sediment flux at each grid node is calculated using 

$Q_{out} = k_s A^m S^n$

The component's default parameters are $m=1.4$, $n=2.1$, and $k_s = 0.0055$ (with time units of years). These defaults are based on Willgoose et al. (1991a), who used the Einstein-Brown sediment transport formula as a basis, but here modified to include an empirical sub-grid-cell channel width. The derivation is provided in an accompanying notebook (*einstein-brown.ipynb*). A tutorial notebook (*transport-limited-LEM-example.ipynb*) shows how to use the component.

The time rate of change of elevation is calculated over a grid cell at node $i$ with surface area $\Lambda_i$, such that mass continuity gives the time rate of elevation ($z_i$) change (in the absence of other processes) as:

$\frac{dz_i}{dt} = \frac{Q_{in} - Q_{out}}{\Lambda_i}$

The sediment influx at each node is calculated as the sum of outflux of all upstream neighbor nodes that flow to it.

Note that this is a no-frills component, at least as of this initial version. It uses only drainage area (not discharge, even if calculated). It uses a very basic forward-Euler solution algorithm, and so it requires very small time steps. There is no adaptive solver. It is designed mainly for illustrative purposes: to show how a basic transport-limited area-slope LEM behaves. As with all Landlab components, the user should understand the theory and be familiar with the background literature!

*This Landlab component is dedicated to the memory of two remarkable hydrologists: Garry Willgoose and Ignacio Rodriguez-Iturbe.*



### Checklist

- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [X] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [X] All tests have passed?
- [X] Formatted code with black?
- [X] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)



