### PR TITLE
misc: allow clobber of field in ListricKinematicExtender

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -21,6 +21,7 @@ from .flow_director import (
 )
 from .fracture_grid import FractureGridGenerator
 from .gflex import gFlex
+from .gravel_bedrock_eroder import GravelBedrockEroder
 from .gravel_river_transporter import GravelRiverTransporter
 from .groundwater import GroundwaterDupuitPercolator
 from .hack_calculator import HackCalculator
@@ -96,6 +97,7 @@ COMPONENTS = [
     FlowDirectorSteepest,
     FractureGridGenerator,
     gFlex,
+    GravelBedrockEroder,
     GravelRiverTransporter,
     GroundwaterDupuitPercolator,
     HackCalculator,

--- a/landlab/components/gravel_bedrock_eroder/__init__.py
+++ b/landlab/components/gravel_bedrock_eroder/__init__.py
@@ -1,0 +1,3 @@
+from .gravel_bedrock_eroder import GravelBedrockEroder
+
+__all__ = ["GravelBedrockEroder"]

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -1,0 +1,547 @@
+import numpy as np
+from scipy.sparse.linalg import spsolve
+
+from landlab import Component, HexModelGrid
+from landlab.grid.diagonals import DiagonalsMixIn
+
+
+def make_empty_matrix_and_rhs(grid):
+    from scipy.sparse import csc_matrix
+
+    mat = csc_matrix((grid.number_of_core_nodes, grid.number_of_core_nodes))
+    rhs = np.zeros(grid.number_of_core_nodes)
+    return mat, rhs
+
+
+def zero_out_matrix(grid, mat, rcvr, mat_id):
+    for i in grid.core_nodes:
+        j = mat_id[i]
+        mat[j, j] = 0.0
+        r = rcvr[i]
+        if grid.status_at_node[r] == grid.BC_NODE_IS_CORE:
+            k = mat_id[r]
+            mat[j, k] = 0.0
+            mat[k, k] = 0.0
+            mat[k, j] = 0.0
+
+
+class GravelRiverTransporter(Component):
+    """Model drainage network evolution for a network of transport-limited
+    gravel-bed rivers with downstream abrasion.
+
+    GravelRiverTransporter is designed to operate together with a flow-routing
+    component such as PriorityFloodFlowRouter, so that each grid node has
+    a defined flow direction toward one of its neighbor nodes. Each core node
+    is assumed to contain one outgoing fluvial channel, and (depending on
+    the drainage structure) zero, one, or more incoming channels. These channels are
+    treated as effectively sub-grid-scale features that are embedded in valleys
+    that have a width of one grid cell. The rate of gravel transport out of
+    a given node is calculated as the product of bankfull discharge, channel
+    gradient (to the 7/6 power), a dimensionless transport coefficient, and
+    an intermittency factor that represents the fraction of time that bankfull
+    flow occurs. The derivation of the transport law is given by Wickert &
+    Schildgen (2019), and it derives from the assumption that channels are
+    gravel-bedded and that they "instantaneously" adjust their width such that
+    bankfull bed shear stress is just slightly higher than the threshold for
+    grain motion. The substrate is assumed to consist entirely of gravel-size
+    material with a given bulk porosity. The component calculates the loss of
+    gravel-sized material to abrasion (i.e., conversion to finer sediment, which
+    is not explicitly tracked) as a function of the volumetric transport rate,
+    an abrasion coefficient with units of inverse length, and the local transport
+    distance (for example, if a grid node is carrying a gravel load Qs to a
+    neighboring node dx meters downstream, the rate of gravel loss in volume per
+    time per area at the node will be beta Qs dx, where beta is the abrasion
+    coefficient). Sediment mass conservation is calculated across each entire
+    grid cell. For example, if a cell has surface area A, a total volume influx
+    Qin, and downstream transport rate Qs, the resulting rate of change of
+    elevation will be (Qin - Qs / (A (1 - phi)), where phi is porosity.
+
+    Parameters
+    ----------
+    grid : ModelGrid
+        A Landlab model grid object
+    intermittency_factor : float (default 0.01)
+        Fraction of time that bankfull flow occurs
+    transport_coefficient : float (default 0.041)
+        Dimensionless transport efficiency factor (see Wickert & Schildgen 2019)
+    abrasion_coefficient : float (default 0.0 1/m)
+        Abrasion coefficient with units of inverse length
+    sediment_porosity : float (default 0.35)
+        Bulk porosity of bed sediment
+    solver : string (default "explicit")
+        Solver type (currently only "explicit" is tested and operational)
+
+    Examples
+    --------
+    >>> from landlab import RasterModelGrid
+    >>> from landlab.components import FlowAccumulator
+    >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
+    >>> elev = grid.add_zeros("topographic__elevation", at="node")
+    >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+    >>> grid.status_at_node[5] = grid.BC_NODE_IS_FIXED_VALUE
+    >>> fa = FlowAccumulator(grid, runoff_rate=10.0)
+    >>> fa.run_one_step()
+    >>> transporter = GravelRiverTransporter(grid, abrasion_coefficient=0.0005)
+    >>> for _ in range(200):
+    ...     fa.run_one_step()
+    ...     elev[grid.core_nodes] += 1.0
+    ...     transporter.run_one_step(10000.0)
+    >>> int(elev[4] * 100)
+    2366
+    """
+
+    _ONE_SIXTH = 1.0 / 6.0
+
+    _name = "GravelRiverTransporter"
+
+    _unit_agnostic = True
+
+    _info = {
+        "bedload_sediment__rate_of_loss_to_abrasion": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m/y",
+            "mapping": "node",
+            "doc": "Rate of bedload sediment volume loss to abrasion per unit area",
+        },
+        "bedload_sediment__volume_influx": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**2/y",
+            "mapping": "node",
+            "doc": "Volumetric incoming streamwise bedload sediment transport rate",
+        },
+        "bedload_sediment__volume_outflux": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**2/y",
+            "mapping": "node",
+            "doc": "Volumetric outgoing streamwise bedload sediment transport rate",
+        },
+        "flow__link_to_receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "ID of link downstream of each node, which carries the discharge",
+        },
+        "flow__receiver_node": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array of receivers (node that receives flow from current node)",
+        },
+        "flow__upstream_node_order": {
+            "dtype": int,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array containing downstream-to-upstream ordered list of node IDs",
+        },
+        "sediment__rate_of_change": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m/y",
+            "mapping": "node",
+            "doc": "Time rate of change of sediment thickness",
+        },
+        "surface_water__discharge": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "m**3/y",
+            "mapping": "node",
+            "doc": "Volumetric discharge of surface water",
+        },
+        "topographic__elevation": {
+            "dtype": float,
+            "intent": "inout",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Land surface topographic elevation",
+        },
+        "topographic__steepest_slope": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "The steepest *downhill* slope",
+        },
+    }
+
+    def __init__(
+        self,
+        grid,
+        intermittency_factor=0.01,
+        transport_coefficient=0.041,
+        abrasion_coefficient=0.0,
+        sediment_porosity=0.35,
+        solver="explicit",
+    ):
+        """Initialize GravelRiverTransporter."""
+
+        super().__init__(grid)
+
+        # Parameters
+        self._trans_coef = transport_coefficient
+        self._intermittency_factor = intermittency_factor
+        self._abrasion_coef = abrasion_coefficient
+        self._porosity_factor = 1.0 / (1.0 - sediment_porosity)
+
+        # Fields and arrays
+        self._elev = grid.at_node["topographic__elevation"]
+        self._discharge = grid.at_node["surface_water__discharge"]
+        self._slope = grid.at_node["topographic__steepest_slope"]
+        self._receiver_node = grid.at_node["flow__receiver_node"]
+        self._receiver_link = grid.at_node["flow__link_to_receiver_node"]
+        super().initialize_output_fields()
+        self._sediment_influx = grid.at_node["bedload_sediment__volume_influx"]
+        self._sediment_outflux = grid.at_node["bedload_sediment__volume_outflux"]
+        self._dzdt = grid.at_node["sediment__rate_of_change"]
+        self._abrasion = grid.at_node["bedload_sediment__rate_of_loss_to_abrasion"]
+
+        # Constants
+        self._SEVEN_SIXTHS = 7.0 / 6.0
+
+        # Solver type
+        if solver == "explicit":
+            self.run_one_step = self.run_one_step_simple_explicit
+        elif solver == "matrix":
+            import warnings
+
+            from landlab.utils.matrix import get_core_node_at_node
+
+            warnings.warn("Matrix-based solver is experimental & not fully tested")
+            self.run_one_step = self.run_one_step_matrix_inversion
+            self._mat, self._rhs = make_empty_matrix_and_rhs(grid)
+            self._mat_id = np.zeros(grid.number_of_nodes, dtype=int)
+            self._mat_id = get_core_node_at_node(grid)
+        else:
+            raise ValueError("Solver type not recognized")
+
+        self._setup_length_of_flow_link()
+
+    def _setup_length_of_flow_link(self):
+        """Set up a float or array containing length of the flow link from each node,
+        which is needed for the abrasion rate calculations.
+        """
+        if isinstance(self.grid, HexModelGrid):
+            self._flow_link_length_over_cell_area = (
+                self.grid.spacing / self.grid.area_of_cell[0]
+            )
+            self._flow_length_is_variable = False
+        elif isinstance(self.grid, DiagonalsMixIn):
+            self._flow_length_is_variable = True
+            self._grid_has_diagonals = True
+        else:
+            self._flow_length_is_variable = True
+            self._grid_has_diagonals = False
+
+    def _update_flow_link_length_over_cell_area(self):
+        """Update the ratio of the length of link along which water flows out of
+        each node to the area of the node's cell."""
+        if self._grid_has_diagonals:
+            self._flow_link_length_over_cell_area = (
+                self.grid.length_of_d8[self._receiver_link[self.grid.core_nodes]]
+                / self.grid.area_of_cell[self.grid.cell_at_node[self.grid.core_nodes]]
+            )
+        else:
+            self._flow_link_length_over_cell_area = (
+                self.grid.length_of_link[self._receiver_link[self.grid.core_nodes]]
+                / self.grid.area_of_cell[self.grid.cell_at_node[self.grid.core_nodes]]
+            )
+
+    def calc_implied_depth(self, grain_diameter=0.01):
+        """Utility function that calculates and returns water depth implied by
+        slope and grain diameter, using Wickert & Schildgen (2019) equation 8.
+
+        The equation is
+
+            h = ((rho_s - rho / rho)) (1 + epsilon) tau_c* (D / S)
+
+        where the factors on the right are sediment and water density, excess
+        shear-stress factor, critical Shields stress, grain diameter, and slope
+        gradient. Here the prefactor on D/S assumes sediment density of 2650 kg/m3,
+        water density of 1000 kg/m3, shear-stress factor of 0.2, and critical
+        Shields stress of 0.0495, giving a value of 0.09801.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[3:] = 10.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid)
+        >>> depth = transporter.calc_implied_depth()
+        >>> int(depth[4] * 1000)
+        98
+        """
+        DEPTH_FACTOR = 0.09801
+        depth = np.zeros(self._grid.number_of_nodes)
+        nonzero_slope = self._slope > 0.0
+        depth[nonzero_slope] = (
+            DEPTH_FACTOR * grain_diameter / self._slope[nonzero_slope]
+        )
+        return depth
+
+    def calc_implied_width(self, grain_diameter=0.01, time_unit="y"):
+        """Utility function that calculates and returns channel width implied by
+        discharge, slope, and grain diameter, using Wickert & Schildgen (2019)
+        equation 16.
+
+        The equation is
+
+            b = kb Q S**(7/6) / D**(3/2)
+
+        where the dimensional prefactor, which includes sediment and water
+        density, gravitational acceleration, critical Shields stress, and the
+        transport factor epsilon, is
+
+            kb = 0.17 g**(-1/2) (((rho_s - rho) / rho) (1 + eps) tau_c*)**(-5/3)
+
+        Using g = 9.8 m/s2, rho_s = 2650 (quartz), rho = 1000 kg/m3, eps = 0.2,
+        and tau_c* = 0.0495, kb ~ 2.61 s/m**(1/2). Converting to years,
+        kb = 8.26e-8.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=10000.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[3:] = 100.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid)
+        >>> width = transporter.calc_implied_width()
+        >>> int(width[4] * 100)
+        3833
+        >>> grid.at_node["surface_water__discharge"] *= 1. / (3600 * 24 * 365.25)
+        >>> width = transporter.calc_implied_width(time_unit="s")
+        >>> int(width[4] * 100)
+        3838
+        """
+        if time_unit[0] == "y":
+            width_fac = 8.26e-8
+        else:
+            width_fac = 2.61  # assume seconds if not years
+        width = np.zeros(self._grid.number_of_nodes)
+        width = (
+            width_fac
+            * self._discharge
+            * self._slope ** (7.0 / 6.0)
+            / (grain_diameter**1.5)
+        )
+        return width
+
+    def calc_transport_capacity(self):
+        """Calculate and return bed-load transport capacity.
+
+        Calculation uses Wickert-Schildgen approach, and provides
+        volume per time rate.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[3:] = 1.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid)
+        >>> transporter.calc_transport_capacity()
+        >>> round(transporter._sediment_outflux[4], 4)
+        0.019
+        """
+        self._sediment_outflux[:] = (
+            self._trans_coef
+            * self._intermittency_factor
+            * self._discharge
+            * self._slope**self._SEVEN_SIXTHS
+        )
+
+    def calc_abrasion_rate(self):
+        """Update the rate of bedload loss to abrasion, per unit area.
+
+        Here we use the average of incoming and outgoing sediment flux to
+        calculate the loss rate to abrasion.
+
+        The factor dx (node spacing) appears in the denominator to represent
+        flow segment length (i.e., length of the link along which water is
+        flowing in the cell) divided by cell area. This would need to be updated
+        to handle non-raster and/or non-uniform grids.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[3:] = 10.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid, abrasion_coefficient=0.0002)
+        >>> transporter.calc_transport_capacity()
+        >>> transporter.calc_abrasion_rate()
+        >>> int(transporter._abrasion[4] * 1e8)
+        19
+        """
+        cores = self._grid.core_nodes
+        if self._flow_length_is_variable:
+            self._update_flow_link_length_over_cell_area()
+        self._abrasion[cores] = (
+            self._abrasion_coef
+            * 0.5
+            * (self._sediment_outflux[cores] + self._sediment_influx[cores])
+            * self._flow_link_length_over_cell_area
+        )
+
+    def calc_sediment_rate_of_change(self):
+        """Update the rate of thickness change of coarse sediment at each core node.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid)
+        >>> transporter.calc_sediment_rate_of_change()
+        >>> np.round(transporter._sediment_outflux[4:7], 3)
+        array([ 0.   ,  0.038,  0.019])
+        >>> np.round(transporter._sediment_influx[4:7], 3)
+        array([ 0.038,  0.019,  0.   ])
+        >>> np.round(transporter._dzdt[5:7], 8)
+        array([ -2.93000000e-06,  -2.93000000e-06])
+        """
+        self.calc_transport_capacity()
+        if self._abrasion_coef > 0.0:
+            self.calc_abrasion_rate()
+        cores = self.grid.core_nodes
+        self._sediment_influx[:] = 0.0
+        for c in cores:  # send sediment downstream
+            r = self._receiver_node[c]
+            self._sediment_influx[r] += self._sediment_outflux[c]
+        self._dzdt[cores] = self._porosity_factor * (
+            (self._sediment_influx[cores] - self._sediment_outflux[cores])
+            / self.grid.area_of_cell[self.grid.cell_at_node[cores]]
+            - self._abrasion[cores]
+        )
+
+    def run_one_step_simple_explicit(self, dt):
+        """Advance solution by time interval dt.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid, solver="explicit")
+        >>> transporter.run_one_step(1000.0)
+        >>> np.round(elev[4:7], 4)
+        array([ 0.    ,  0.9971,  1.9971])
+        """
+        self.calc_sediment_rate_of_change()
+        self._elev += self._dzdt * dt
+
+    def _fill_matrix_and_rhs(self, dt):
+        """Fill out entries in a sparse matrix and corresponding right-hand side
+        vector.
+
+        Examples
+        --------
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> transporter = GravelRiverTransporter(grid, solver="matrix")
+        >>> transporter._mat.toarray()
+        array([[ 0.,  0.],
+               [ 0.,  0.]])
+        >>> fa.run_one_step()
+        >>> transporter._receiver_node[5:7]
+        array([4, 5])
+        >>> transporter._fill_matrix_and_rhs(1000.0)
+        >>> transporter._rhs
+        array([ 1.,  2.])
+        """
+        prefac = (
+            self._trans_coef * self._intermittency_factor * self._porosity_factor * dt
+        ) / self.grid.dx**2
+        a = prefac * (1.0 / self.grid.dx + self._abrasion_coef / 2)
+        b = prefac * (1.0 / self.grid.dx - self._abrasion_coef / 2)
+        f = self._discharge * (self._slope ** (self._ONE_SIXTH))
+
+        zero_out_matrix(self.grid, self._mat, self._receiver_node, self._mat_id)
+        for i in self.grid.core_nodes:
+            j = self._mat_id[i]
+            self._rhs[j] = self._elev[i]
+            self._mat[j, j] += 1 + a * f[i]
+            r = self._receiver_node[i]
+            if self.grid.status_at_node[r] == self.grid.BC_NODE_IS_CORE:
+                k = self._mat_id[r]
+                self._mat[j, k] -= a * f[i]
+                self._mat[k, k] += b * f[i]
+                self._mat[k, j] -= b * f[i]
+            else:
+                self._rhs[j] += a * f[i] * self._elev[r]
+
+    def run_one_step_matrix_inversion(self, dt):
+        """Advance solution by time interval dt.
+
+        WARNING: EXPERIMENTAL AND NOT FULLY TESTED - USE AT OWN RISK!
+
+        Notes
+        -----
+        Does not update abrasion rate or sediment outflux fields.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
+        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> transporter = GravelRiverTransporter(grid, solver="matrix")
+        >>> transporter.run_one_step == transporter.run_one_step_matrix_inversion
+        True
+        >>> transporter.run_one_step(1000.0)
+        """
+        self._fill_matrix_and_rhs(dt)
+        self._elev[self.grid.core_nodes] = spsolve(self._mat, self._rhs)

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -553,6 +553,13 @@ class GravelBedrockEroder(Component):
             * self._rock_exposure_fraction
         )
 
+    def calc_sediment_influx(self):
+        """Update the volume influx at each node."""
+        self._sediment_influx[:] = 0.0
+        for c in self.grid.core_nodes:  # send sediment downstream
+            r = self._receiver_node[c]
+            self._sediment_influx[r] += self._sediment_outflux[c]
+
     def calc_sediment_rate_of_change(self):
         """Update the rate of thickness change of coarse sediment at each core node.
 
@@ -572,6 +579,7 @@ class GravelBedrockEroder(Component):
         >>> fa.run_one_step()
         >>> eroder = GravelBedrockEroder(grid)
         >>> eroder.calc_transport_capacity()
+        >>> eroder.calc_sediment_influx()
         >>> eroder.calc_sediment_rate_of_change()
         >>> np.round(eroder._sediment_outflux[4:7], 3)
         array([ 0.   ,  0.038,  0.019])
@@ -581,10 +589,6 @@ class GravelBedrockEroder(Component):
         array([ -2.93000000e-06,  -2.93000000e-06])
         """
         cores = self.grid.core_nodes
-        self._sediment_influx[:] = 0.0
-        for c in cores:  # send sediment downstream
-            r = self._receiver_node[c]
-            self._sediment_influx[r] += self._sediment_outflux[c]
         self._dHdt[cores] = self._porosity_factor * (
             (self._sediment_influx[cores] - self._sediment_outflux[cores])
             / self.grid.area_of_cell[self.grid.cell_at_node[cores]]
@@ -616,6 +620,7 @@ class GravelBedrockEroder(Component):
         """
         self.calc_rock_exposure_fraction()
         self.calc_transport_capacity()
+        self.calc_sediment_influx()
         self.calc_bedrock_plucking_rate()
         if self._abrasion_coef > 0.0:
             self.calc_abrasion_rate()

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -385,7 +385,24 @@ class GravelBedrockEroder(Component):
     def calc_rock_exposure_fraction(self):
         """Update the bedrock exposure fraction.
 
-        TODO: ADD TEST(S)
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[4] = 1000.0
+        >>> sed[5] = 0.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> eroder.calc_rock_exposure_fraction()
+        >>> eroder._rock_exposure_fraction[4:6]
+        array([ 0.,  1.])
+        >>> sed[4] = 1.0  # exposure frac should be 1/e ~ 0.3679
+        >>> sed[5] = 2.0  # exposure frac should be 1/e^2 ~ 0.1353
+        >>> eroder.calc_rock_exposure_fraction()
+        >>> np.round(eroder._rock_exposure_fraction[4:6], 4)
+        array([ 0.3679,  0.1353])
         """
         self._rock_exposure_fraction = np.exp(-self._sed / self._depth_decay_scale)
 

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -616,6 +616,8 @@ class GravelBedrockEroder(Component):
         >>> np.round(elev[4:7], 4)
         array([ 0.    ,  0.9971,  1.9971])
         """
+        self.calc_rock_exposure_fraction()
         self.calc_sediment_rate_of_change()
+        #self.calc_bedrock_lowering_rate() TODO: ADD THIS FN
         self._sed += self._dHdt * dt
         self._elev[:] = self._bedrock__elevation + self._sed

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -472,7 +472,23 @@ class GravelBedrockEroder(Component):
     def calc_bedrock_plucking_rate(self):
         """Update the rate of bedrock erosion by plucking.
 
-        TODO: ADD TEST(S) HERE
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 3), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[4] = 1.0
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> eroder.calc_rock_exposure_fraction()
+        >>> eroder.calc_bedrock_plucking_rate()
+        >>> predicted_plucking_rate = 1.0e-6 * 1.0e4 * 0.01**(7./ 6.)
+        >>> round(predicted_plucking_rate, 9)  # Kp Q S^(7/6)
+        4.6416e-05
+        >>> int(round(eroder._pluck_rate[4] * 1e9))
+        46416
         """
         self._pluck_rate = (
             self._plucking_coef

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -1,41 +1,21 @@
 import numpy as np
-from scipy.sparse.linalg import spsolve
-
 from landlab import Component, HexModelGrid
 from landlab.grid.diagonals import DiagonalsMixIn
 
 
-def make_empty_matrix_and_rhs(grid):
-    from scipy.sparse import csc_matrix
+class GravelBedrockEroder(Component):
+    """Model drainage network evolution for a network of rivers that have
+    a layer of gravel alluvium overlying bedrock.
 
-    mat = csc_matrix((grid.number_of_core_nodes, grid.number_of_core_nodes))
-    rhs = np.zeros(grid.number_of_core_nodes)
-    return mat, rhs
-
-
-def zero_out_matrix(grid, mat, rcvr, mat_id):
-    for i in grid.core_nodes:
-        j = mat_id[i]
-        mat[j, j] = 0.0
-        r = rcvr[i]
-        if grid.status_at_node[r] == grid.BC_NODE_IS_CORE:
-            k = mat_id[r]
-            mat[j, k] = 0.0
-            mat[k, k] = 0.0
-            mat[k, j] = 0.0
-
-
-class GravelRiverTransporter(Component):
-    """Model drainage network evolution for a network of transport-limited
-    gravel-bed rivers with downstream abrasion.
-
-    GravelRiverTransporter is designed to operate together with a flow-routing
-    component such as PriorityFloodFlowRouter, so that each grid node has
+    GravelBedrockEroder is designed to operate together with a flow-routing
+    component such as FlowAccumulator, so that each grid node has
     a defined flow direction toward one of its neighbor nodes. Each core node
     is assumed to contain one outgoing fluvial channel, and (depending on
     the drainage structure) zero, one, or more incoming channels. These channels are
     treated as effectively sub-grid-scale features that are embedded in valleys
-    that have a width of one grid cell. The rate of gravel transport out of
+    that have a width of one grid cell.
+
+    As with the GravelRiverTransporter component, the rate of gravel transport out of
     a given node is calculated as the product of bankfull discharge, channel
     gradient (to the 7/6 power), a dimensionless transport coefficient, and
     an intermittency factor that represents the fraction of time that bankfull
@@ -51,10 +31,20 @@ class GravelRiverTransporter(Component):
     distance (for example, if a grid node is carrying a gravel load Qs to a
     neighboring node dx meters downstream, the rate of gravel loss in volume per
     time per area at the node will be beta Qs dx, where beta is the abrasion
-    coefficient). Sediment mass conservation is calculated across each entire
+    coefficient).
+
+    Sediment mass conservation is calculated across each entire
     grid cell. For example, if a cell has surface area A, a total volume influx
     Qin, and downstream transport rate Qs, the resulting rate of change of
-    elevation will be (Qin - Qs / (A (1 - phi)), where phi is porosity.
+    alluvium thickness will be (Qin - Qs / (A (1 - phi)), plus gravel produced by
+    plucking erosion of bedrock (phi is porosity).
+
+    Bedrock is eroded by a combination of abrasion and plucking. Abrasion per unit
+    channel length is calculated as the product of volumetric sediment discharge
+    and an abrasion coefficient. Sediment produced by abrasion is assumed to
+    go into wash load that is removed from the model domain. Plucking is calculated
+    using a discharge-slope expression, and a user-defined fraction of plucked
+    material is added to the coarse alluvium.
 
     Parameters
     ----------
@@ -68,8 +58,8 @@ class GravelRiverTransporter(Component):
         Abrasion coefficient with units of inverse length
     sediment_porosity : float (default 0.35)
         Bulk porosity of bed sediment
-    solver : string (default "explicit")
-        Solver type (currently only "explicit" is tested and operational)
+    depth_decay_scale : float (default 1.0)
+        Scale for depth decay in bedrock exposure function
 
     Examples
     --------
@@ -77,22 +67,24 @@ class GravelRiverTransporter(Component):
     >>> from landlab.components import FlowAccumulator
     >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
     >>> elev = grid.add_zeros("topographic__elevation", at="node")
+    >>> sed = grid.add_zeros("soil__depth", at="node")
+    >>> sed[4] = 300.0
     >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
     >>> grid.status_at_node[5] = grid.BC_NODE_IS_FIXED_VALUE
     >>> fa = FlowAccumulator(grid, runoff_rate=10.0)
     >>> fa.run_one_step()
-    >>> transporter = GravelRiverTransporter(grid, abrasion_coefficient=0.0005)
+    >>> eroder = GravelBedrockEroder(grid, abrasion_coefficient=0.0005)
     >>> for _ in range(200):
     ...     fa.run_one_step()
     ...     elev[grid.core_nodes] += 1.0
-    ...     transporter.run_one_step(10000.0)
+    ...     eroder.run_one_step(10000.0)
     >>> int(elev[4] * 100)
     2366
     """
 
     _ONE_SIXTH = 1.0 / 6.0
 
-    _name = "GravelRiverTransporter"
+    _name = "GravelBedrockEroder"
 
     _unit_agnostic = True
 
@@ -120,6 +112,14 @@ class GravelRiverTransporter(Component):
             "units": "m**2/y",
             "mapping": "node",
             "doc": "Volumetric outgoing streamwise bedload sediment transport rate",
+        },
+        "bedrock__elevation": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "elevation of the bedrock surface",
         },
         "flow__link_to_receiver_node": {
             "dtype": int,
@@ -152,6 +152,14 @@ class GravelRiverTransporter(Component):
             "units": "m/y",
             "mapping": "node",
             "doc": "Time rate of change of sediment thickness",
+        },
+        "soil__depth": {
+            "dtype": float,
+            "intent": "in",
+            "optional": False,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Depth of soil or weathered bedrock",
         },
         "surface_water__discharge": {
             "dtype": float,
@@ -186,7 +194,7 @@ class GravelRiverTransporter(Component):
         transport_coefficient=0.041,
         abrasion_coefficient=0.0,
         sediment_porosity=0.35,
-        solver="explicit",
+        depth_decay_scale=1.0,
     ):
         """Initialize GravelRiverTransporter."""
 
@@ -197,9 +205,18 @@ class GravelRiverTransporter(Component):
         self._intermittency_factor = intermittency_factor
         self._abrasion_coef = abrasion_coefficient
         self._porosity_factor = 1.0 / (1.0 - sediment_porosity)
+        self._depth_decay_scale = depth_decay_scale
 
         # Fields and arrays
         self._elev = grid.at_node["topographic__elevation"]
+        self._sed = grid.at_node["soil__depth"]
+        if "bedrock__elevation" in grid.at_node:
+            self._bedrock__elevation = grid.at_node["bedrock__elevation"]
+        else:
+            self._bedrock__elevation = grid.add_zeros(
+                "bedrock__elevation", at="node", dtype=float
+            )
+            self._bedrock__elevation[:] = self._elev - self._sed
         self._discharge = grid.at_node["surface_water__discharge"]
         self._slope = grid.at_node["topographic__steepest_slope"]
         self._receiver_node = grid.at_node["flow__receiver_node"]
@@ -212,22 +229,6 @@ class GravelRiverTransporter(Component):
 
         # Constants
         self._SEVEN_SIXTHS = 7.0 / 6.0
-
-        # Solver type
-        if solver == "explicit":
-            self.run_one_step = self.run_one_step_simple_explicit
-        elif solver == "matrix":
-            import warnings
-
-            from landlab.utils.matrix import get_core_node_at_node
-
-            warnings.warn("Matrix-based solver is experimental & not fully tested")
-            self.run_one_step = self.run_one_step_matrix_inversion
-            self._mat, self._rhs = make_empty_matrix_and_rhs(grid)
-            self._mat_id = np.zeros(grid.number_of_nodes, dtype=int)
-            self._mat_id = get_core_node_at_node(grid)
-        else:
-            raise ValueError("Solver type not recognized")
 
         self._setup_length_of_flow_link()
 
@@ -282,18 +283,20 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[3:] = 10.0
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[3:] = 100.0
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid)
-        >>> depth = transporter.calc_implied_depth()
-        >>> int(depth[4] * 1000)
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> water_depth = eroder.calc_implied_depth()
+        >>> int(water_depth[4] * 1000)
         98
         """
-        DEPTH_FACTOR = 0.09801
+        depth_factor = 0.09801
         depth = np.zeros(self._grid.number_of_nodes)
         nonzero_slope = self._slope > 0.0
         depth[nonzero_slope] = (
-            DEPTH_FACTOR * grain_diameter / self._slope[nonzero_slope]
+            depth_factor * grain_diameter / self._slope[nonzero_slope]
         )
         return depth
 
@@ -323,22 +326,23 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 3), xy_spacing=10000.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[3:] = 100.0
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[3:] = 100.0
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid)
-        >>> width = transporter.calc_implied_width()
-        >>> int(width[4] * 100)
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> chan_width = eroder.calc_implied_width()
+        >>> int(chan_width[4] * 100)
         3833
         >>> grid.at_node["surface_water__discharge"] *= 1. / (3600 * 24 * 365.25)
-        >>> width = transporter.calc_implied_width(time_unit="s")
-        >>> int(width[4] * 100)
+        >>> chan_width = eroder.calc_implied_width(time_unit="s")
+        >>> int(chan_width[4] * 100)
         3838
         """
         if time_unit[0] == "y":
             width_fac = 8.26e-8
         else:
             width_fac = 2.61  # assume seconds if not years
-        width = np.zeros(self._grid.number_of_nodes)
         width = (
             width_fac
             * self._discharge
@@ -351,7 +355,10 @@ class GravelRiverTransporter(Component):
         """Calculate and return bed-load transport capacity.
 
         Calculation uses Wickert-Schildgen approach, and provides
-        volume per time rate.
+        volume per time rate. Transport rate is modulated by available
+        sediment, using the exponential function (1 - exp(-H / Hs)),
+        so that transport rate approaches zero as sediment thickness
+        approaches zero.
 
         Examples
         --------
@@ -360,11 +367,13 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 3), xy_spacing=100.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[3:] = 1.0
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[3:] = 100.0
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid)
-        >>> transporter.calc_transport_capacity()
-        >>> round(transporter._sediment_outflux[4], 4)
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> eroder.calc_transport_capacity()
+        >>> round(eroder._sediment_outflux[4], 4)
         0.019
         """
         self._sediment_outflux[:] = (
@@ -372,6 +381,7 @@ class GravelRiverTransporter(Component):
             * self._intermittency_factor
             * self._discharge
             * self._slope**self._SEVEN_SIXTHS
+            * (1.0 - np.exp(-self._sed / self._depth_decay_scale))
         )
 
     def calc_abrasion_rate(self):
@@ -392,12 +402,14 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 3), xy_spacing=1000.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[3:] = 10.0
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[3:] = 100.0
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid, abrasion_coefficient=0.0002)
-        >>> transporter.calc_transport_capacity()
-        >>> transporter.calc_abrasion_rate()
-        >>> int(transporter._abrasion[4] * 1e8)
+        >>> eroder = GravelBedrockEroder(grid, abrasion_coefficient=0.0002)
+        >>> eroder.calc_transport_capacity()
+        >>> eroder.calc_abrasion_rate()
+        >>> int(eroder._abrasion[4] * 1e8)
         19
         """
         cores = self._grid.core_nodes
@@ -421,17 +433,19 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[:] = 0.01 * grid.x_of_node
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[:] = 100.0
         >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
         >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid)
-        >>> transporter.calc_sediment_rate_of_change()
-        >>> np.round(transporter._sediment_outflux[4:7], 3)
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> eroder.calc_sediment_rate_of_change()
+        >>> np.round(eroder._sediment_outflux[4:7], 3)
         array([ 0.   ,  0.038,  0.019])
-        >>> np.round(transporter._sediment_influx[4:7], 3)
+        >>> np.round(eroder._sediment_influx[4:7], 3)
         array([ 0.038,  0.019,  0.   ])
-        >>> np.round(transporter._dzdt[5:7], 8)
+        >>> np.round(eroder._dzdt[5:7], 8)
         array([ -2.93000000e-06,  -2.93000000e-06])
         """
         self.calc_transport_capacity()
@@ -448,7 +462,7 @@ class GravelRiverTransporter(Component):
             - self._abrasion[cores]
         )
 
-    def run_one_step_simple_explicit(self, dt):
+    def run_one_step(self, dt):
         """Advance solution by time interval dt.
 
         Examples
@@ -459,89 +473,16 @@ class GravelRiverTransporter(Component):
         >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
         >>> elev = grid.add_zeros("topographic__elevation", at="node")
         >>> elev[:] = 0.01 * grid.x_of_node
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[:] = 1000.0
         >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
         >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
         >>> fa = FlowAccumulator(grid)
         >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid, solver="explicit")
-        >>> transporter.run_one_step(1000.0)
+        >>> eroder = GravelBedrockEroder(grid)
+        >>> eroder.run_one_step(1000.0)
         >>> np.round(elev[4:7], 4)
         array([ 0.    ,  0.9971,  1.9971])
         """
         self.calc_sediment_rate_of_change()
         self._elev += self._dzdt * dt
-
-    def _fill_matrix_and_rhs(self, dt):
-        """Fill out entries in a sparse matrix and corresponding right-hand side
-        vector.
-
-        Examples
-        --------
-        >>> from landlab import RasterModelGrid
-        >>> from landlab.components import FlowAccumulator
-        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
-        >>> elev = grid.add_zeros("topographic__elevation", at="node")
-        >>> elev[:] = 0.01 * grid.x_of_node
-        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
-        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
-        >>> fa = FlowAccumulator(grid)
-        >>> transporter = GravelRiverTransporter(grid, solver="matrix")
-        >>> transporter._mat.toarray()
-        array([[ 0.,  0.],
-               [ 0.,  0.]])
-        >>> fa.run_one_step()
-        >>> transporter._receiver_node[5:7]
-        array([4, 5])
-        >>> transporter._fill_matrix_and_rhs(1000.0)
-        >>> transporter._rhs
-        array([ 1.,  2.])
-        """
-        prefac = (
-            self._trans_coef * self._intermittency_factor * self._porosity_factor * dt
-        ) / self.grid.dx**2
-        a = prefac * (1.0 / self.grid.dx + self._abrasion_coef / 2)
-        b = prefac * (1.0 / self.grid.dx - self._abrasion_coef / 2)
-        f = self._discharge * (self._slope ** (self._ONE_SIXTH))
-
-        zero_out_matrix(self.grid, self._mat, self._receiver_node, self._mat_id)
-        for i in self.grid.core_nodes:
-            j = self._mat_id[i]
-            self._rhs[j] = self._elev[i]
-            self._mat[j, j] += 1 + a * f[i]
-            r = self._receiver_node[i]
-            if self.grid.status_at_node[r] == self.grid.BC_NODE_IS_CORE:
-                k = self._mat_id[r]
-                self._mat[j, k] -= a * f[i]
-                self._mat[k, k] += b * f[i]
-                self._mat[k, j] -= b * f[i]
-            else:
-                self._rhs[j] += a * f[i] * self._elev[r]
-
-    def run_one_step_matrix_inversion(self, dt):
-        """Advance solution by time interval dt.
-
-        WARNING: EXPERIMENTAL AND NOT FULLY TESTED - USE AT OWN RISK!
-
-        Notes
-        -----
-        Does not update abrasion rate or sediment outflux fields.
-
-        Examples
-        --------
-        >>> import numpy as np
-        >>> from landlab import RasterModelGrid
-        >>> from landlab.components import FlowAccumulator
-        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
-        >>> elev = grid.add_zeros("topographic__elevation", at="node")
-        >>> elev[:] = 0.01 * grid.x_of_node
-        >>> grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED
-        >>> grid.status_at_node[4] = grid.BC_NODE_IS_FIXED_VALUE
-        >>> fa = FlowAccumulator(grid)
-        >>> fa.run_one_step()
-        >>> transporter = GravelRiverTransporter(grid, solver="matrix")
-        >>> transporter.run_one_step == transporter.run_one_step_matrix_inversion
-        True
-        >>> transporter.run_one_step(1000.0)
-        """
-        self._fill_matrix_and_rhs(dt)
-        self._elev[self.grid.core_nodes] = spsolve(self._mat, self._rhs)

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -231,7 +231,7 @@ class GravelBedrockEroder(Component):
         abrasion_coefficient=0.0,
         sediment_porosity=0.35,
         depth_decay_scale=1.0,
-        plucking_coefficient=1.0e-6,
+        plucking_coefficient=1.0e-4,
         coarse_fraction_from_plucking=1.0,
     ):
         """Initialize GravelRiverTransporter."""
@@ -548,6 +548,7 @@ class GravelBedrockEroder(Component):
         """
         self._pluck_rate = (
             self._plucking_coef
+            * self._intermittency_factor
             * self._discharge
             * self._slope**self._SEVEN_SIXTHS
             * self._rock_exposure_fraction

--- a/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
+++ b/landlab/components/gravel_bedrock_eroder/gravel_bedrock_eroder.py
@@ -482,9 +482,35 @@ class GravelBedrockEroder(Component):
 
         Note: assumes _abrasion (of sediment) and _rock_exposure_fraction
         have already been updated.
-        TODO: ADD TEST(S) HERE
+
+        >>> import numpy as np
+        >>> from landlab import RasterModelGrid
+        >>> from landlab.components import FlowAccumulator
+        >>> grid = RasterModelGrid((3, 4), xy_spacing=100.0)
+        >>> elev = grid.add_zeros("topographic__elevation", at="node")
+        >>> elev[:] = 0.01 * grid.x_of_node
+        >>> sed = grid.add_zeros("soil__depth", at="node")
+        >>> sed[:] = 1.0
+        >>> fa = FlowAccumulator(grid)
+        >>> fa.run_one_step()
+        >>> eroder = GravelBedrockEroder(grid, abrasion_coefficient=1.0e-4)
+        >>> eroder.calc_rock_exposure_fraction()
+        >>> round(eroder._rock_exposure_fraction[6], 4)
+        0.3679
+        >>> eroder.calc_transport_capacity()
+        >>> np.round(eroder._sediment_outflux[5:7], 3)
+        array([ 0.024,  0.012])
+        >>> eroder.calc_abrasion_rate()
+        >>> np.round(eroder._abrasion[5:7], 9)
+        array([  1.20000000e-08,   6.00000000e-09])
+        >>> eroder.calc_bedrock_abrasion_rate()
+        >>> np.round(eroder._rock_abrasion_rate[5:7], 10)
+        array([  4.40000000e-09,   2.20000000e-09])
         """
-        self._rock_abrasion_rate = self._abrasion * self._rock_exposure_fraction
+        self._rock_abrasion_rate = (
+                self._abrasion
+                * self._rock_exposure_fraction
+        )
 
     def calc_bedrock_plucking_rate(self):
         """Update the rate of bedrock erosion by plucking.

--- a/landlab/components/tectonics/listric_kinematic_extender.py
+++ b/landlab/components/tectonics/listric_kinematic_extender.py
@@ -142,7 +142,9 @@ class ListricKinematicExtender(Component):
                 raise KeyError(
                     "When handle_thickness is True you must provide an 'upper_crust_thickness' node field."
                 )
-            self._cum_subs = grid.add_zeros("cumulative_subsidence_depth", at="node")
+            self._cum_subs = grid.add_zeros(
+                "cumulative_subsidence_depth", at="node", clobber=True
+            )
             self._fields_to_shift.append("upper_crust_thickness")
 
         if isinstance(grid, HexModelGrid):

--- a/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
+++ b/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f13d1024",
+   "id": "54f015aa",
    "metadata": {},
    "source": [
     "## Test setup\n",
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dda9b283",
+   "id": "0a268150",
    "metadata": {},
    "source": [
     "## Imports"
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "876a6f51",
+   "id": "ffe31e00",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2d9583cd",
+   "id": "d983c1aa",
    "metadata": {},
    "source": [
     "## Instantaneous tests\n",
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ad42760",
+   "id": "ecb8430d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c3f0968",
+   "id": "b904522d",
    "metadata": {},
    "source": [
     "For the case with limiting sediment cover, when the cover thickness is equal to the depth decay scale (set to 0.5 m), the transport rate should be reduced by a factor of $1 - 1/e$. This works out to:"
@@ -116,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df76860a",
+   "id": "33dc6e8d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3509f826",
+   "id": "6e34d097",
    "metadata": {},
    "source": [
     "Finally, with no sediment at all, the transport rate should be zero."
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c7ae7d39",
+   "id": "694dace1",
    "metadata": {},
    "source": [
     "Note that in order to give the grid nodes a gradient of 0.01, the elevations need to rise in the y-direction at a rate equal to 0.01 / cos 30$^\\circ$."
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a1a902b",
+   "id": "b0a73c4e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c9e3bb5",
+   "id": "b82703a3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7c43e18e",
+   "id": "82c2d50d",
    "metadata": {},
    "source": [
     "### Sediment abrasion rate\n",
@@ -208,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab279de9",
+   "id": "58f2ca16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22e64e13",
+   "id": "2d3862c7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "723b7b8e",
+   "id": "27634b67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0ee479c9",
+   "id": "c6ab4aba",
    "metadata": {},
    "source": [
     "### Bedrock abrasion\n",
@@ -279,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58d13656",
+   "id": "2f034af8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4605b79",
+   "id": "d5f5851e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,11 +343,54 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d6c9beb",
+   "id": "7807d6f6",
    "metadata": {},
    "outputs": [],
    "source": [
     "test_rock_abrasion_rate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5761999b",
+   "metadata": {},
+   "source": [
+    "### Test plucking erosion\n",
+    "\n",
+    "Here we can use test cases with zero, thin, and thick sedimentary covers.\n",
+    "\n",
+    "The theory behind the plucking rate goes something like this. Assume that the bankfull plucking rate is proportional to excess shear stress to a power. Whipple et al. (2000) suggested that the block loosening rate would be proportional to bed-load transport rate, which in turn tends to scale with excess stress to the 3/2 power. They also suggested that the block extraction rate might also scale linearly to weakly nonlinearly with excess shear stress. Here we take 3/2 as a suitable choice for \"weakly nonlinear\", and assume that the combination of block loosening and block extraction results in a rate of bedrock lowering by plucking (at bankfull stage) that scales with $(\\tau - \\tau_c)^{3/2}$. Given near-threshold theory, this then produces the same scaling as the bed-load transport rate, with an unknown coefficient:\n",
+    "\n",
+    "$$k_p I Q S^{7/6} e^{-H/H_s}$$\n",
+    "\n",
+    "where the exponential factor represents the fractional bedrock exposure.\n",
+    "\n",
+    "Now this is the rate of lowering per unit bed area. To convert this into an average rate of lowering across a grid cell, one needs to make a choice. Option 1 is to assume that the portions of the cell outside of the channel \"follow the channel down\" at the same rate, by some process of rapid near-channel hillslope response. The rate of volume removal of rock per time across the cell is then the incision rate times the cell area:\n",
+    "\n",
+    "$$V_p = k_p I Q S^{7/6} e^{-H/H_s} \\Lambda$$\n",
+    "\n",
+    "where $\\Lambda$ is grid-cell surface area. The resulting lowering rate is simply this volume rate divided by cell area:\n",
+    "\n",
+    "$$E_p = k_p I Q S^{7/6} e^{-H/H_s}$$\n",
+    "\n",
+    "In this case, the rate of incision does not depend on grid-cell size, but the rate of volumetric rate of rock erosion in the cell does (the wider the cell is relative to the channel, the greater the extra area that is effectively controlled by the embedded channel).\n",
+    "\n",
+    "Option 2 is to calculate the *average* rate of lowering across the grid cell, by combining the area of the cell that is undergoing channel downcutting and the area that is not. In this case, the volumetric rock erosion rate is the incision rate per unit bed area times the surface area of the channel, which can be approximated as the width of a channel exiting the cell times its length, $\\lambda$:\n",
+    "\n",
+    "$$V_p = k_p I Q S^{7/6} e^{-H/H_s} \\lambda b$$\n",
+    "\n",
+    "and the average lowering rate across the cell is:\n",
+    "\n",
+    "$$E_p = k_p I Q S^{7/6} e^{-H/H_s} \\lambda b / \\Lambda$$\n",
+    "\n",
+    "For a square cell of width $\\Delta x$, this becomes:\n",
+    "\n",
+    "$$E_p = k_p I Q S^{7/6} e^{-H/H_s} b / \\Delta x$$\n",
+    "\n",
+    "Here's an aside, a kind of thought experiment. Suppose you wanted to reduce this cell-size dependence. Imagine you tried assigning some fraction of the erosion at the cell to some of its neighbors. Suppose for the sake of argument that you did this by considering the probability that a portion of the channel laps onto a neighboring cell. One way to think about it is as an average overlap. If a channel is 1 m wide in a 5 m wide cell and you move it from side to side so that its centerline goes from right up against one side to right up against the other, you have an overlap function (overlap length as a function of position) that looks like this: `\\___/`. Within the sloping bits, which make up b/dx of the domain, the average overlap should be b/4 (b/2 is the max, 0 is the min, and it's a linear function). So the weighted average is $((b/dx) (b/4) + ((dx-b)/dx) 0 = b^2 / 4 dx$. If $b=0$, the overlap function is of course zero. If $b=dx$, the overlap function is $dx/4$, meaning perhaps that 3/4 of the calculated erosion happens in the cell itself, and the rest is distributed among neighbors somehow. This treatment has the result of causing the $\\Delta x$ in the denominator to go away, which seems promising...\n",
+    "\n",
+    "\n",
+    "For the zero-sediment case, we'll change the default plucking rate coefficient to 10x higher, at $k_p = 10^{-3}$."
    ]
   },
   {

--- a/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
+++ b/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f8e2987c",
+   "id": "f13d1024",
    "metadata": {},
    "source": [
     "## Test setup\n",
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cbfe402",
+   "id": "dda9b283",
    "metadata": {},
    "source": [
     "## Imports"
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b210a221",
+   "id": "876a6f51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78545160",
+   "id": "2d9583cd",
    "metadata": {},
    "source": [
     "## Instantaneous tests\n",
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6db76e75",
+   "id": "0ad42760",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5778b41f",
+   "id": "7c3f0968",
    "metadata": {},
    "source": [
     "For the case with limiting sediment cover, when the cover thickness is equal to the depth decay scale (set to 0.5 m), the transport rate should be reduced by a factor of $1 - 1/e$. This works out to:"
@@ -116,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46c1bdec",
+   "id": "df76860a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65c7dea3",
+   "id": "3509f826",
    "metadata": {},
    "source": [
     "Finally, with no sediment at all, the transport rate should be zero."
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "470fff6e",
+   "id": "c7ae7d39",
    "metadata": {},
    "source": [
     "Note that in order to give the grid nodes a gradient of 0.01, the elevations need to rise in the y-direction at a rate equal to 0.01 / cos 30$^\\circ$."
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "460d251f",
+   "id": "7a1a902b",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbd1f308",
+   "id": "1c9e3bb5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34acbfff",
+   "id": "7c43e18e",
    "metadata": {},
    "source": [
     "### Sediment abrasion rate\n",
@@ -208,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d25ade8",
+   "id": "ab279de9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c1cf8d7",
+   "id": "22e64e13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,11 +259,95 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d0daf8b",
+   "id": "723b7b8e",
    "metadata": {},
    "outputs": [],
    "source": [
     "test_sediment_abrasion_rate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0ee479c9",
+   "metadata": {},
+   "source": [
+    "### Bedrock abrasion\n",
+    "\n",
+    "Here we test the calculation of bedrock abrasion rate. We need a test that has some sediment, but not so much that the bed is totally shielded. We'll use 1 m thick sediment. That reduces the transport capacity, which should be equal to the above transport rates times the fractional alluvial cover, which is 1 minus the bedrock exposure fraction:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58d13656",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beta = 1.0e-4\n",
+    "path_length = 1000.0\n",
+    "frac_bed_exposed = np.exp(-1.0)\n",
+    "cell_area = 1.0e6 * 0.5 * 3.0**0.5\n",
+    "Qs_out = (\n",
+    "    0.041\n",
+    "    * 0.01\n",
+    "    * 0.01**(7./6.)\n",
+    "    * cell_area\n",
+    "    * np.array([3, 1, 1])\n",
+    "    * (1.0 - frac_bed_exposed)\n",
+    ")\n",
+    "Qs_in = np.array([Qs_out[1] + Qs_out[2], 0., 0.])\n",
+    "\n",
+    "print('Sed outflux:', Qs_out)\n",
+    "print('Sed influx:', Qs_in)\n",
+    "\n",
+    "sed_abr_rate = beta * 0.5 * (Qs_in + Qs_out) * path_length / cell_area\n",
+    "print('Sediment abrasion rate:', sed_abr_rate)\n",
+    "\n",
+    "rock_abr_rate = sed_abr_rate * frac_bed_exposed\n",
+    "print('Bed abrasion rate:', rock_abr_rate)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4605b79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_rock_abrasion_rate():\n",
+    "\n",
+    "    grid = HexModelGrid((4, 2), spacing=1000.0)\n",
+    "    grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED\n",
+    "    grid.status_at_node[0] = grid.BC_NODE_IS_FIXED_VALUE\n",
+    "\n",
+    "    elev = grid.add_zeros('topographic__elevation', at='node')\n",
+    "    elev[:] = (0.01 * grid.y_of_node) / np.cos(np.radians(30.0))\n",
+    "    sed = grid.add_zeros('soil__depth', at='node')\n",
+    "    sed[:] = 1.0\n",
+    "    \n",
+    "    fa = FlowAccumulator(grid)\n",
+    "    fa.run_one_step()\n",
+    "    gbe = GravelBedrockEroder(grid, abrasion_coefficient=1.0e-4)\n",
+    "    gbe.run_one_step(1.0)\n",
+    "\n",
+    "    assert_almost_equal(\n",
+    "        gbe._sediment_outflux[grid.core_nodes],\n",
+    "        [ 3.12537638,  1.04179213,  1.04179213]\n",
+    "    )\n",
+    "    assert_almost_equal(\n",
+    "        gbe._rock_abrasion_rate[grid.core_nodes],\n",
+    "        [1.10635873e-07,   2.21271745e-08,   2.21271745e-08]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d6c9beb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_rock_abrasion_rate()"
    ]
   },
   {

--- a/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
+++ b/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "threaded-aircraft",
+   "metadata": {},
+   "source": [
+    "# Unit Tests for the Landlab GravelBedrockEroder Component\n",
+    "\n",
+    "*G.E. Tucker, CIRES and Department of Geological Sciences, University of Colorado Boulder*\n",
+    "\n",
+    "This notebook describes a series of basic unit tests for the `GravelBedrockEroder` component. These tests are implemented in the file `test_gravel_bedrock_eroder.py`, and are in addition to the unit tests implemented as doctests in the source code."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sudden-singles",
+   "metadata": {},
+   "source": [
+    "## Types of test\n",
+    "\n",
+    "The theory starts with a representation of a layer of sediment overlying rock. Each grid cell is assumed to contain a primary channel that drains to an adjacent cell. The cell may also receive inflow of water and sediment from neighboring cells.\n",
+    "\n",
+    "Processes and effects include:\n",
+    "\n",
+    "1. Dynamic adjustment of channel width, based on near-threshold theory (implicit in derivation; not calculated explicitly unless requested via function call)\n",
+    "2. Transport of coarse (assumed gravel-size) sediment as bed load\n",
+    "3. Abrasion of sediment, which turns coarse sediment into wash load (not tracked)\n",
+    "4. Abrasion of underlying bedrock\n",
+    "5. Plucking erosion of underlying bedrock, which supplies coarse sediment\n",
+    "\n",
+    "Ideally, each of these elements should be tested, both separately and in combination. Two types of test are used: instantaneous tests, which are \"single iteration\" comparisons between predicted and computed values, and equilibrium tests, in which a small terrain is run with baselevel forcing (\"uplift\") until it reaches an equilibrium that is then compared with an independently calculated solution.\n",
+    "\n",
+    "In addition, the tests should collectively vary each input parameter from its default value at least once. Input parameters and their defaults include:\n",
+    "\n",
+    "- intermittency_factor=0.01\n",
+    "- transport_coefficient=0.041\n",
+    "- abrasion_coefficient=0.0\n",
+    "- sediment_porosity=0.35\n",
+    "- depth_decay_scale=1.0\n",
+    "- plucking_coefficient=1.0e-6\n",
+    "- coarse_fraction_from_plucking=1.0\n",
+    "\n",
+    "Channel width is adequately tested by the doctests, so additional tests of width are not included here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7035da45",
+   "metadata": {},
+   "source": [
+    "## Test setup\n",
+    "\n",
+    "The doctests in the code use a `RasterModelGrid`. For these external tests, we will use a `HexModelGrid` with three core nodes and a single open boundary node. This configuration is small enough for tests to be quick and efficient, but large enough to include flow convergence (two cells feel flow into a third, which then drains to the open boundary)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4877670b",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85a22b1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from numpy.testing import assert_almost_equal\n",
+    "from landlab import HexModelGrid\n",
+    "from landlab.components import FlowAccumulator, GravelBedrockEroder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8b84628",
+   "metadata": {},
+   "source": [
+    "## Instantaneous tests\n",
+    "\n",
+    "### Transport rate\n",
+    "\n",
+    "**Test condition**: 3-core-node hex grid with gradient of 0.01 along flow paths. Sediment cover: ample (100 m), limited (0.5 m, with depth decay scale also set to 0.5 m), and none.\n",
+    "\n",
+    "Predicted sediment transport rate under ample cover (not limited by bedrock exposure):\n",
+    "\n",
+    "$$Q_s = k_Q I Q S^{7/6}$$\n",
+    "\n",
+    "Here the default value $k_Q=0.041$ is used, but the intermittency factor is set to 0.02. The discharge by default will be one meter per year times drainage area. The drainage area of one cell is the cell's area, here about 866,025 m$^2$, and the drainage area of the cell that receives flow is three times this. Therefore the predicted sediment transport rate for the two \"upstream\" cells and for the single \"downstream\" cell is:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6bcd5f9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q = (3.0**0.5 / 2.0) * 1e6 * np.array([3, 1, 1])\n",
+    "Qs = 0.041 * 0.02 * Q * (0.01)**(7. / 6.)\n",
+    "print('Predicted transport rate:', Qs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3151555d",
+   "metadata": {},
+   "source": [
+    "For the case with limiting sediment cover, when the cover thickness is equal to the depth decay scale (set to 0.5 m), the transport rate should be reduced by a factor of $1 - 1/e$. This works out to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "422e8785",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Predicted transport rate:', Qs * (1.0 - np.exp(-1.)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22234f58",
+   "metadata": {},
+   "source": [
+    "Finally, with no sediment at all, the transport rate should be zero."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5189700a",
+   "metadata": {},
+   "source": [
+    "Note that in order to give the grid nodes a gradient of 0.01, the elevations need to rise in the y-direction at a rate equal to 0.01 / cos 30$^\\circ$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8c12223",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_transport_rate():\n",
+    "\n",
+    "    grid = HexModelGrid((4, 2), spacing=1000.0)\n",
+    "    grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED\n",
+    "    grid.status_at_node[0] = grid.BC_NODE_IS_FIXED_VALUE\n",
+    "\n",
+    "    elev = grid.add_zeros('topographic__elevation', at='node')\n",
+    "    elev[:] = (0.01 * grid.y_of_node) / np.cos(np.radians(30.0))\n",
+    "    sed = grid.add_zeros('soil__depth', at='node')\n",
+    "    sed[:] = 100.0\n",
+    "    \n",
+    "    fa = FlowAccumulator(grid)\n",
+    "    fa.run_one_step()\n",
+    "    gbe = GravelBedrockEroder(grid, intermittency_factor=0.02, depth_decay_scale=0.5)\n",
+    "    qs_out = grid.at_node['bedload_sediment__volume_outflux']\n",
+    "\n",
+    "    gbe.run_one_step(0.0)  # using dt=0 prevents change to sed, rock, or elev\n",
+    "    assert_almost_equal(qs_out[grid.core_nodes], [ 9.88854526,   3.29618175,  3.29618175])\n",
+    "\n",
+    "    elev[:] = (0.01 * grid.y_of_node) / np.cos(np.radians(30.0))\n",
+    "    sed[:] = 0.5\n",
+    "    \n",
+    "    gbe.run_one_step(0.0)\n",
+    "    assert_almost_equal(qs_out[grid.core_nodes], [ 6.25075275,  2.08358425,  2.08358425])\n",
+    "    \n",
+    "    elev[:] = (0.01 * grid.y_of_node) / np.cos(np.radians(30.0))\n",
+    "    sed[:] = 0.0\n",
+    "    \n",
+    "    gbe.run_one_step(0.0)\n",
+    "    assert_almost_equal(qs_out[grid.core_nodes], [ 0., 0., 0.])\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e59052e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_transport_rate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1994b5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(3.0)**0.5/2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149bbbaf",
+   "metadata": {},
+   "source": [
+    "## References and further reading\n",
+    "\n",
+    "Attal, M., & Lavé, J. (2006). Changes of bedload characteristics along the Marsyandi River (central Nepal): Implications for understanding hillslope sediment supply, sediment load evolution along fluvial networks, and denudation in active orogenic belts. Geol. Soc. Am. Spec. Pap, 398, 143-171.\n",
+    "\n",
+    "Attal, M., & Lavé, J. (2009). Pebble abrasion during fluvial transport: Experimental results and implications for the evolution of the sediment load along rivers. Journal of Geophysical Research: Earth Surface, 114(F4).\n",
+    "\n",
+    "Grant, G. E. (1997). Critical flow constrains flow hydraulics in mobile‐bed streams: A new hypothesis. Water Resources Research, 33(2), 349-358.\n",
+    "\n",
+    "Meyer-Peter, E., & Müller, R. (1948). Formulas for bed-load transport. In IAHSR 2nd meeting, Stockholm, appendix 2. IAHR.\n",
+    "\n",
+    "Parker, G. (1978). Self-formed straight rivers with equilibrium banks and mobile bed. Part 2. The gravel river. Journal of Fluid mechanics, 89(1), 127-146.\n",
+    "\n",
+    "Phillips, C. B., & Jerolmack, D. J. (2016). Self-organization of river channels as a critical filter on climate signals. Science, 352(6286), 694-697.\n",
+    "\n",
+    "Wickert, A. D., & Schildgen, T. F. (2019). Long-profile evolution of transport-limited gravel-bed rivers. Earth Surface Dynamics, 7(1), 17-43.\n",
+    "\n",
+    "Willgoose, G., Bras, R. L., & Rodriguez‐Iturbe, I. (1991). A physical explanation of an observed link area‐slope relationship. Water Resources Research, 27(7), 1697-1702.\n",
+    "\n",
+    "Willgoose, G. (1994). A physical explanation for an observed area‐slope‐elevation relationship for catchments with declining relief. Water Resources Research, 30(2), 151-159.\n",
+    "\n",
+    "Wong, M., & Parker, G. (2006). Reanalysis and correction of bed-load relation of Meyer-Peter and Müller using their own database. Journal of Hydraulic Engineering, 132(11), 1159-1168."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
+++ b/notebooks/tutorials/landscape_evolution/gravel_bedrock_eroder/gravel_bedrock_transporter_unit_tests.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7035da45",
+   "id": "f8e2987c",
    "metadata": {},
    "source": [
     "## Test setup\n",
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4877670b",
+   "id": "4cbfe402",
    "metadata": {},
    "source": [
     "## Imports"
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85a22b1f",
+   "id": "b210a221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c8b84628",
+   "id": "78545160",
    "metadata": {},
    "source": [
     "## Instantaneous tests\n",
@@ -96,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bcd5f9a",
+   "id": "6db76e75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3151555d",
+   "id": "5778b41f",
    "metadata": {},
    "source": [
     "For the case with limiting sediment cover, when the cover thickness is equal to the depth decay scale (set to 0.5 m), the transport rate should be reduced by a factor of $1 - 1/e$. This works out to:"
@@ -116,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "422e8785",
+   "id": "46c1bdec",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22234f58",
+   "id": "65c7dea3",
    "metadata": {},
    "source": [
     "Finally, with no sediment at all, the transport rate should be zero."
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5189700a",
+   "id": "470fff6e",
    "metadata": {},
    "source": [
     "Note that in order to give the grid nodes a gradient of 0.01, the elevations need to rise in the y-direction at a rate equal to 0.01 / cos 30$^\\circ$."
@@ -142,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8c12223",
+   "id": "460d251f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e59052e7",
+   "id": "fbd1f308",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,13 +190,80 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "34acbfff",
+   "metadata": {},
+   "source": [
+    "### Sediment abrasion rate\n",
+    "\n",
+    "Consider the first of the cases above, in which the transport rate is about 3.3 m$^3$/y for the upstream cells and 9.9 m$^3$/y for the downstream ones. If the abrasion coefficient is 10$^{-4}$ m$^{-1}$, then we can calculate the resulting lowering rate of the thickness of sediment as:\n",
+    "\n",
+    "$$\\frac{dH}{dt} = -\\beta (Q_{in} + Q_{out}) \\lambda / 2 \\Lambda$$\n",
+    "\n",
+    "where $\\beta$ is the abrasion coefficient, $Q_s$ is the transport rate (m$^3$/y), $\\lambda$ is the length of the flow path (distance from the node to its downstream neighbor), and $\\Lambda$ is the surface area of the cell.\n",
+    "\n",
+    "In this case, the numbers are as follows (here sediment flux is half the above case because we are using the default intermittency factor):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1994b5a",
+   "id": "5d25ade8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "(3.0)**0.5/2"
+    "beta = 1.0e-4  # abrasion coefficient, 1/m\n",
+    "Qout = 0.5 * 3.29618175  # transport rate, m3/y\n",
+    "path_length = 1000.0  # node spacing, m\n",
+    "cell_area = 1000.0 * 1000.0 * 0.5 * 3.0**0.5\n",
+    "print('Rate of thickness loss from sediment abrasion (upstream):',\n",
+    "      beta * 0.5 * (0.0 + Qout) * path_length / cell_area\n",
+    "     )\n",
+    "\n",
+    "Qin = 2 * Qout\n",
+    "Qout = 0.5 * 9.88854526\n",
+    "print('Rate of thickness loss from sediment abrasion (downstream):',\n",
+    "      beta * 0.5 * (Qin + Qout) * path_length / cell_area\n",
+    "     )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c1cf8d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_sediment_abrasion_rate():\n",
+    "\n",
+    "    grid = HexModelGrid((4, 2), spacing=1000.0)\n",
+    "    grid.status_at_node[grid.perimeter_nodes] = grid.BC_NODE_IS_CLOSED\n",
+    "    grid.status_at_node[0] = grid.BC_NODE_IS_FIXED_VALUE\n",
+    "\n",
+    "    elev = grid.add_zeros('topographic__elevation', at='node')\n",
+    "    elev[:] = (0.01 * grid.y_of_node) / np.cos(np.radians(30.0))\n",
+    "    sed = grid.add_zeros('soil__depth', at='node')\n",
+    "    sed[:] = 100.0\n",
+    "    \n",
+    "    fa = FlowAccumulator(grid)\n",
+    "    fa.run_one_step()\n",
+    "    gbe = GravelBedrockEroder(grid, abrasion_coefficient=1.0e-4)\n",
+    "    gbe.run_one_step(1.0)\n",
+    "\n",
+    "    assert_almost_equal(\n",
+    "        gbe._abrasion[grid.core_nodes],\n",
+    "        [4.7576285545378313e-07, 9.515257103302159e-08, 9.515257103302159e-08]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d0daf8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_sediment_abrasion_rate()"
    ]
   },
   {


### PR DESCRIPTION

### Description

Enables clobber of existing `cumulative_subsidence_depth` field. Just a one-line change that allows a model to read in a saved grid and instantiate the `ListricKinematicExtender` without triggering a clobber error.

### Checklist - did you ...



- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [ ] All tests have passed?
- [ ] Formatted code with black?
- [ ] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)


