### PR TITLE
Change the target branch for dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    target-branch: "dependencies"
     labels: ["skip news", "dependencies"]
 
   - package-ecosystem: "pip"
     directory: "."
     schedule:
       interval: "daily"
+    target-branch: "dependencies"
     labels: ["skip news", "dependencies"]

--- a/.github/workflows/rebase_dependencies.yml
+++ b/.github/workflows/rebase_dependencies.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  push:
+    branches:
+      - master
+jobs:
+  rebase:
+    name: Rebase `dependencies` with `master`
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
+          ref: dependencies
+      - run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git rebase origin/master
+          git push origin dependencies --force

--- a/news/1602.misc
+++ b/news/1602.misc
@@ -1,0 +1,5 @@
+Changed the target branch for *dependabot* pull requests to *dependencies*
+and added a GitHub action that automatically keeps the *dependencies* branch
+up-to-date with *master*.
+
+


### PR DESCRIPTION
This pull request changes the target branch for _dependabot_ pull requests from *master* to *dependencies*. I've also added a GitHub action workflow that will automatically rebase the _dependencies_ branch whenever _master_ is changed.