### PR TITLE
Fix flaky LateralEroder and NetworkSedimentTransporter tests

### DIFF
--- a/landlab/components/network_sediment_transporter/sediment_pulser_at_links.py
+++ b/landlab/components/network_sediment_transporter/sediment_pulser_at_links.py
@@ -92,6 +92,7 @@ class SedimentPulserAtLinks(SedimentPulserBase):
         rho_sediment=2650.0,
         parcel_volume=0.5,
         abrasion_rate=0.0,
+        rng=None,
     ):
         """Create :class:`~.SedimentPulserAtLinks`.
 
@@ -116,6 +117,11 @@ class SedimentPulserAtLinks(SedimentPulserBase):
         abrasion_rate: float
             Volumetric abrasion exponent [1 / m]
         """
+        if rng is None:
+            rng = np.random.default_rng()
+        elif isinstance(rng, int):
+            rng = np.random.default_rng(seed=rng)
+        self._rng = rng
 
         SedimentPulserBase.__init__(
             self,
@@ -282,7 +288,7 @@ class SedimentPulserAtLinks(SedimentPulserBase):
         offset = 0
         for link, n_parcels in enumerate(n_parcels_at_link):
             element_id[offset : offset + n_parcels] = links[link]
-            grain_size[offset : offset + n_parcels] = np.random.lognormal(
+            grain_size[offset : offset + n_parcels] = self._rng.lognormal(
                 np.log(D50[link]), np.log(D84_D50[link]), n_parcels
             )
             volume[offset : offset + n_parcels] = parcel_volume[link] % n_parcels
@@ -313,7 +319,7 @@ class SedimentPulserAtLinks(SedimentPulserBase):
         # link location (distance from link inlet / link length) is stochastically
         # determined
         location_in_link = np.expand_dims(
-            np.random.uniform(size=np.sum(n_parcels_at_link)), axis=1
+            self._rng.uniform(size=np.sum(n_parcels_at_link)), axis=1
         )
 
         # All parcels in pulse are in the active layer (1) rather than subsurface (0)

--- a/landlab/components/network_sediment_transporter/sediment_pulser_each_parcel.py
+++ b/landlab/components/network_sediment_transporter/sediment_pulser_each_parcel.py
@@ -100,6 +100,7 @@ class SedimentPulserEachParcel(SedimentPulserBase):
         rho_sediment=2650.0,
         parcel_volume=0.5,
         abrasion_rate=0.0,
+        rng=None,
     ):
         """
         instantiate SedimentPulserEachParcel
@@ -121,6 +122,12 @@ class SedimentPulserEachParcel(SedimentPulserBase):
         abrasion_rate: float, optional
             volumetric abrasion exponent [1/m]
         """
+        if rng is None:
+            rng = np.random.default_rng()
+        elif isinstance(rng, int):
+            rng = np.random.default_rng(seed=rng)
+        self._rng = rng
+
         SedimentPulserBase.__init__(
             self,
             grid,
@@ -310,7 +317,7 @@ class SedimentPulserEachParcel(SedimentPulserBase):
                 n_parcels = p_np[i]
                 D50 = row["D50"]
                 D84_D50 = row["D84_D50"]
-                grain_size_pulse = np.random.lognormal(
+                grain_size_pulse = self._rng.lognormal(
                     np.log(D50), np.log(D84_D50), n_parcels
                 )
                 grain_size = np.concatenate((grain_size, grain_size_pulse))
@@ -318,7 +325,7 @@ class SedimentPulserEachParcel(SedimentPulserBase):
             n_parcels = sum(p_np)
             D50 = self._D50
             D84_D50 = self._D84_D50
-            grain_size = np.random.lognormal(np.log(D50), np.log(D84_D50), n_parcels)
+            grain_size = self._rng.lognormal(np.log(D50), np.log(D84_D50), n_parcels)
 
         grain_size = np.expand_dims(grain_size, axis=1)
 

--- a/news/1722.feature
+++ b/news/1722.feature
@@ -1,0 +1,2 @@
+Added an ``rng`` keyword to the :class:`~.NetworkSedimentTransporter` utilities
+that allows a user to control the random number generator used.

--- a/news/1722.misc
+++ b/news/1722.misc
@@ -1,0 +1,2 @@
+Fixed a flaky test with the :class:`~.LateralEroder` where it would occasionally
+fail to reach the steady state solution.

--- a/news/1722.misc
+++ b/news/1722.misc
@@ -1,2 +1,2 @@
-Fixed a flaky test with the :class:`~.LateralEroder` where it would occasionally
+Fixed a flaky test with the :class:`~.lateral_erosion.lateral_erosion.LateralEroder` where it would occasionally
 fail to reach the steady state solution.

--- a/news/1722.misc.1
+++ b/news/1722.misc.1
@@ -1,0 +1,2 @@
+Fixed a flaky test with the `sediment_pulser_at_links.ipynb` notebook where it
+would occasionally hang.

--- a/notebooks/tutorials/network_sediment_transporter/sediment_pulser_at_links.ipynb
+++ b/notebooks/tutorials/network_sediment_transporter/sediment_pulser_at_links.ipynb
@@ -157,6 +157,7 @@
     "    drainage_area_exponent=-0.2,\n",
     "    sed_thickness=1,\n",
     "    median_number_of_starting_parcels=2,\n",
+    "    rng=1945,\n",
     ")\n",
     "parcels = initialize_parcels()"
    ]
@@ -288,7 +289,7 @@
     "\n",
     "\n",
     "make_pulse = SedimentPulserAtLinks(\n",
-    "    nmg, parcels=parcels, time_to_pulse=always_time_to_pulse\n",
+    "    nmg, parcels=parcels, time_to_pulse=always_time_to_pulse, rng=1945\n",
     ")"
    ]
   },
@@ -689,7 +690,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/tests/components/lateral_erosion/test_latero.py
+++ b/tests/components/lateral_erosion/test_latero.py
@@ -330,10 +330,9 @@ def test_latero_steady_inlet():
     mg.status_at_node[mg.nodes_at_bottom_edge] = mg.BC_NODE_IS_FIXED_VALUE
 
     rng = np.random.default_rng(seed=1945)
-    z = np.repeat(np.linspace(1, 2.5, num=nr), nc) + rng.uniform(
-        low=0.0, high=0.8, size=nr * nc
-    )
-    mg.at_node["topographic__elevation"] = z
+    mg.at_node["topographic__elevation"] = np.repeat(
+        np.linspace(1, 2.5, num=nr), nc
+    ) + rng.uniform(low=0.0, high=0.8, size=nr * nc)
 
     fa = FlowAccumulator(
         mg,
@@ -370,7 +369,7 @@ def test_latero_steady_inlet():
     testing.assert_array_almost_equal(
         num_sedflux,
         analytical_sedflux,
-        decimal=5,
+        decimal=2,
         err_msg="LatEro inlet transport-limited sediment flux test failed",
         verbose=True,
     )

--- a/tests/components/lateral_erosion/test_latero.py
+++ b/tests/components/lateral_erosion/test_latero.py
@@ -319,23 +319,21 @@ def test_latero_steady_inlet():
     nr = 5
     nc = 5
     dx = 10
-    # instantiate grid
+
     mg = RasterModelGrid((nr, nc), xy_spacing=dx)
     for edge in (
         mg.nodes_at_top_edge,
-        mg.nodes_at_bottom_edge,
         mg.nodes_at_left_edge,
         mg.nodes_at_right_edge,
     ):
         mg.status_at_node[edge] = mg.BC_NODE_IS_CLOSED
-    for edge in mg.nodes_at_bottom_edge:
-        mg.status_at_node[edge] = mg.BC_NODE_IS_FIXED_VALUE
+    mg.status_at_node[mg.nodes_at_bottom_edge] = mg.BC_NODE_IS_FIXED_VALUE
 
-    z = mg.add_zeros("topographic__elevation", at="node")
-    loading_vector = np.linspace(1, 2.5, num=nr)
-    ramp = np.repeat(loading_vector, nc)
-    ramp += np.random.random_sample(mg.number_of_nodes) * 0.8
-    z += ramp
+    rng = np.random.default_rng(seed=1945)
+    z = np.repeat(np.linspace(1, 2.5, num=nr), nc) + rng.uniform(
+        low=0.0, high=0.8, size=nr * nc
+    )
+    mg.at_node["topographic__elevation"] = z
 
     fa = FlowAccumulator(
         mg,
@@ -360,9 +358,8 @@ def test_latero_steady_inlet():
         fa.run_one_step()  # flow accumulator
         # erode the landscape with lateral erosion
         (mg, dzlat) = latero.run_one_step(dt)
-        mg.at_node["topographic__elevation"][mg.core_nodes] += (
-            U * dt
-        )  # uplift the landscape
+        # uplift the landscape
+        mg.at_node["topographic__elevation"][mg.core_nodes] += U * dt
 
     da = mg.at_node["surface_water__discharge"] / dx**2
     num_sedflux = mg.at_node["qs"]
@@ -373,7 +370,7 @@ def test_latero_steady_inlet():
     testing.assert_array_almost_equal(
         num_sedflux,
         analytical_sedflux,
-        decimal=2,
+        decimal=5,
         err_msg="LatEro inlet transport-limited sediment flux test failed",
         verbose=True,
     )

--- a/tests/components/network_sediment_transporter/test_bed_initializer.py
+++ b/tests/components/network_sediment_transporter/test_bed_initializer.py
@@ -157,12 +157,12 @@ class Test_BedParcelInitializer:
         Minimum attributes specified, most attributes should use
         defaults specified at instantiation. uses BedParcelInitializerDischarge.
         """
-        np.random.seed(seed=5)
         discharge = np.full(example_nmg2.number_of_links, 1.0)
         initialize_parcels = BedParcelInitializerDischarge(
             example_nmg2,
             discharge_at_link=discharge,
             median_number_of_starting_parcels=1,
+            rng=5,
         )
 
         parcels = initialize_parcels()
@@ -185,18 +185,16 @@ class Test_BedParcelInitializer:
         ALe = np.expand_dims(np.ones(8), axis=1)
         AL = parcels.dataset["active_layer"]
         LL = parcels.dataset["location_in_link"]
-        De = np.array(
-            [
-                [0.06802885],
-                [0.06232028],
-                [0.37674903],
-                [0.06607135],
-                [0.07391346],
-                [0.29280262],
-                [0.04609956],
-                [0.05135768],
-            ]
-        )
+        De = [
+            [0.02704727],
+            [0.02982003],
+            [0.05161594],
+            [0.10882225],
+            [0.15829283],
+            [0.09817898],
+            [0.06006139],
+            [0.0445011],
+        ]
         D = parcels.dataset["D"]
         V = parcels.dataset["volume"]
 
@@ -216,13 +214,13 @@ class Test_BedParcelInitializer:
         Test normal outputs of bed parcel initializer with abrasion.
         uses BedParcelInitializerDischarge.
         """
-        np.random.seed(seed=5)
         discharge = np.full(example_nmg2.number_of_links, 1.0)
         initialize_parcels = BedParcelInitializerDischarge(
             example_nmg2,
             discharge_at_link=discharge,
             median_number_of_starting_parcels=1,
             abrasion_rate=0.1,
+            rng=5,
         )
 
         parcels = initialize_parcels()
@@ -244,18 +242,16 @@ class Test_BedParcelInitializer:
         TA = parcels.dataset["time_arrival_in_link"]
         ALe = np.expand_dims(np.ones(8), axis=1)
         AL = parcels.dataset["active_layer"]
-        De = np.array(
-            [
-                [0.06802885],
-                [0.06232028],
-                [0.37674903],
-                [0.06607135],
-                [0.07391346],
-                [0.29280262],
-                [0.04609956],
-                [0.05135768],
-            ]
-        )
+        De = [
+            [0.02704727],
+            [0.02982003],
+            [0.05161594],
+            [0.10882225],
+            [0.15829283],
+            [0.09817898],
+            [0.06006139],
+            [0.0445011],
+        ]
         D = parcels.dataset["D"]
         V = parcels.dataset["volume"]
 

--- a/tests/components/network_sediment_transporter/test_sediment_pulser.py
+++ b/tests/components/network_sediment_transporter/test_sediment_pulser.py
@@ -541,11 +541,10 @@ class Test_SedimentPulserEachParcel:
         SedimentPulserEachParcel."""
 
         grid = example_nmg2
-        np.random.seed(seed=5)  # use the random seed for this test
 
         # define the initial parcels datarecord
         make_pulse_links = SedimentPulserAtLinks(
-            grid, time_to_pulse=always_time_to_pulse
+            grid, time_to_pulse=always_time_to_pulse, rng=5
         )
 
         # pulse 1
@@ -643,16 +642,19 @@ class Test_SedimentPulserEachParcel:
             ]
         )
         AL = parcels.dataset["active_layer"]
-        LLe = np.array(
+        LLe = [
+            [0.51532556, np.nan, np.nan, np.nan],
+            [0.28580138, np.nan, np.nan, np.nan],
+            [np.nan, 0.5, np.nan, np.nan],
+            [np.nan, 0.5, np.nan, np.nan],
+            [np.nan, np.nan, 0.38336888, np.nan],
             [
-                [0.20671916, np.nan, np.nan, np.nan],
-                [0.91861091, np.nan, np.nan, np.nan],
-                [np.nan, 0.5, np.nan, np.nan],
-                [np.nan, 0.5, np.nan, np.nan],
-                [np.nan, np.nan, 0.2968005, np.nan],
-                [np.nan, np.nan, np.nan, 0.2],
-            ]
-        )
+                np.nan,
+                np.nan,
+                np.nan,
+                0.2,
+            ],
+        ]
         LL = parcels.dataset["location_in_link"]
         D = parcels.dataset["D"].values
         D[~np.isnan(D)]
@@ -699,9 +701,8 @@ class Test_SedimentPulserEachParcel:
         datarecord"""
 
         grid = example_nmg2
-        np.random.seed(seed=5)
 
-        make_pulse = SedimentPulserEachParcel(grid)
+        make_pulse = SedimentPulserEachParcel(grid, rng=5)
 
         PulseDF = pd.DataFrame(
             {
@@ -735,17 +736,15 @@ class Test_SedimentPulserEachParcel:
         AL = parcels.dataset["active_layer"]
         LLe = np.array([[0.8], [0.7], [0.7], [0.5], [0.5], [0.5], [0.2]])
         LL = parcels.dataset["location_in_link"]
-        De = np.array(
-            [
-                [0.06936526],
-                [0.03911625],
-                [0.30353682],
-                [0.04147067],
-                [0.05423609],
-                [0.16176179],
-                [0.02546817],
-            ]
-        )
+        De = [
+            [0.0275786],
+            [0.01871699],
+            [0.04158561],
+            [0.06830391],
+            [0.11615185],
+            [0.05423998],
+            [0.03318153],
+        ]
         D = parcels.dataset["D"]
         Ve = np.array([[0.2], [0.5], [0.5], [0.5], [0.5], [0.1], [0.5]])
         V = parcels.dataset["volume"]


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

This pull request fixes the flaky tests described in #1722.

The ``LateralEroder`` test (`test_ss_sed_flux`) was would occasionally fail because the initial elevation grid was created with some random noise but without using a seed. I rewrote the test to use an initial seed with `np.random.default_rng`.

The `sediment_pulser_at_links.ipynb` notebook that would occasionally stall had a similar problem—several of the `NetworkSedimentTransporter` utilities used a random number generator but not an initial seed. Certain sets of random numbers generated a configuration that would stall the notebook. To fix this, I've added an `rng` keyword to these functions/classes that allow a user to pass a random number generator, a seed, or `None` for the old behavior.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [x] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
- [x] All tests have passed?
- [x] Formatted code with black?
- [x] Removed lint reported by flake8?
- [x] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->
