### PR TITLE
Doc: mamba is discouraged as of September 2023

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ in your terminal of choice:
   $ pip install landlab
 
 
-For a full description of how to install *Landlab*, including using *mamba*/*conda*,
+For a full description of how to install *Landlab*, including using *conda*,
 please see the documentation for our `installation instructions`_.
 
 

--- a/docs/source/install/developer_install.rst
+++ b/docs/source/install/developer_install.rst
@@ -51,13 +51,6 @@ Install dependencies
 
 *Landlab*'s dependencies are listed in *requirements.in*.
 
-.. tab:: mamba
-
-  .. code-block:: bash
-
-     cd landlab
-     mamba install --file=requirements.in -c nodefaults -c conda-forge --override-channels
-
 .. tab:: conda
 
   .. code-block:: bash
@@ -83,14 +76,8 @@ on `compiling code on Windows <https://conda-forge.org/docs/maintainer/knowledge
 or the `Python wiki page for Windows compilers <https://wiki.python.org/moin/WindowsCompilers>`__.
 
 
-If you are using *conda*/*mamba*, set up your compilers to build libraries
+If you are using *conda*, set up your compilers to build libraries
 compatible with other installed packages,
-
-.. tab:: mamba
-
-  .. code-block:: bash
-
-     mamba install compilers -c nodefaults -c conda-forge --override-channels
 
 .. tab:: conda
 

--- a/docs/source/install/environments.rst
+++ b/docs/source/install/environments.rst
@@ -8,18 +8,9 @@ A virtual environment is a self-contained directory tree that contains a Python 
 version of Python along with additional packages. It solves the problem of one application's
 package requirements conflicting with another's.
 
-Two popular tools used for creating virtual environments are the built-in *venv* module and *conda*
-(or the *much* faster and more reliable *mamba*). For virtual environments created using *conda*/*mamba*,
-you can use either *conda*/*mamba* or *pip* to install additional packages, while *venv*-created environments
-should stick with *pip*.
-
-.. tab:: mamba
-
-    .. code-block:: bash
-
-        conda install mamba -c conda-forge
-        mamba create -n landlab
-        mamba activate landlab
+Two popular tools used for creating virtual environments are the built-in *venv* module and *conda*.
+For virtual environments created using *conda*, you can use either *conda* or *pip* to install additional
+packages, while *venv*-created environments should stick with *pip*.
 
 .. tab:: conda
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,12 +20,6 @@ scientific computing.
 
 To install *Landlab*, simply run the following in your terminal of choice:
 
-.. tab:: mamba
-
-  .. code-block:: bash
-
-    mamba install landlab -c nodefaults -c conda-forge --override-channels
-
 .. tab:: conda
 
   .. code-block:: bash

--- a/docs/source/user_guide/tutorials.rst
+++ b/docs/source/user_guide/tutorials.rst
@@ -102,19 +102,11 @@ contains a list of requirements needed to run the notebook tutorials.
   not necessary, we **highly recommend** you install these into a separate
   :ref:`virtual environment <virtual_environments>`.
 
-Use *mamba* or *conda* to install the requirements.
+Use *conda* to install the requirements.
 
-.. tab:: mamba
+.. code-block:: bash
 
-  .. code-block:: bash
-
-     mamba install --file=requirements-notebooks.txt
-
-.. tab:: conda
-
-  .. code-block:: bash
-
-     conda install --file=requirements-notebooks.txt
+   conda install --file=requirements-notebooks.txt
 
 
 Run the tutorials


### PR DESCRIPTION
This simplifies the docs by removing "mamba" and just showing "conda".

This assumes users are using recent versions of [miniforge](https://github.com/conda-forge/miniforge) at least [Miniforge3 23.3.1-0](https://github.com/conda-forge/miniforge/releases/tag/23.3.1-0) or later, which is the first version to bundle `conda-libmamba-solver`, which means "conda" is just as fast as "mamba". As of September 2023, miniforge discourages mambaforge on their GitHub page.

To enable this for existing conda installations, see [this article](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community):
```
conda install -n base conda-libmamba-solver
conda config --set solver libmamba
```