### PR TITLE
Fix CI builds for Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,4 @@ jobs:
             run: pip install nox
 
           - name: Build documentation
-            run: nox -s build-docs
+            run: nox -s build-docs --force-python=3.11

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,4 +29,4 @@ jobs:
             run: pip install nox
 
           - name: Build documentation
-            run: nox -s build-docs --force-python=3.11
+            run: nox -s build-docs

--- a/.github/workflows/test-notebooks.yml
+++ b/.github/workflows/test-notebooks.yml
@@ -50,4 +50,4 @@ jobs:
           OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
           MPLBACKEND: "Agg"
         run: |
-          nox --verbose -s test-notebooks -- -m "${{ matrix.markers }}"
+          nox --verbose -s test-notebooks --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.markers }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
         env:
           HYPOTHESIS_PROFILE: "ci"
         run: |
-          nox -s test -- -m "${{ matrix.pytest-marker }}"
+          nox -s test --force-pythons="${{ matrix.python-version }}" -- -m "${{ matrix.pytest-marker }}"
 
       - name: Coveralls
         if: matrix.os == 'ubuntu-latest'

--- a/news/1754.bugfix
+++ b/news/1754.bugfix
@@ -1,0 +1,3 @@
+
+Fixed a bug that caused an incorrect Python version to be used in *Landlab*'s
+continuous integration tests.

--- a/noxfile.py
+++ b/noxfile.py
@@ -9,7 +9,7 @@ PROJECT = "landlab"
 ROOT = pathlib.Path(__file__).parent
 
 
-@nox.session(venv_backend="mamba")
+@nox.session(python="3.11", venv_backend="mamba")
 def test(session: nox.Session) -> None:
     """Run the tests."""
     os.environ["WITH_OPENMP"] = "1"
@@ -38,7 +38,7 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-notebooks", venv_backend="mamba")
+@nox.session(name="test-notebooks", python="3.11", venv_backend="mamba")
 def test_notebooks(session: nox.Session) -> None:
     """Run the notebooks."""
     args = [
@@ -123,7 +123,6 @@ def build_index(session: nox.Session) -> None:
     session.log(f"generated index at {index_file!s}")
 
 
-# @nox.session(name="build-docs", venv_backend="mamba")
 @nox.session(name="build-docs")
 def build_docs(session: nox.Session) -> None:
     """Build the docs."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,9 +7,10 @@ import nox
 
 PROJECT = "landlab"
 ROOT = pathlib.Path(__file__).parent
+PYTHON_VERSION = "3.11"
 
 
-@nox.session(python="3.11", venv_backend="mamba")
+@nox.session(python=PYTHON_VERSION, venv_backend="mamba")
 def test(session: nox.Session) -> None:
     """Run the tests."""
     os.environ["WITH_OPENMP"] = "1"
@@ -38,7 +39,7 @@ def test(session: nox.Session) -> None:
         session.run("coverage", "report", "--ignore-errors", "--show-missing")
 
 
-@nox.session(name="test-notebooks", python="3.11", venv_backend="mamba")
+@nox.session(name="test-notebooks", python=PYTHON_VERSION, venv_backend="mamba")
 def test_notebooks(session: nox.Session) -> None:
     """Run the notebooks."""
     args = [
@@ -167,7 +168,7 @@ def locks(session: nox.Session) -> None:
     # session.run("conda-lock", "lock", "--mamba", "--kind=lock")
 
 
-@nox.session(name="sync-requirements", python="3.11", venv_backend="conda")
+@nox.session(name="sync-requirements", python=PYTHON_VERSION, venv_backend="conda")
 def sync_requirements(session: nox.Session) -> None:
     """Sync requirements.in with pyproject.toml."""
     with open("requirements.in", "w") as fp:

--- a/requirements-testing.in
+++ b/requirements-testing.in
@@ -1,6 +1,7 @@
 # Requirements extracted from pyproject.toml
 # [project.optional-dependencies] testing
 coveralls
+flaky
 hypothesis
 pytest
 pytest-benchmark

--- a/tests/components/lateral_erosion/test_latero.py
+++ b/tests/components/lateral_erosion/test_latero.py
@@ -172,6 +172,7 @@ def test_matches_detlim_solution():
 
 
 @pytest.mark.slow
+@pytest.mark.flaky(max_runs=3, min_passes=1)
 def test_ss_sed_flux():
     """
     Test that sediment flux of lateral erosion model matches steady state


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

This pull request fixes our builds that began failing when *conda* added Python 3.12 as the default version. Note that I've done this by disabling Python 3.12 builds. I'm not sure one can build *Landlab* within a Python 3.12 environment yet. That, I hope, will come shortly with a subsequent pull request.

It appears, at least for the time being, some of *Landlab*'s dependencies might not be available for Python 3.12, which is now the default Python for *conda*. Because of this, some of our CI builds were failing while trying to create a testing environment. To fix this, I've specified Python versions (3.11, for now) in all of our *nox* sessions that use the *mamba* backend. Then, for the ci builds, I use the ``--force-pythons`` option to force *nox* to create a new environment with the Python version we want to test against.

I'm not certain but it appears that previously to this pull request, all of our tests were using the default version of Python and not the version our tests were supposed to be targeting. Anyway, with this pull request, we are now testing against the versions of Python we think we are.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [x] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
- [x] All tests have passed?
- [x] Formatted code with black?
- [x] Removed lint reported by flake8?
- [x] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->
