### PR TITLE
Add FastscapelibFlowRouter component

### DIFF
--- a/landlab/components/__init__.py
+++ b/landlab/components/__init__.py
@@ -15,6 +15,7 @@ from .erosion_deposition import ErosionDeposition
 from .fire_generator import FireGenerator
 from .flexure import Flexure, Flexure1D
 from .flow_accum import FlowAccumulator, LossyFlowAccumulator
+from .flow_router import FastscapelibFlowRouter
 from .flow_director import (
     FlowDirectorD8,
     FlowDirectorDINF,
@@ -100,6 +101,7 @@ COMPONENTS = [
     ExponentialWeatherer,
     ExponentialWeathererIntegrated,
     FastscapeEroder,
+    FastscapelibFlowRouter,
     FireGenerator,
     Flexure,
     Flexure1D,

--- a/landlab/components/flow_router/__init__.py
+++ b/landlab/components/flow_router/__init__.py
@@ -1,0 +1,3 @@
+from .fastscapelib_flow_router import FastscapelibFlowRouter
+
+__all__ = ["FastscapelibFlowRouter"]

--- a/landlab/components/flow_router/fastscapelib_flow_router.py
+++ b/landlab/components/flow_router/fastscapelib_flow_router.py
@@ -1,0 +1,205 @@
+"""fastscapelib_flow_router.py: Component to compute flow routes, accumulate
+flow and calculate drainage area.
+
+It provides the FastscapelibFlowRouter components which exposes the flow routing
+capabilities available in the Fastscapelib library
+(https://fastscapelib.readthedocs.io/). This includes:
+
+- computing flow routes on different kinds of grids and using simple to advanced
+  strategies (single vs. multiple direction flow, closed depression resolving)
+- accumulate flow
+- compute drainage area
+"""
+
+import numpy as np
+import fastscapelib as fs
+
+from landlab import (
+    Component,
+    RasterModelGrid,
+)
+from landlab.utils import return_array_at_node
+
+
+def _get_nodes_status(grid):
+    """Return a dictionary of Fastscapelib NodeStatus from a landlab grid."""
+
+    node_status = {}
+    for i in grid.fixed_value_boundary_nodes:
+        node_status[i] = fs.NodeStatus.FIXED_VALUE
+    for i in grid.fixed_gradient_boundary_nodes:
+        node_status[i] = fs.NodeStatus.FIXED_GRADIENT
+
+    return node_status
+
+
+class FastscapelibFlowRouter(Component):
+
+    _name = "FastscapelibFlowRouter"
+
+    _unit_agnostic = True
+
+    _info = {
+        # input grid fields
+        "topographic__elevation": {
+            "dtype": float,
+            "intent": "in",
+            "optional": True,
+            "units": "m",
+            "mapping": "node",
+            "doc": "Land surface topographic elevation",
+        },
+        # output grid fields
+        "flow__link_to_receiver_node": {
+            "dtype": int,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "ID of link downstream of each node, which carries the discharge",
+        },
+        "flow__receiver_node": {
+            "dtype": int,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array of receivers (node that receives flow from current node)",
+        },
+        "flow__upstream_node_order": {
+            "dtype": int,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Node array containing downstream-to-upstream ordered list of node IDs",
+        },
+        "flood_status_code": {
+            "dtype": int,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "Map of flood status (_PIT, _CURRENT_LAKE, _UNFLOODED, or _FLOODED).",
+        },
+        "topographic__steepest_slope": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "-",
+            "mapping": "node",
+            "doc": "The steepest *downhill* slope",
+        },
+        "drainage_area": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**2",
+            "mapping": "node",
+            "doc": "Upstream accumulated surface area contributing to the node's discharge",
+        },
+        "surface_water__discharge": {
+            "dtype": float,
+            "intent": "out",
+            "optional": False,
+            "units": "m**3/s",
+            "mapping": "node",
+            "doc": "Volumetric discharge of surface water",
+        },
+    }
+
+    def __init__(
+        self,
+        grid,
+        operators,
+        surface="topographic__elevation",
+    ):
+        super().__init__(grid)
+
+        node_status = _get_nodes_status(grid)
+
+        if isinstance(grid, RasterModelGrid):
+            self._fs_grid = fs.RasterGrid(
+                list(grid.shape), grid.spacing, fs.NodeStatus.CORE
+            )
+        else:
+            raise TypeError("other grids than raster are not yet supported")
+
+        self._fs_flow_graph = fs.FlowGraph(self._fs_grid, operators)
+        base_levels = [i for i, status in node_status.items() if status == fs.NodeStatus.FIXED_VALUE]
+        self._fs_flow_graph.base_levels = base_levels
+
+        # do not include closed nodes in the flow graph
+        mask = np.zeros(grid.shape, dtype=bool)
+        mask.ravel()[grid.closed_boundary_nodes] = True
+        self._fs_flow_graph.mask = mask
+
+        self._surface = surface
+        self._surface_values = return_array_at_node(grid, surface)
+
+        self.initialize_output_fields()
+
+        self._drainage_area = grid.at_node["drainage_area"]
+
+    def _maybe_reshape(self, arr) -> np.ndarray:
+        if isinstance(self._grid, RasterModelGrid):
+            return arr.reshape(self._grid.shape)
+        else:
+            return arr
+
+    @property
+    def surface_values(self):
+        """Values of the surface over which flow is routed and accumulated."""
+        return self._surface_values
+
+    @property
+    def node_drainage_area(self):
+        """Return the drainage area."""
+        return self._grid["node"]["drainage_area"]
+
+    @property
+    def node_water_discharge(self):
+        """Return the surface water discharge."""
+        return self._grid["node"]["surface_water__discharge"]
+
+    def _set_link_to_receiver_node(self, receivers):
+        # TODO: more grid-agnostic and efficient way to do this?
+        ncols = self._grid.shape[1]
+        rel_idx = receivers - np.arange(receivers.size)
+
+        # translate relative receiver index to landlab relative link index
+        map_idx = [1, ncols, -1, -ncols, ncols + 1, ncols - 1, -ncols - 1, -ncols + 1]
+
+        temp = rel_idx.copy()
+
+        for i, idx in enumerate(map_idx):
+            temp = np.where(rel_idx == idx, i, temp)
+
+        rcvr_links = np.take_along_axis(self._grid.d8s_at_node, temp[:, None], axis=1).squeeze()
+        self._grid.at_node["flow__link_to_receiver_node"][:] = np.where(rel_idx == 0, -1, rcvr_links)
+
+    def update_routes(self):
+        filled_elevation = self._fs_flow_graph.update_routes(self._maybe_reshape(self.surface_values))
+        filled_elevation_flat = filled_elevation.ravel()
+
+        elevation = self.surface_values
+        receivers = self._fs_flow_graph.impl().receivers.astype("int").squeeze()
+        receivers_distance = self._fs_flow_graph.impl().receivers_distance.squeeze()
+        node_order = self._fs_flow_graph.impl().nodes_indices_bottomup.astype("int")
+        slope = (filled_elevation_flat - filled_elevation_flat[receivers]) / np.where(receivers_distance == 0, 1, receivers_distance)
+        flood_code = np.where(elevation < filled_elevation_flat, 3, 0)   # 0: unflooded, 3: flooded
+        flood_code[self._fs_flow_graph.base_levels] = 0
+
+        self._grid.at_node["flow__receiver_node"][:] = receivers
+        self._grid.at_node["flow__upstream_node_order"][:] = node_order
+        self._grid.at_node["topographic__steepest_slope"][:] = slope
+        self._grid.at_node["flood_status_code"] = flood_code
+        self._set_link_to_receiver_node(receivers)
+
+    def accumulate_flow(self):
+        self._fs_flow_graph.accumulate(self._maybe_reshape(self.node_drainage_area), 1)
+        self._fs_flow_graph.accumulate(self._maybe_reshape(self.node_water_discharge), 1)
+
+    def run_one_step(self):
+        self.update_routes()
+        self.accumulate_flow()


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

This PR adds yet another flow router component to Landlab, here reusing the [Fastscapelib](https://github.com/fastscape-lem/fastscapelib) library under the hood. This is very much work in progress (just a minimal proof-of-concept working only with raster grids at the moment... ~~I also have some issues running some depression resolution methods with eroders like SPACE~~ fixed upstream).

The `FastscapelibFlowRouter` component added here obviously has a lot of overlap with the other flow router components (including the one implemented in #1487), which isn't necessarily bad IMO. This one has the following advantages:

- It is (should be) a lightweight wrapper exposing Fastscapelib's flow routing capabilities to Landlab. We can directly plug fastscapelib's [flow operators](https://fastscapelib.readthedocs.io/en/latest/guide_flow.html#flow-operators) into a new `FastscapelibFlowRouter`, which means that any operator (flow router, depression resolver, etc.) added in Fastscapelib in the future (hopefully!) will be readily available to Landlab users without changing anything in the Landlab code base. Other future enhancements (we plan to add parallelization) will be available too without any additional development effort here.

- It is very fast. On a 300x300 raster grid with 100 time steps starting from a flat / randomly perturbed surface and using Fastscapelib's [SingleFlowRouter](https://fastscapelib.readthedocs.io/en/latest/api_python/_api_generated/fastscapelib.SingleFlowRouter.html#fastscapelib.SingleFlowRouter) and [MSTSinkResolver](https://fastscapelib.readthedocs.io/en/latest/api_python/_api_generated/fastscapelib.MSTSinkResolver.html#fastscapelib.MSTSinkResolver) (details in the example below), it is 2x faster than `FlowRouter` (#1487), 15x faster than `PriorityFloodFlowRouter` (I've also tried `FlowAccumulator` with `DepressionFinderAndRouter` but it didn't complete the 1st time step after 1'50"). I don't think we can fully avoid duplicating some data in memory, but Fastscapelib is optimized to avoid re-allocating arrays many times.

- Fastscapelib supports [various kinds of grids](https://fastscapelib.readthedocs.io/en/latest/guide_grids.html) so I guess it would be possible to reuse `FastscapelibFlowRouter` with other kinds of Landlab grids too. Fastscapelib has also full support for periodic boundaries for rectangular uniform grids.

This component relies on an external dependency, which should always be considered carefully even if we make it optional. Fastscapelib doesn't have a large community yet, but I think that the last release of Fastscapelib (just a few days old!) is "robust" enough to mitigate the risk: it has extensive tests, documentation, CI, binary wheels and conda-forge packages for all platforms, it only depends on Python and Numpy... And the wrapper code isn't a lot to maintain in Landlab. Alternatively, I'd be happy to maintain `FastscapelibFlowRouter` in a 3rd-party Landlab extension if Landlab's components API is public and stable enough to allow that, although it wouldn't be as discoverable as if it was in Landlab (I don't know if/how many components are implemented in other repositories). 


### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [ ] All tests have passed?
- [ ] Formatted code with black?
- [ ] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->

## Example

Adapted from https://github.com/landlab/landlab/pull/1487#issuecomment-1737337838.

<details>
<summary>Click me to show the Python code!</summary>

```python
import numpy as np

from landlab import RasterModelGrid
from landlab.components import (
    PriorityFloodFlowRouter,
    FlowAccumulator,
    DepressionFinderAndRouter,
    StreamPowerEroder,
    # https://github.com/landlab/landlab/pull/1487
    FlowRouter,
    # this PR
    FastscapelibFlowRouter,
)

import fastscapelib as fs


num_rows = 301
num_columns = 301
node_spacing = 100.0
mg = RasterModelGrid((num_rows, num_columns), xy_spacing=node_spacing)

np.random.seed(seed=5000)

mg.add_full("soil__depth", 2.0, at="node")
mg.add_field(
    "bedrock__elevation",
    np.random.rand(len(mg.node_y)) / 1000.0,
    at="node",
)
mg.add_field(
    "topographic__elevation",
    mg.at_node["bedrock__elevation"] + mg.at_node["soil__depth"],
    at="node",
)

mg.set_closed_boundaries_at_grid_edges(
    bottom_is_closed=True,
    left_is_closed=True,
    right_is_closed=True,
    top_is_closed=True,
)

node_next_to_outlet = num_columns + 1
mg.set_watershed_boundary_condition_outlet_id(
    0, mg.at_node['topographic__elevation'], -9999.0
)
mg.at_node["soil__depth"][0] = 0.0
mg.at_node["bedrock__elevation"][0] = 1.0
mg.at_node["topographic__elevation"][0] = 1.0

#fr = PriorityFloodFlowRouter(mg, flow_metric='D8', suppress_out = True)

#fr = FlowAccumulator(
#    mg,
#    'topographic__elevation',
#    flow_director='FlowDirectorD8',
#    depression_finder=DepressionFinderAndRouter
#)

fr = FastscapelibFlowRouter(mg, [fs.SingleFlowRouter(), fs.MSTSinkResolver()])

#fr = FlowRouter(
#    mg, 
#    surface="topographic__elevation", 
#    diagonals=True, 
#    runoff_rate=1,
#    single_flow=True
#)

sp = StreamPowerEroder(
    mg,
    K_sp=0.001,
    m_sp=0.5,
    n_sp=1.0,
)

timestep = 10.0
nsteps = 100
run_time = timestep * nsteps

for i in range(nsteps):
    fr.run_one_step()
    sp.run_one_step(dt=timestep)
```

</details>
