### PR TITLE
Use Ruff linter instead of flake8 and pyupgrade

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,8 +21,8 @@
     Ensure proper code formatting with black. You can do this by running
     black from landlab's top-level folder.
 
-    Ensure landlab is lint-free by running flake8 at landlab's top-level
-    folder.
+    Ensure landlab is lint-free by running `ruff check .` at landlab's
+    top-level folder.
 
     If you like, you can automate these tasks by installing pre-commit hooks.
     This is done by running `pre-commit install` at landlab's top-level
@@ -34,7 +34,7 @@
 - [ ] Add new / update outdated documentation?
 - [ ] All tests have passed?
 - [ ] Formatted code with black?
-- [ ] Removed lint reported by flake8?
+- [ ] Removed lint reported by ruff check?
 - [ ] Sucessful documentation built? (if documentation added or modified)
 
 <!-- Thanks for your time and effort. If you have any feedback in regards

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,14 +42,14 @@ repos:
   - id: blackdoc
     description: "Black for doctests"
 
-- repo: https://github.com/pycqa/flake8
-  rev: 6.1.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.8
   hooks:
-  - id: flake8
-    additional_dependencies:
-    - flake8-bugbear
-    - flake8-comprehensions
-    - flake8-simplify
+    # Run the linter
+    - id: ruff
+      args: [ --fix ]
+    # Run the formatter
+    # - id: ruff-format
 
 - repo: https://github.com/nbQA-dev/nbQA
   rev: 1.7.1
@@ -57,7 +57,7 @@ repos:
     - id: nbqa-pyupgrade
       args: ["--py310-plus"]
     - id: nbqa-isort
-    - id: nbqa-flake8
+    - id: nbqa-ruff
       args: ["--extend-ignore=E402"]
       exclude: |
           (?x)^(
@@ -70,12 +70,6 @@ repos:
     - id: nbstripout
       description: Strip output from jupyter notebooks
       args: [--drop-empty-cells]
-
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.15.0
-  hooks:
-  - id: pyupgrade
-    args: [--py310-plus]
 
 - repo: https://github.com/PyCQA/isort
   rev: 5.12.0

--- a/docs/source/development/practices/style_conventions.rst
+++ b/docs/source/development/practices/style_conventions.rst
@@ -30,15 +30,15 @@ If you followed the
 :ref:`developer installation instructions <install>` you have
 everything you need in the `landlab_dev` conda environment.
 
-Currently we check for all the `flake8
+Currently we check for all the `Ruff Linter
+violations <https://docs.astral.sh/ruff/linter/>`_ (based on `flake8
 violations <https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes>`_
 and `pycodestyle
-violations <http://flake8.pycqa.org/en/latest/user/error-codes.html>`_
-except for (as defined in our ``setup.cfg``)
+violations <http://flake8.pycqa.org/en/latest/user/error-codes.html>`_),
+except for (as defined in ``pyproject.toml``):
 
 * E203: whitespace before
 * E501: line too long (n > 88 characters)
-* W503: line break before binary operator
 
 To format files to meet these standards, we recommend using
 `isort <https://pypi.org/project/isort/>`_ +

--- a/landlab/bmi/bmi_bridge.py
+++ b/landlab/bmi/bmi_bridge.py
@@ -249,11 +249,9 @@ def wrap_as_bmi(cls):
         raise TypeError("class must inherit from Component")
 
     class BmiWrapper(Bmi):
-        __doc__ = """
-        Basic Modeling Interface for the {name} component.
-        """.format(
-            name=cls.__name__
-        ).strip()
+        __doc__ = f"""
+        Basic Modeling Interface for the {cls.__name__} component.
+        """.strip()
 
         _cls = cls
 

--- a/landlab/bmi/standard_names.py
+++ b/landlab/bmi/standard_names.py
@@ -31,9 +31,6 @@ STANDARD_NAME = {
     "lithosphere_surface__elevation_increment": (
         "lithosphere_top_surface__increment_of_elevation"
     ),
-    "lithosphere_surface__elevation_increment": (
-        "lithosphere_top_surface__increment_of_elevation"
-    ),
     "plant__age": "plant__age",
     "plant__live_index": None,
     "radiation__incoming_shortwave_flux": (

--- a/landlab/ca/celllab_cts.py
+++ b/landlab/ca/celllab_cts.py
@@ -394,7 +394,7 @@ class CellLabCTSModel:
         self.num_node_states_sq = self.num_node_states * self.num_node_states
         self.num_link_states = self.number_of_orientations * self.num_node_states_sq
 
-        assert type(transition_list) is list, "transition_list must be a list!"
+        assert isinstance(transition_list, list), "transition_list must be a list!"
         assert transition_list, "Transition list must contain at least one transition"
         last_type = None
         for t in transition_list:

--- a/landlab/components/lake_fill/lake_fill_barnes.py
+++ b/landlab/components/lake_fill/lake_fill_barnes.py
@@ -1232,7 +1232,7 @@ class LakeMapperBarnes(Component):
                     for neighbor_set, link_set in zip(
                         self._neighbor_arrays, self._link_arrays
                     ):
-                        for n, l in zip(neighbor_set[c, :], link_set[c, :]):
+                        for n, lks in zip(neighbor_set[c, :], link_set[c, :]):
                             # fully closed
                             if (closedq[n] == 2) or (n == -1):
                                 continue
@@ -1242,7 +1242,7 @@ class LakeMapperBarnes(Component):
                             else:
                                 if closedq[n] == 0:
                                     self._receivers[n] = c
-                                    self._receiverlinks[n] = l
+                                    self._receiverlinks[n] = lks
                                     self._steepestslopes[n] = 0.0
                                     closedq[n] = 2  # close it
                                     openq.add_task(n, priority=surface[n])

--- a/landlab/core/model_component.py
+++ b/landlab/core/model_component.py
@@ -76,9 +76,7 @@ class Component:
                 # if required input, verify that it exists.
                 if name not in self._grid[at]:
                     raise FieldError(
-                        "{component} is missing required input field: {name} at {at}".format(
-                            component=self._name, name=name, at=at
-                        )
+                        f"{self._name} is missing required input field: {name} at {at}"
                     )
 
                 # if required input exists, check dtype.

--- a/landlab/core/utils.py
+++ b/landlab/core/utils.py
@@ -66,9 +66,7 @@ class ExampleData:
         for dst in (dstdir / p for p in self):
             if dst.exists():
                 raise FileExistsError(
-                    "[Errno {errno}] File exists: {name}".format(
-                        errno=errno.EEXIST, name=repr(dst.name)
-                    )
+                    f"[Errno {errno.EEXIST}] File exists: {dst.name!r}"
                 )
 
         for src in (srcdir / p for p in self):

--- a/landlab/data_record/data_record.py
+++ b/landlab/data_record/data_record.py
@@ -963,9 +963,7 @@ class DataRecord:
                [ 0.4]])
         """
         if data_variable not in self.variable_names:
-            raise KeyError(
-                "the variable '{}' is not in the " "DataRecord".format(data_variable)
-            )
+            raise KeyError(f"the variable '{data_variable}' is not in the DataRecord")
 
         # If record to be changed is 'grid_element' or 'element_id',
         # check that provided grid_element is valid and that new

--- a/landlab/field/errors.py
+++ b/landlab/field/errors.py
@@ -38,8 +38,6 @@ class GroupSizeError(Error, KeyError):
 
     def __str__(self):
         return (
-            "number of {group} elements has changed. "
-            "(was = {was}, now={now})".format(
-                group=self._group, was=self._old_size, now=self._new_size
-            )
+            f"number of {self._group} elements has changed. "
+            f"(was = {self._old_size}, now={self._new_size})"
         )

--- a/landlab/field/graph_field.py
+++ b/landlab/field/graph_field.py
@@ -130,9 +130,7 @@ def shape_for_storage(array, field_size=None):
 
     if array.size % field_size != 0:
         raise ValueError(
-            "unable to reshape array to field size ({} != {})".format(
-                array.size, field_size
-            )
+            f"unable to reshape array to field size ({array.size} != {field_size})"
         )
 
     if field_size == array.size:
@@ -233,9 +231,7 @@ class FieldDataset(dict):
         if self._size != size:
             if self._size is not None and self.fixed_size:
                 raise ValueError(
-                    "size has already been set ({size}) and fixed_size is True".format(
-                        size=self._size
-                    )
+                    f"size has already been set ({self._size}) and fixed_size is True"
                 )
             elif not isinstance(size, int) or size < 0:
                 raise ValueError(f"size must be a positive integer or None ({size})")

--- a/landlab/grid/base.py
+++ b/landlab/grid/base.py
@@ -1655,7 +1655,7 @@ class ModelGrid(
         else:
             assert out.shape is self.links_at_node.shape
             assert out.dtype is bool
-        if type(values) is str:
+        if isinstance(values, str):
             vals = self.at_link[values]
         else:
             assert len(values) == self.number_of_links
@@ -1737,7 +1737,7 @@ class ModelGrid(
         else:
             assert out.shape is self.links_at_node.shape
             assert out.dtype is bool
-        if type(values) is str:
+        if isinstance(values, str):
             vals = self.at_link[values]
         else:
             assert len(values) == self.number_of_links
@@ -1810,7 +1810,7 @@ class ModelGrid(
 
         :meta landlab: info-link, info-node, connectivity
         """
-        if type(values) is str:
+        if isinstance(values, str):
             vals = self.at_link[values]
         else:
             assert len(values) == self.number_of_links
@@ -1895,7 +1895,7 @@ class ModelGrid(
 
         :meta landlab: info-link, info-node, connectivity
         """
-        if type(values) is str:
+        if isinstance(values, str):
             vals = self.at_link[values]
         else:
             assert len(values) == self.number_of_links

--- a/landlab/grid/hex.py
+++ b/landlab/grid/hex.py
@@ -365,7 +365,7 @@ class HexModelGrid(DualHexGraph, ModelGrid):
         # Handle *data*: if it's a numpy array, then we consider it the
         # data to be plotted. If it's a string, we consider it the name of the
         # node-field to plot, and we fetch it.
-        if type(data) is str:
+        if isinstance(data, str):
             data_label = data
             data = self.at_node[data]
 

--- a/landlab/grid/mappers.py
+++ b/landlab/grid/mappers.py
@@ -119,7 +119,7 @@ def map_link_head_node_to_link(grid, var_name, out=None):
 
     :meta landlab: info-node, info-link, map
     """
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     if out is None:
         out = grid.empty(at="link")
@@ -178,7 +178,7 @@ def map_link_tail_node_to_link(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     out[:] = var_name[grid.node_at_link_tail]
 
@@ -241,7 +241,7 @@ def map_min_of_link_nodes_to_link(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     np.minimum(
         var_name[grid.node_at_link_head], var_name[grid.node_at_link_tail], out=out
@@ -306,7 +306,7 @@ def map_max_of_link_nodes_to_link(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     np.maximum(
         var_name[grid.node_at_link_head], var_name[grid.node_at_link_tail], out=out
@@ -363,7 +363,7 @@ def map_mean_of_link_nodes_to_link(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     out[:] = 0.5 * (var_name[grid.node_at_link_head] + var_name[grid.node_at_link_tail])
 
@@ -432,9 +432,9 @@ def map_value_at_min_node_to_link(grid, control_name, value_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(control_name) is str:
+    if isinstance(control_name, str):
         control_name = grid.at_node[control_name]
-    if type(value_name) is str:
+    if isinstance(value_name, str):
         value_name = grid.at_node[value_name]
     head_control = control_name[grid.node_at_link_head]
     tail_control = control_name[grid.node_at_link_tail]
@@ -507,9 +507,9 @@ def map_value_at_max_node_to_link(grid, control_name, value_name, out=None):
     if out is None:
         out = grid.empty(at="link")
 
-    if type(control_name) is str:
+    if isinstance(control_name, str):
         control_name = grid.at_node[control_name]
-    if type(value_name) is str:
+    if isinstance(value_name, str):
         value_name = grid.at_node[value_name]
     head_control = control_name[grid.node_at_link_head]
     tail_control = control_name[grid.node_at_link_tail]
@@ -566,7 +566,7 @@ def map_node_to_cell(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="cell")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     out[:] = var_name[grid.node_at_cell]
 
@@ -625,7 +625,7 @@ def map_min_of_node_links_to_node(grid, var_name, out=None):
 
     values_at_linksX = np.empty(grid.number_of_links + 1, dtype=float)
     values_at_linksX[-1] = np.finfo(dtype=float).max
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_linksX[:-1] = grid.at_link[var_name]
     else:
         values_at_linksX[:-1] = var_name
@@ -686,7 +686,7 @@ def map_max_of_node_links_to_node(grid, var_name, out=None):
 
     values_at_linksX = np.empty(grid.number_of_links + 1, dtype=float)
     values_at_linksX[-1] = np.finfo(dtype=float).min
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_linksX[:-1] = grid.at_link[var_name]
     else:
         values_at_linksX[:-1] = var_name
@@ -765,7 +765,7 @@ def map_upwind_node_link_max_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_link[var_name]
     values_at_links = var_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -844,7 +844,7 @@ def map_downwind_node_link_max_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(at="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_link[var_name]
     values_at_links = var_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -925,7 +925,7 @@ def map_upwind_node_link_mean_to_node(grid, var_name, out=None):
         out = grid.empty(at="node")
     out[:] = 0.0
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_link[var_name]
     values_at_links = var_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -1010,7 +1010,7 @@ def map_downwind_node_link_mean_to_node(grid, var_name, out=None):
         out = grid.empty(at="node")
     out[:] = 0.0
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_link[var_name]
     values_at_links = var_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -1101,9 +1101,9 @@ def map_value_at_upwind_node_link_max_to_node(grid, control_name, value_name, ou
     if out is None:
         out = grid.empty(at="node")
 
-    if type(control_name) is str:
+    if isinstance(control_name, str):
         control_name = grid.at_link[control_name]
-    if type(value_name) is str:
+    if isinstance(value_name, str):
         value_name = grid.at_link[value_name]
     values_at_nodes = control_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -1196,9 +1196,9 @@ def map_value_at_downwind_node_link_max_to_node(
     if out is None:
         out = grid.empty(at="node")
 
-    if type(control_name) is str:
+    if isinstance(control_name, str):
         control_name = grid.at_link[control_name]
-    if type(value_name) is str:
+    if isinstance(value_name, str):
         value_name = grid.at_link[value_name]
     values_at_nodes = control_name[grid.links_at_node] * grid.link_dirs_at_node
     # this procedure makes incoming links NEGATIVE
@@ -1267,7 +1267,7 @@ def map_mean_of_patch_nodes_to_patch(
     if out is None:
         out = np.zeros(grid.number_of_patches, dtype=float)
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     values_at_nodes = var_name[grid.nodes_at_patch]
     if ignore_closed_nodes:
@@ -1343,7 +1343,7 @@ def map_max_of_patch_nodes_to_patch(grid, var_name, ignore_closed_nodes=True, ou
     if out is None:
         out = np.zeros(grid.number_of_patches, dtype=float)
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     values_at_nodes = var_name[grid.nodes_at_patch]
     if ignore_closed_nodes:
@@ -1419,7 +1419,7 @@ def map_min_of_patch_nodes_to_patch(grid, var_name, ignore_closed_nodes=True, ou
     if out is None:
         out = np.zeros(grid.number_of_patches, dtype=float)
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_node[var_name]
     values_at_nodes = var_name[grid.nodes_at_patch]
     if ignore_closed_nodes:
@@ -1528,7 +1528,7 @@ def map_link_vector_sum_to_patch(grid, var_name, ignore_inactive_links=True, out
     else:
         assert len(out) == 2
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         var_name = grid.at_link[var_name]
     angles_at_links = grid.angle_of_link  # CCW round tail
     hoz_cpt = np.cos(angles_at_links)

--- a/landlab/grid/raster_mappers.py
+++ b/landlab/grid/raster_mappers.py
@@ -188,7 +188,7 @@ def map_sum_of_inlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -241,7 +241,7 @@ def map_mean_of_inlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -296,7 +296,7 @@ def map_max_of_inlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -350,7 +350,7 @@ def map_min_of_inlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -404,7 +404,7 @@ def map_sum_of_outlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -458,7 +458,7 @@ def map_mean_of_outlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -512,7 +512,7 @@ def map_max_of_outlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -565,7 +565,7 @@ def map_min_of_outlinks_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -620,7 +620,7 @@ def map_mean_of_links_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -686,7 +686,7 @@ def map_mean_of_horizontal_links_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -747,7 +747,7 @@ def map_mean_of_horizontal_active_links_to_node(grid, var_name, out=None):
     else:
         out.fill(0.0)
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -803,7 +803,7 @@ def map_mean_of_vertical_links_to_node(grid, var_name, out=None):
     if out is None:
         out = grid.empty(centering="node")
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name
@@ -864,7 +864,7 @@ def map_mean_of_vertical_active_links_to_node(grid, var_name, out=None):
     else:
         out.fill(0.0)
 
-    if type(var_name) is str:
+    if isinstance(var_name, str):
         values_at_links = grid.at_link[var_name]
     else:
         values_at_links = var_name

--- a/landlab/io/esri_ascii.py
+++ b/landlab/io/esri_ascii.py
@@ -105,9 +105,7 @@ class DataSizeError(Error):
         self._expected = expected_size
 
     def __str__(self):
-        return "{} != {}".format(
-            self._actual, self._expected
-        )  # this line not yet tested
+        return f"{self._actual} != {self._expected}"  # this line not yet tested
 
 
 class MismatchGridDataSizeError(Error):
@@ -119,10 +117,7 @@ class MismatchGridDataSizeError(Error):
         self._expected = expected_size
 
     def __str__(self):
-        return "(data size) {} != {} (grid size)".format(
-            self._actual,
-            self._expected,
-        )  # this line not yet tested
+        return f"(data size) {self._actual} != {self._expected} (grid size)"  # this line not yet tested
 
 
 class MismatchGridXYSpacing(Error):
@@ -134,10 +129,7 @@ class MismatchGridXYSpacing(Error):
         self._expected = expected_dx
 
     def __str__(self):
-        return "(data dx) {} != {} (grid dx)".format(
-            self._actual,
-            self._expected,
-        )  # this line not yet tested
+        return f"(data dx) {self._actual} != {self._expected} (grid dx)"  # this line not yet tested
 
 
 class MismatchGridXYLowerLeft(Error):
@@ -149,10 +141,7 @@ class MismatchGridXYLowerLeft(Error):
         self._expected = expected_llc
 
     def __str__(self):
-        return "(data lower-left) {} != {} (grid lower-left)".format(
-            self._actual,
-            self._expected,
-        )  # this line not yet tested
+        return f"(data lower-left) {self._actual} != {self._expected} (grid lower-left)"  # this line not yet tested
 
 
 def _parse_header_key_value(line):

--- a/landlab/layers/eventlayers.py
+++ b/landlab/layers/eventlayers.py
@@ -209,9 +209,7 @@ class _BlockSlice:
 
         if self._stop is not None and self._stop < self._start:
             raise ValueError(
-                "stop ({}) must be greater than start ({})".format(
-                    self._stop, self._start
-                )
+                f"stop ({self._stop}) must be greater than start ({self._start})"
             )
 
     def __repr__(self):
@@ -307,11 +305,10 @@ def _valid_keywords_or_raise(kwds, required=(), optional=()):
 
     unknown = keys - optional
     if unknown:
+        unknown_str = ", ".join(sorted(repr(name) for name in unknown))
+        optional_str = ", ".join(sorted(repr(name) for name in optional))
         raise TypeError(
-            "invalid keyword arguments ({0} not in {{{1}}})".format(
-                ", ".join(sorted(repr(name) for name in unknown)),
-                ", ".join(sorted(repr(name) for name in optional)),
-            )
+            f"invalid keyword arguments ({unknown_str} not in {optional_str})"
         )
 
     missing = required - keys
@@ -560,9 +557,7 @@ class EventLayers:
         )
 
     def __repr__(self):
-        return self.__class__.__name__ + "({number_of_stacks})".format(
-            number_of_stacks=self.number_of_stacks
-        )
+        return self.__class__.__name__ + f"({self.number_of_stacks})"
 
     @property
     def tracking(self):

--- a/landlab/plot/imshow.py
+++ b/landlab/plot/imshow.py
@@ -407,16 +407,16 @@ def _imshow_grid_values(
 
     if var_name is not None or var_units is not None:
         if var_name is not None:
-            assert type(var_name) is str
+            assert isinstance(var_name, str)
             if var_units is not None:
-                assert type(var_units) is str
+                assert isinstance(var_units, str)
                 colorbar_label = var_name + " (" + var_units + ")"
             else:
                 colorbar_label = var_name
         else:
-            assert type(var_units) is str
+            assert isinstance(var_units, str)
             colorbar_label = "(" + var_units + ")"
-        assert type(colorbar_label) is str
+        assert isinstance(colorbar_label, str)
         assert allow_colorbar
         cb.set_label(colorbar_label)
 
@@ -424,7 +424,7 @@ def _imshow_grid_values(
         plt.gca().set_facecolor(color_for_background)
 
     if output is not None:
-        if type(output) is str:
+        if isinstance(output, str):
             plt.savefig(output)
             plt.clf()
         elif output:

--- a/landlab/plot/imshowhs.py
+++ b/landlab/plot/imshowhs.py
@@ -945,16 +945,16 @@ def _imshowhs_grid_values(
         and plot_type != "Drape2"
     ):
         if var_name is not None:
-            assert type(var_name) is str
+            assert isinstance(var_name, str)
             if var_units is not None:
-                assert type(var_units) is str
+                assert isinstance(var_units, str)
                 colorbar_label = var_name + " (" + var_units + ")"
             else:
                 colorbar_label = var_name
         else:
-            assert type(var_units) is str
+            assert isinstance(var_units, str)
             colorbar_label = "(" + var_units + ")"
-        assert type(colorbar_label) is str
+        assert isinstance(colorbar_label, str)
         if allow_colorbar:
             cb.set_label(
                 colorbar_label,

--- a/landlab/utils/decorators.py
+++ b/landlab/utils/decorators.py
@@ -130,13 +130,9 @@ def add_signature_to_doc(func):
     <BLANKLINE>
     Do something.
     """
-    return """{name}{argspec}
+    return f"""{func.__name__}{inspect.signature(func)!s}
 
-{body}""".format(
-        name=func.__name__,
-        argspec=str(inspect.signature(func)),
-        body=inspect.getdoc(func),
-    )
+{inspect.getdoc(func)}"""
 
 
 class use_field_name_or_array:
@@ -377,14 +373,12 @@ def deprecated(use, version):
     """
 
     def real_decorator(func):
-        warning_str = """
-.. note:: This method is deprecated as of Landlab version {ver}.
+        warning_str = f"""
+.. note:: This method is deprecated as of Landlab version {version}.
 
     Use :func:`{use}` instead.
 
-""".format(
-            ver=version, use=use
-        )
+"""
 
         doc_lines = (func.__doc__ or "").split(os.linesep)
 
@@ -406,9 +400,7 @@ def deprecated(use, version):
                 pass
             else:
                 warnings.warn(
-                    message="Call to deprecated function {name}.".format(
-                        name=func.__name__
-                    ),
+                    message=f"Call to deprecated function {func.__name__}.",
                     category=DeprecationWarning,
                     stacklevel=2,
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,30 @@ archs = "x86_64,aarch64,arm64,AMD64,x86"
 channels = ["conda-forge", "defaults"]
 platforms = ["osx-arm64", "linux-64", "osx-64", "win-64"]
 
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    #"B",
+    # flake8-simplify
+    #"SIM",
+    # isort
+    #"I",
+]
+ignore = [
+    # whitespace before
+    "E203",
+    # line too long (n > 88 characters)
+    "E501",
+    # avoid for now; see https://github.com/astral-sh/ruff/issues/7871
+    "UP038",
+]
+
 [tool.towncrier]
 directory = "news"
 package = "landlab"

--- a/scripts/introspect_components.py
+++ b/scripts/introspect_components.py
@@ -222,7 +222,7 @@ for name in comp_elements.keys():
                                 + "('node', 'link', etc)."
                             )
                 else:
-                    if any(type(x) is not str for x in this_un[prop].values()):
+                    if any(not isinstance(x, str) for x in this_un[prop].values()):
                         problems.append(
                             "One or more values in the dict "
                             + prop
@@ -246,7 +246,7 @@ for name in comp_elements.keys():
 for key, vals in problematic_components.items():
     if len(vals) == 0:
         problematic_components.pop(key)
-    elif type(vals) is dict:
+    elif isinstance(vals, dict):
         problematic_components[key] = (
             "The following LL standard interface "
             + "properties are not defined: "

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,3 @@
-[flake8]
-exclude = docs, build, .nox
-ignore = C901, E203, E266, E501, W503, B905
-max-line-length = 88
-max-complexity = 18
-select = B,C,E,F,W,T4,B9
-
 [zest.releaser]
 tag-format = v{version}
 python-file-with-version = landlab/_version.py

--- a/tests/graph/structured_quad/test_quad.py
+++ b/tests/graph/structured_quad/test_quad.py
@@ -152,12 +152,8 @@ def test_layouts_cython_is_faster(method, size):
 
     def time_method(impl):
         return timeit(
-            "{impl}.{method}(({n_rows}, {n_cols}))".format(
-                impl=impl, method=method, n_rows=n_rows, n_cols=n_cols
-            ),
-            setup="from landlab.graph.structured_quad.structured_quad import {impl}".format(
-                impl=impl
-            ),
+            f"{impl}.{method}(({n_rows}, {n_cols}))",
+            setup=f"from landlab.graph.structured_quad.structured_quad import {impl}",
             number=1,
         )
 


### PR DESCRIPTION
### Description

This PR uses the much faster [Ruff Linter](https://docs.astral.sh/ruff/linter/) instead of flake8 and pyupgrade. Also `nbqa-flake8` is replaced with the recent `nbqa-ruff` hook.

Changes to the code are to resolve new issues highlighted by Ruff. Also, the pre-commit version has the `--fix` flag to try and resolve simple fixes.

I considered enabling `flake8-bugbear` and `flake8-simplify`, but these raise many more potential fixes. (Anyone can try this by uncommenting the appropriate line in `pyproject.toml` then do `ruff check .`)

Furthermore, the [Ruff Formater](https://docs.astral.sh/ruff/formatter/) could be considered at some point to replace black, but not in this PR.

### Checklist - did you ...

- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [X] Add new / update outdated documentation?
- [ ] All tests have passed?
- [X] Formatted code with black?
- [X] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)
