### PR TITLE
Fix an issue installing multidict on Mac and Python 3.12

### DIFF
--- a/news/1850.misc
+++ b/news/1850.misc
@@ -1,0 +1,3 @@
+
+Fixed an issue that caused with the CI to fail when building *multidict* on
+Mac and Python 3.12.

--- a/noxfile.py
+++ b/noxfile.py
@@ -2,13 +2,14 @@ import json
 import os
 import pathlib
 import shutil
+import sys
 
 import nox
 from packaging.requirements import Requirement
 
 PROJECT = "landlab"
 ROOT = pathlib.Path(__file__).parent
-PYTHON_VERSION = "3.11"
+PYTHON_VERSION = "3.12"
 PATH = {
     "build": ROOT / "build",
     "docs": ROOT / "docs",
@@ -24,6 +25,10 @@ def test(session: nox.Session) -> None:
     os.environ["WITH_OPENMP"] = "1"
 
     session.log(f"CC = {os.environ.get('CC', 'NOT FOUND')}")
+
+    if sys.platform.startswith("darwin") and session.python == "3.12":
+        session.log("installing multidict from conda-forge.")
+        session.conda_install("multidict")
 
     session.install(
         "-r",
@@ -69,6 +74,10 @@ def test_notebooks(session: nox.Session) -> None:
     ] + session.posargs
 
     os.environ["WITH_OPENMP"] = "1"
+
+    if sys.platform.startswith("darwin") and session.python == "3.12":
+        session.log("installing multidict from conda-forge")
+        session.conda_install("multidict")
 
     session.install(
         "-r",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

This pull request fixes an issue with installing the *multidict* package on Mac and Python 3.12 when using the *conda* compilers. Since *multidict* does not yet provide a wheel for python 3.12 on [PyPI](https://pypi.org/project/multidict/), it must be built from source, which requires compiling some C code. That C code, though, requires *clang* 14 (not 16, which is the latest *conda-forge* version).

The temporary fix is to modify the *test* and *test-notebooks* *nox* sessions to install *multidict* from *conda-forge* if using Python 3.12 on Mac. Once Python 3.12 wheels are available for *multidict*, these changes should be removed.

The error we were seeing when running our CI tests was the following (the entire error message is pasted at the end),
```
/private/var/folders/3s/vfzpb5r51gs6y328rmlgzm7c0000gn/T/pip-build-env-gu49740f/overlay/lib/python3.12/site-packages/setuptools/command/build_py.py:207: _Warning: Package 'multidict._multilib' is absent from the `packages` configuration.
...
Failed to build multidict
ERROR: Could not build wheels for multidict, which is required to install pyproject.toml-based projects
```

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [x] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [x] Add / update tests if necessary?
- [x] Add new / update outdated documentation?
- [x] All tests have passed?
- [x] Formatted code with black?
- [x] Removed lint reported by flake8?
- [x] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->

<details>
<summary>The entire error message</summary>
```
/private/var/folders/3s/vfzpb5r51gs6y328rmlgzm7c0000gn/T/pip-build-env-gu49740f/overlay/lib/python3.12/site-packages/setuptools/command/build_py.py:207: _Warning: Package 'multidict._multilib' is absent from the `packages` configuration.
      !!
      
              ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'multidict._multilib' as an importable package[^1],
              but it is absent from setuptools' `packages` configuration.
      
              This leads to an ambiguous overall configuration. If you want to distribute this
              package, please make sure that 'multidict._multilib' is explicitly added
              to the `packages` configuration field.
      
              Alternatively, you can also rely on setuptools' discovery methods
              (for example by using `find_namespace_packages(...)`/`find_namespace:`
              instead of `find_packages(...)`/`find:`).
      
              You can read more about "package discovery" on setuptools documentation page:
      
              - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
      
              If you don't want 'multidict._multilib' to be distributed and are
              already explicitly excluding 'multidict._multilib' via
              `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
              you can try to use `exclude_package_data`, or `include-package-data=False` in
              combination with a more fine grained `package-data` configuration.
      
              You can read more about "package data files" on setuptools documentation page:
      
              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html
      
      
              [^1]: For Python, any directory (with suitable naming) can be imported,
                    even if it does not contain any `.py` files.
                    On the other hand, currently there is no concept of package data
                    directory, all directories are treated like packages.
              ********************************************************************************
      
      !!
        check.warn(importable)
      copying multidict/__init__.pyi -> build/lib.macosx-10.9-x86_64-cpython-312/multidict
      copying multidict/py.typed -> build/lib.macosx-10.9-x86_64-cpython-312/multidict
      running build_ext
      building 'multidict._multidict' extension
      creating build/temp.macosx-10.9-x86_64-cpython-312
      creating build/temp.macosx-10.9-x86_64-cpython-312/multidict
      x86_64-apple-darwin13.4.0-clang -fno-strict-overflow -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /Users/runner/work/landlab/landlab/.nox/test-3-12/include -fPIC -O2 -isystem /Users/runner/work/landlab/landlab/.nox/test-3-12/include -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fPIE -fstack-protector-strong -O2 -pipe -isystem /Users/runner/miniconda3/envs/test/include -D_FORTIFY_SOURCE=2 -isystem /Users/runner/miniconda3/envs/test/include -I/Users/runner/work/landlab/landlab/.nox/test-3-12/include/python3.12 -c multidict/_multidict.c -o build/temp.macosx-10.9-x86_64-cpython-312/multidict/_multidict.o -O2 -std=c99 -Wall -Wsign-compare -Wconversion -fno-strict-aliasing -pedantic
      In file included from multidict/_multidict.c:9:
      multidict/_multilib/iter.h:225:20: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
      multidict_iter_init()
                         ^
                          void
      In file included from multidict/_multidict.c:10:
      multidict/_multilib/views.h:388:21: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
      multidict_views_init()
                          ^
                           void
      multidict/_multidict.c:458:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "getall", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:458:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "getall", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:458:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[7]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "getall", 0};
                                                           ^~~~~~~~
      multidict/_multidict.c:503:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "getone", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:503:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "getone", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:503:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[7]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "getone", 0};
                                                           ^~~~~~~~
      multidict/_multidict.c:538:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "get", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:538:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "get", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:538:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[4]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "get", 0};
                                                           ^~~~~
      multidict/_multidict.c:712:5: warning: 'UsingDeprecatedTrashcanMacro' is deprecated [-Wdeprecated-declarations]
          Py_TRASHCAN_SAFE_BEGIN(self);
          ^
      /Users/runner/work/landlab/landlab/.nox/test-3-12/include/python3.12/cpython/object.h:551:9: note: expanded from macro 'Py_TRASHCAN_SAFE_BEGIN'
              UsingDeprecatedTrashcanMacro cond=1; \
              ^
      /Users/runner/work/landlab/landlab/.nox/test-3-12/include/python3.12/cpython/object.h:548:1: note: 'UsingDeprecatedTrashcanMacro' has been explicitly marked deprecated here
      Py_DEPRECATED(3.11) typedef int UsingDeprecatedTrashcanMacro;
      ^
      /Users/runner/work/landlab/landlab/.nox/test-3-12/include/python3.12/pyport.h:317:54: note: expanded from macro 'Py_DEPRECATED'
      #define Py_DEPRECATED(VERSION_UNUSED) __attribute__((__deprecated__))
                                                           ^
      multidict/_multidict.c:780:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "add", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:780:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "add", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:780:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[4]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "add", 0};
                                                           ^~~~~
      multidict/_multidict.c:839:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "setdefault", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:839:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "setdefault", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:839:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[11]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "setdefault", 0};
                                                           ^~~~~~~~~~~~
      multidict/_multidict.c:875:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "popone", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:875:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "popone", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:875:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[7]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "popone", 0};
                                                           ^~~~~~~~
      multidict/_multidict.c:922:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "pop", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:922:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "pop", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:922:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[4]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "pop", 0};
                                                           ^~~~~
      multidict/_multidict.c:970:37: error: incompatible pointer to integer conversion initializing 'int' with an expression of type 'void *' [-Wint-conversion]
          static _PyArg_Parser _parser = {NULL, _keywords, "popall", 0};
                                          ^~~~
      /Users/runner/miniconda3/envs/test/lib/clang/16/include/stddef.h:89:16: note: expanded from macro 'NULL'
      #  define NULL ((void*)0)
                     ^~~~~~~~~~
      multidict/_multidict.c:970:43: warning: incompatible pointer types initializing 'const char *' with an expression of type 'const char *const[3]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "popall", 0};
                                                ^~~~~~~~~
      multidict/_multidict.c:970:54: warning: incompatible pointer types initializing 'const char *const *' with an expression of type 'char[7]' [-Wincompatible-pointer-types]
          static _PyArg_Parser _parser = {NULL, _keywords, "popall", 0};
                                                           ^~~~~~~~
      multidict/_multidict.c:1684:18: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
      PyInit__multidict()
                       ^
                        void
      20 warnings and 8 errors generated.
      error: command '/Users/runner/miniconda3/envs/test/bin/x86_64-apple-darwin13.4.0-clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for multidict
```
</details>