### PR TITLE
Fix numpy printoptions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_numpy_printoptions():
+    np.set_printoptions(legacy="1.25")

--- a/news/2018.bugfix
+++ b/news/2018.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue that caused a `TypeError` to be raised when printing numpy arrays using
+older versions of numpy.

--- a/src/landlab/__init__.py
+++ b/src/landlab/__init__.py
@@ -9,8 +9,6 @@
 :URL: https://landlab.readthedocs.io/en/release/
 :License: MIT
 """
-import numpy as np
-
 from landlab._registry import registry
 from landlab._version import __version__
 from landlab.core.errors import MissingKeyError
@@ -34,8 +32,6 @@ from landlab.plot.imshow import imshow_grid
 from landlab.plot.imshow import imshow_grid_at_node
 from landlab.plot.imshowhs import imshowhs_grid
 from landlab.plot.imshowhs import imshowhs_grid_at_node
-
-np.set_printoptions(legacy="1.25")
 
 cite_as = registry.format_citations
 


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

As reported in #2018, if *landlab* is used with an older version of *numpy*, an error is raised when trying to print a *numpy* array. This is due to us calling *numpy*'s `set_printoptions` function within `__init__.py` using the `legacy` keyword, which isn't available for older versions of *numpy*. This was done solely to ensure correct array formatting of the *doctests* and, otherwise, didn't have anything to do with the proper functioning of *landlab*.

I've removed the offending line from `__init__.py` and added a test fixture that calls `set_printoptions` so that it's only run with the tests.


<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [ ] Add a [news fragment](https://landlab.readthedocs.io/en/master/development/contribution/index.html#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [ ] All tests have passed?
- [ ] Formatted code with black?
- [ ] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.readthedocs.io/en/master/development
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->
