### PR TITLE
Add a new composite action that runs the notebooks

### DIFF
--- a/.github/actions/run-notebooks/action.yml
+++ b/.github/actions/run-notebooks/action.yml
@@ -1,0 +1,56 @@
+name: "Run notebooks"
+inputs:
+  python-version:
+    required: true
+  pytest-addopts:
+    required: false
+    default: ''
+  nox-session:
+    required: true
+  upload-name:
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v4
+    - name: Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - uses: actions/download-artifact@v4
+      name: Download build artifacts
+      with:
+        pattern: "build-*"
+        merge-multiple: true
+        path: ${{ github.workspace }}/dist
+
+    - name: Test
+      env:
+        OPENTOPOGRAPHY_API_KEY: ${{ inputs.opentopography_api_key }}
+        MPLBACKEND: "module://matplotlib_inline.backend_inline"
+        PYTEST_ADDOPTS: ${{ inputs.pytest-addopts }}
+      shell: bash -l {0}
+      run: |
+        pip install nox
+        nox --verbose -s ${{ inputs.nox-session }} \
+            --force-pythons=${{ inputs.python-version }} \
+            -- dist/
+
+    - name: Find executed notebooks
+      shell: bash -l {0}
+      run: |
+        for f in $(git diff --name-only); do
+          mkdir -p executed/$(dirname $f);
+          cp $f executed/$(dirname $f);
+        done
+        ls -R executed/
+
+    - name: Upload executed notebooks
+      if: ${{ inputs.upload-name != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.upload-name }}
+        path: executed/
+        overwrite: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,8 +103,9 @@ jobs:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
   test-notebooks:
+    name: Run the notebooks
     needs: build-wheels
-    name: Run the notebook tests
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -113,53 +114,16 @@ jobs:
         python-version: ["3.13"]
         pytest-marker: ["slow", "not slow"]
 
-    runs-on: ${{ matrix.os }}
-
-    defaults:
-      run:
-        shell: bash -l {0}
-
     steps:
       - uses: actions/checkout@v4
-      - name: Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: ./.github/actions/run-notebooks/
         with:
           python-version: ${{ matrix.python-version }}
+          nox-session: "test-notebooks"
+          pytest-addopts: "--overwrite -m '${{ matrix.pytest-marker }} and not richdem'"
+          opentopography-api-key: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
+          upload-name: ${{ matrix.os == 'macos-latest' && format('notebooks-{0}', matrix.pytest-marker) || '' }}
 
-      - uses: actions/download-artifact@v4
-        name: Download build artifacts
-        with:
-          pattern: "build-*"
-          merge-multiple: true
-          path: ${{ github.workspace }}/dist
-
-      - name: Test
-        env:
-          OPENTOPOGRAPHY_API_KEY: ${{ secrets.OPENTOPOGRAPHY_API_KEY }}
-          MPLBACKEND: "module://matplotlib_inline.backend_inline"
-          PYTEST_ADDOPTS: "--overwrite -m '${{ matrix.pytest-marker }} and not richdem'"
-        run: |
-          pip install matplotlib_inline
-          pip install nox
-          nox --verbose -s test-notebooks \
-              --force-pythons=${{ matrix.python-version }} \
-              -- dist/
-
-      - name: Find executed notebooks
-        run: |
-          for f in $(git diff --name-only); do
-            mkdir -p executed/$(dirname $f);
-            cp $f executed/$(dirname $f);
-          done
-          ls -R executed/
-
-      - name: Upload executed notebooks
-        if: ${{ matrix.os == 'macos-latest' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: notebooks-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.pytest-marker }}
-          path: executed/
-          overwrite: true
 
   test-richdem:
     needs: build-wheels


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR. To help make things go a bit more
     smoothly we would appreciate that you go through this template.
-->

### Description

I've added a new composite action, *run-notebooks*, that runs the notebooks using *nox*.

<!-- Good things to put here include: reasoning for the change (please link
     any relevant issues!), any noteworthy (or hacky) choices to be aware of,
     or what the problem resolved here looked like ... we won't mind a ranty
     story :)
-->

### Checklist - did you ...

<!-- If any of the following items aren't relevant for your contribution
     please still tick them so we know you've gone through the checklist.

    Tests are required for bugfixes and new features. Documentation changes
    are necessary for formatting and most enhancement changes.

    Ensure proper code formatting with black. You can do this by running
    black from landlab's top-level folder.

    Ensure landlab is lint-free by running flake8 at landlab's top-level
    folder.

    If you like, you can automate these tasks by installing pre-commit hooks.
    This is done by running `pre-commit install` at landlab's top-level
    folder.
-->

- [ ] Add a [news fragment](https://landlab.csdms.io/development/contribution/#news-entries) file entry if necessary?
- [ ] Add / update tests if necessary?
- [ ] Add new / update outdated documentation?
- [ ] All tests have passed?
- [ ] Formatted code with black?
- [ ] Removed lint reported by flake8?
- [ ] Sucessful documentation built? (if documentation added or modified)

<!-- Thanks for your time and effort. If you have any feedback in regards
     to your experience contributing here, please let us know!

     Helpful links:

      Developer guide: https://landlab.csdms.io/development/
      Ask a question or submit an issue: https://github.com/landlab/landlab/issues
      Landlab Slack channel: https://landlab.slack.com
-->
