### PR TITLE
Use TypeError instead of ValueError.

### DIFF
--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -314,7 +314,7 @@ class NetworkSedimentTransporter(Component):
             Pfeiffer et al. (2022)
         """
         if not isinstance(grid, NetworkModelGrid):
-            raise ValueError("grid must be NetworkModelGrid")
+            raise TypeError("grid must be NetworkModelGrid")
 
         # run super. this will check for required inputs specified by _info
         super().__init__(grid)
@@ -322,7 +322,7 @@ class NetworkSedimentTransporter(Component):
         # check key information about the parcels, including that all required
         # attributes are present.
         if not isinstance(parcels, DataRecord):
-            raise ValueError("parcels must be an instance of DataRecord")
+            raise TypeError("parcels must be an instance of DataRecord")
 
         for rpa in _REQUIRED_PARCEL_ATTRIBUTES:
             if rpa not in parcels.dataset:
@@ -338,7 +338,7 @@ class NetworkSedimentTransporter(Component):
         # assert that the flow director is a component and is of type
         # FlowDirectorSteepest
         if not isinstance(flow_director, FlowDirectorSteepest):
-            raise ValueError("flow_director must be FlowDirectorSteepest.")
+            raise TypeError("flow_director must be FlowDirectorSteepest")
 
         # save reference to flow director
         self._fd = flow_director

--- a/tests/components/network_sediment_transporter/test_init.py
+++ b/tests/components/network_sediment_transporter/test_init.py
@@ -16,7 +16,7 @@ def test_basic_init(example_nmg, example_parcels, example_flow_director):
 
 
 def test_bad_flow_director(example_nmg, example_parcels):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         NetworkSedimentTransporter(
             example_nmg,
             example_parcels,
@@ -29,7 +29,7 @@ def test_bad_flow_director(example_nmg, example_parcels):
 
 
 def test_bad_network_model_grid(example_parcels, example_flow_director):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         NetworkSedimentTransporter(
             "bad_nmg",
             example_parcels,
@@ -42,7 +42,7 @@ def test_bad_network_model_grid(example_parcels, example_flow_director):
 
 
 def test_bad_parcels(example_nmg, example_flow_director):
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         NetworkSedimentTransporter(
             example_nmg,
             "bad_parcels",

--- a/tests/components/network_sediment_transporter/test_init.py
+++ b/tests/components/network_sediment_transporter/test_init.py
@@ -15,38 +15,21 @@ def test_basic_init(example_nmg, example_parcels, example_flow_director):
     )
 
 
-def test_bad_flow_director(example_nmg, example_parcels):
+@pytest.mark.parametrize(
+    "bad_args",
+    ({"flow_director": "bad_fd"}, {"parcels": "bad_parcels"}, {"grid": "bad_nmg"}),
+)
+def test_bad_arg_raises_type_error(
+    example_nmg, example_parcels, example_flow_director, bad_args
+):
+    good_args = {
+        "grid": example_nmg,
+        "parcels": example_parcels,
+        "flow_director": example_flow_director,
+    }
     with pytest.raises(TypeError):
         NetworkSedimentTransporter(
-            example_nmg,
-            example_parcels,
-            "bad_fd",
-            bed_porosity=0.03,
-            g=9.81,
-            fluid_density=1000,
-            transport_method="WilcockCrowe",
-        )
-
-
-def test_bad_network_model_grid(example_parcels, example_flow_director):
-    with pytest.raises(TypeError):
-        NetworkSedimentTransporter(
-            "bad_nmg",
-            example_parcels,
-            example_flow_director,
-            bed_porosity=0.03,
-            g=9.81,
-            fluid_density=1000,
-            transport_method="WilcockCrowe",
-        )
-
-
-def test_bad_parcels(example_nmg, example_flow_director):
-    with pytest.raises(TypeError):
-        NetworkSedimentTransporter(
-            example_nmg,
-            "bad_parcels",
-            example_flow_director,
+            **{**good_args, **bad_args},
             bed_porosity=0.03,
             g=9.81,
             fluid_density=1000,

--- a/tests/components/network_sediment_transporter/test_init.py
+++ b/tests/components/network_sediment_transporter/test_init.py
@@ -37,27 +37,20 @@ def test_bad_arg_raises_type_error(
         )
 
 
-def test_bad_porosity(example_nmg, example_parcels, example_flow_director):
+@pytest.mark.parametrize(
+    "bad_args",
+    ({"bed_porosity": -0.03}, {"transport_method": "bad_transport_method"}),
+)
+def test_bad_arg_raises_value_error(
+    example_nmg, example_parcels, example_flow_director, bad_args
+):
+    good_args = {"bed_porosity": 0.03, "transport_method": "WilcockCrowe"}
     with pytest.raises(ValueError):
         NetworkSedimentTransporter(
             example_nmg,
             example_parcels,
             example_flow_director,
-            bed_porosity=-0.03,
+            **{**good_args, **bad_args},
             g=9.81,
             fluid_density=1000,
-            transport_method="WilcockCrowe",
-        )
-
-
-def test_bad_transport_method(example_nmg, example_parcels, example_flow_director):
-    with pytest.raises(ValueError):
-        NetworkSedimentTransporter(
-            example_nmg,
-            example_parcels,
-            example_flow_director,
-            bed_porosity=0.03,
-            g=9.81,
-            fluid_density=1000,
-            transport_method="bad_transport_method",
         )


### PR DESCRIPTION
Reading through the code of NetworkSedimentTransporter, I came across code that uses `ValueError` in checking function arguments. `ValueError` is documented as follows:

> Raised when an operation or function receives an argument that has the right type but an inappropriate value, and the situation is not described by a more precise exception such as [IndexError](https://docs.python.org/3/library/exceptions.html#IndexError).

In the three cases changed here, it is that the argument has the wrong *type*, not an invalid value. The right exception class for this is `TypeError`, documented as

> Raised when an operation or function is applied to an object of inappropriate type. The associated value is a string giving details about the type mismatch.
> [...]
> Passing arguments of the wrong type (e.g. passing a [list](https://docs.python.org/3/library/stdtypes.html#list) when an [int](https://docs.python.org/3/library/functions.html#int) is expected) should result in a [TypeError](https://docs.python.org/3/library/exceptions.html#TypeError), but passing arguments with the wrong value (e.g. a number outside expected boundaries) should result in a [ValueError](https://docs.python.org/3/library/exceptions.html#ValueError).
