### PR TITLE
Add a tutorial notebook on heat diffusion in permafrost 

### DIFF
--- a/docs/source/tutorials/thermal/heat_diffusion_talik_landlab_example.ipynb
+++ b/docs/source/tutorials/thermal/heat_diffusion_talik_landlab_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "12b7dc23-638b-4633-bcee-b35f701da282",
+   "id": "0",
    "metadata": {},
    "source": [
     "# Heat diffusion: using Landlab to model the temperature field around an Arctic talik\n",
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3be556ac-7a8f-4360-a7a2-3dae0a4bda61",
+   "id": "1",
    "metadata": {},
    "source": [
     "## Code\n",
@@ -67,18 +67,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd1ec243-f802-4fea-a87c-14a0c0547719",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
     "from landlab import RasterModelGrid, imshow_grid"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b76e23bb-e616-4888-a880-0ea24bb8eeca",
+   "id": "3",
    "metadata": {},
    "source": [
     "Define parameters for the simulation (here using rather rough values, since this is just meant to be an illustration of how to build a model)::"
@@ -87,41 +88,43 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c3ee0f2-2f99-4cfd-9256-6d0bd136e9a6",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Parameters\n",
-    "domain_width = 500.0 # width of domain, m\n",
-    "domain_depth = 320.0 # depth of domain, m\n",
-    "lake_width = 250.0 # width of lake, m\n",
-    "dx = 5.0 # grid cell spacing, m\n",
-    "conductivity = 2.5 # thermal conductivity, W/mK\n",
-    "density = 1500.0 # mass density of permafrost, kg/m3\n",
-    "specific_heat = 1000.0 # specific heat of permafrost, J/kg K\n",
-    "geothermal_heat_flux = 0.025 # heat flux at base of profile, W/m2\n",
-    "courant = 0.2 # Courant number for finite-volume solution\n",
-    "Ts_mean = 0.5 * (5.4 - 24.4) # Mean surface temperature outside of lake, C\n",
-    "Ts_amp = 0.5 * (24.4 + 5.4) # Amplitude of annual temperature variation, C\n",
-    "period = 365.25 * 24.0 * 3600.0 # Period of temperature variation, s\n",
-    "run_duration = 100.0 * 365.25 * 24.0 * 3600.0 # Duration of run, s\n",
-    "T_talik_base = 1.0 # temperature of lake base, C\n",
+    "domain_width = 500.0  # width of domain, m\n",
+    "domain_depth = 320.0  # depth of domain, m\n",
+    "lake_width = 250.0  # width of lake, m\n",
+    "dx = 5.0  # grid cell spacing, m\n",
+    "conductivity = 2.5  # thermal conductivity, W/mK\n",
+    "density = 1500.0  # mass density of permafrost, kg/m3\n",
+    "specific_heat = 1000.0  # specific heat of permafrost, J/kg K\n",
+    "geothermal_heat_flux = 0.025  # heat flux at base of profile, W/m2\n",
+    "courant = 0.2  # Courant number for finite-volume solution\n",
+    "Ts_mean = 0.5 * (5.4 - 24.4)  # Mean surface temperature outside of lake, C\n",
+    "Ts_amp = 0.5 * (24.4 + 5.4)  # Amplitude of annual temperature variation, C\n",
+    "period = 365.25 * 24.0 * 3600.0  # Period of temperature variation, s\n",
+    "run_duration = 100.0 * 365.25 * 24.0 * 3600.0  # Duration of run, s\n",
+    "T_talik_base = 1.0  # temperature of lake base, C\n",
     "\n",
     "# Derived\n",
-    "kappa = conductivity / (density * specific_heat) # thermal diffusivity, m2/s\n",
-    "dt = courant * dx * dx / kappa # time-step duration, s\n",
-    "dt = min(dt, 3600.0 * 24) # time steps should be no longer than one day\n",
-    "nrows = int(domain_depth / dx) + 1 # number of node rows\n",
-    "ncols = int(domain_width / dx) + 1 # number of node columns\n",
-    "Tgrad_mean = geothermal_heat_flux / conductivity # temperature gradient, C/m\n",
-    "one_over_rho_cp = 1.0 / (density * specific_heat) # 1 / rho Cp (for calculating rate of change of temperature)\n",
-    "current_time = 0.0 # current time in simulation, s\n",
-    "num_steps = int(run_duration / dt) # number of time steps"
+    "kappa = conductivity / (density * specific_heat)  # thermal diffusivity, m2/s\n",
+    "dt = courant * dx * dx / kappa  # time-step duration, s\n",
+    "dt = min(dt, 3600.0 * 24)  # time steps should be no longer than one day\n",
+    "nrows = int(domain_depth / dx) + 1  # number of node rows\n",
+    "ncols = int(domain_width / dx) + 1  # number of node columns\n",
+    "Tgrad_mean = geothermal_heat_flux / conductivity  # temperature gradient, C/m\n",
+    "one_over_rho_cp = 1.0 / (\n",
+    "    density * specific_heat\n",
+    ")  # 1 / rho Cp (for calculating rate of change of temperature)\n",
+    "current_time = 0.0  # current time in simulation, s\n",
+    "num_steps = int(run_duration / dt)  # number of time steps"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "60f80bfd-b70c-48d4-b113-76e578e132e2",
+   "id": "5",
    "metadata": {},
    "source": [
     "Set up the grid and associated data:\n",
@@ -137,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b98e3ed-cabd-4a68-a5a5-74609d63dd96",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,22 +159,21 @@
     "\n",
     "# Set up lake and \"tundra\" nodes\n",
     "lake_nodes = np.logical_and(\n",
-    "    grid.y_of_node==0.0,\n",
+    "    grid.y_of_node == 0.0,\n",
     "    np.logical_and(\n",
-    "        grid.x_of_node > 0.5 * lake_width,\n",
-    "        grid.x_of_node < 1.5 * lake_width\n",
-    "    )\n",
+    "        grid.x_of_node > 0.5 * lake_width, grid.x_of_node < 1.5 * lake_width\n",
+    "    ),\n",
     ")\n",
     "tundra_nodes = np.logical_and(\n",
-    "    grid.y_of_node==0.0,\n",
-    "    lake_nodes==False,\n",
+    "    grid.y_of_node == 0.0,\n",
+    "    lake_nodes is False,\n",
     ")\n",
     "T[lake_nodes] = T_talik_base"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "acd9b0fc-0b9e-42ec-bcf9-0202f112212e",
+   "id": "7",
    "metadata": {},
    "source": [
     "Plot the initial temperature field."
@@ -180,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d4315c6-dc3e-44ef-a1e4-09e710d3789c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2f78df4a-a2a2-46db-acd7-b5e07e253e67",
+   "id": "9",
    "metadata": {},
    "source": [
     "Next, run the time loop. The loop takes advantage of two of Landlab's numerical functions:\n",
@@ -226,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54f9b1fd-d621-43cc-8724-631ea95af175",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22d957b0-342e-4442-ba17-27ede539fe5d",
+   "id": "11",
    "metadata": {},
    "source": [
     "Plot the final temperature field:"
@@ -249,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db7efdfd-89d2-4a56-af2a-597259cfca84",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "01a77832-da11-4b7c-bf05-ecea8613e6ef",
+   "id": "13",
    "metadata": {},
    "source": [
     "For more about Landlab, see [https://landlab.csdms.io](https://landlab.csdms.io)."

--- a/docs/source/tutorials/thermal/heat_diffusion_talik_landlab_example.ipynb
+++ b/docs/source/tutorials/thermal/heat_diffusion_talik_landlab_example.ipynb
@@ -1,0 +1,301 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "12b7dc23-638b-4633-bcee-b35f701da282",
+   "metadata": {},
+   "source": [
+    "# Heat diffusion: using Landlab to model the temperature field around an Arctic talik\n",
+    "\n",
+    "*(Greg Tucker, University of Colorado Boulder, May 2025)*\n",
+    "\n",
+    "The Arctic is famous for its permafrost: ground that remains below 0$^\\circ$C and frozen permanently, or at least for 2 years or more in a row. Yet there are exceptions to the permafrost rule. The ground beneath shallow lakes and rivers often forms what's known as a *talik*: an area of unfrozen ground that is held above the freezing point by virtue of its contact with seasonally unfrozen water at the surface.\n",
+    "\n",
+    "The purpose of this notebook is to demonstrate how to create a 2D thermal model in Landlab, using as a motivating example a hypothetical talik. The model domain consists of a vertical slice of ground. The model calculates heat conduction through the slice, assuming an initial geothermal gradient. Geothermal heat flows in through the bottom boundary. The top boundary is split into two parts. One part, representing dry land, has a surface temperature that varies sinusoidally throughout each year. The other, representing a shallow lake, stays fixed at or near the freezing point. The model is highly simplified, representing only heat conduction, and omitting consideration of the heat taken in or released by phase changes (solid to liquid or the reverse).\n",
+    "\n",
+    "## Mathematical theory\n",
+    "\n",
+    "The equation governing 2D heat conduction in a solid, with no internal sources or sinks, is:\n",
+    "\n",
+    "$$\\frac{\\partial T}{\\partial t} = -\\frac{1}{\\rho C_p} \\nabla \\cdot \\mathbf{q}$$\n",
+    "\n",
+    "where $T$ is temperature, $t$ is time, $\\rho$ is material density, and $C_p$ is the specific heat of the material (usually expressed in Joules per kilogram per degree). Here $\\mathbf{q} = [q_x, q_y]$ is the two-dimensional vector of heat flux (power per unit area, e.g., Watts per square meter). The symbol $\\nabla\\cdot$ represents the divergence operator,  defined as\n",
+    "\n",
+    "$$\\nabla\\cdot \\equiv \\frac{\\partial}{\\partial x}\\hat{\\mathbf{i}} + \\frac{\\partial}{\\partial y}\\hat{\\mathbf{j}}$$\n",
+    "\n",
+    "where $\\hat{\\mathbf{i}}$ and $\\hat{\\mathbf{j}}$ are unit vectors in the $x$ and $y$ directions, respectively.\n",
+    "\n",
+    "The heat flux is given by Fourier's law:\n",
+    "\n",
+    "$$\\mathbf{q} = -k \\nabla{T}$$\n",
+    "\n",
+    "where $k$ is thermal conductivity (e.g., Watts per meter per Kelvin) and $\\nabla{T}$ is the temperature gradient.\n",
+    "\n",
+    "## Numerical implementation\n",
+    "\n",
+    "This example uses the Finite Volume Method, in which an average value of $T$ is tracked in each cell within a grid, in this case a regular rectilinear grid with square cells of dimensions $\\Delta x$ by $\\Delta x$. In a Landlab grid, each cell contains a grid *node*. The temperature gradient between each adjacent pair of nodes is calculated by taking the difference between $T$ at the two nodes and dividing by the distance between them (in this case, that distance is always equal to the grid spacing $\\Delta x$). Each adjacent pair of nodes is represented by a grid objected called a *link*: a directed line segment that extends from its *tail node* to its *head node*. Therefore, every value of temperature gradient calculated between nodes is assigned to the corresponding link. The sign of the gradient is taken in reference to the link's direction: if temperature at the head node is greater than at the tail node, then the gradient is positive; if the reverse, the gradient is negative, and if the two temperatures are equal, the gradient is of course zero.\n",
+    "\n",
+    "The faces of each grid cell are associated with links. The heat flux per unit width across a cell face is calculated using Fourier's law, by multiplying the corresponding temperature gradient by $-k$. Once heat fluxes have been calculated for all of the cell faces, the *flux divergence* is calculated for each grid cell by multiplying each $q$ (in Watts per meter) by cell width and adding up the resulting total heat fluxes (now in Watts) coming in or out of the four cell faces. This total flux is then divided by cell area to get the flux divergence (in Watts per square meter).\n",
+    "\n",
+    "For more examples of finite-volume numerical methods using Landlab, see:\n",
+    "\n",
+    "- [Tutorial notebook on \"Using Landlab’s gradient and flux divergence functions\"](https://landlab.csdms.io/tutorials/gradient_and_divergence/gradient_and_divergence.html)\n",
+    "\n",
+    "- [Tutorial notebook on \"Introduction to Landlab: Creating a simple 2D scarp diffusion model\"](https://landlab.csdms.io/tutorials/fault_scarp/landlab-fault-scarp.html)\n",
+    "\n",
+    "For more on Landlab grids, see:\n",
+    "\n",
+    "- [Grid object tutorial (https://landlab.csdms.io/tutorials/grids/grid_object_demo.html)](https://landlab.csdms.io/tutorials/grids/grid_object_demo.html)\n",
+    "\n",
+    "- [Overview of different grid types (https://landlab.csdms.io/tutorials/grids/diverse_grid_classes.html)](https://landlab.csdms.io/tutorials/grids/diverse_grid_classes.html)\n",
+    "\n",
+    "- [Hobley et al. (2017)](https://doi.org/10.5194/esurf-5-21-2017)\n",
+    "\n",
+    "- [Barnhart et al. (2020)](https://doi.org/10.5194/esurf-8-379-2020)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3be556ac-7a8f-4360-a7a2-3dae0a4bda61",
+   "metadata": {},
+   "source": [
+    "## Code\n",
+    "\n",
+    "First, we import stuff: numpy for numerical calculations, matplotlib's `pyplot` library for plotting, and Landlab's `RasterModelGrid` (which we'll use for the simulation grid) and the plotting function `imshow_grid`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd1ec243-f802-4fea-a87c-14a0c0547719",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from landlab import RasterModelGrid, imshow_grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b76e23bb-e616-4888-a880-0ea24bb8eeca",
+   "metadata": {},
+   "source": [
+    "Define parameters for the simulation (here using rather rough values, since this is just meant to be an illustration of how to build a model)::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c3ee0f2-2f99-4cfd-9256-6d0bd136e9a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "domain_width = 500.0 # width of domain, m\n",
+    "domain_depth = 320.0 # depth of domain, m\n",
+    "lake_width = 250.0 # width of lake, m\n",
+    "dx = 5.0 # grid cell spacing, m\n",
+    "conductivity = 2.5 # thermal conductivity, W/mK\n",
+    "density = 1500.0 # mass density of permafrost, kg/m3\n",
+    "specific_heat = 1000.0 # specific heat of permafrost, J/kg K\n",
+    "geothermal_heat_flux = 0.025 # heat flux at base of profile, W/m2\n",
+    "courant = 0.2 # Courant number for finite-volume solution\n",
+    "Ts_mean = 0.5 * (5.4 - 24.4) # Mean surface temperature outside of lake, C\n",
+    "Ts_amp = 0.5 * (24.4 + 5.4) # Amplitude of annual temperature variation, C\n",
+    "period = 365.25 * 24.0 * 3600.0 # Period of temperature variation, s\n",
+    "run_duration = 100.0 * 365.25 * 24.0 * 3600.0 # Duration of run, s\n",
+    "T_talik_base = 1.0 # temperature of lake base, C\n",
+    "\n",
+    "# Derived\n",
+    "kappa = conductivity / (density * specific_heat) # thermal diffusivity, m2/s\n",
+    "dt = courant * dx * dx / kappa # time-step duration, s\n",
+    "dt = min(dt, 3600.0 * 24) # time steps should be no longer than one day\n",
+    "nrows = int(domain_depth / dx) + 1 # number of node rows\n",
+    "ncols = int(domain_width / dx) + 1 # number of node columns\n",
+    "Tgrad_mean = geothermal_heat_flux / conductivity # temperature gradient, C/m\n",
+    "one_over_rho_cp = 1.0 / (density * specific_heat) # 1 / rho Cp (for calculating rate of change of temperature)\n",
+    "current_time = 0.0 # current time in simulation, s\n",
+    "num_steps = int(run_duration / dt) # number of time steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60f80bfd-b70c-48d4-b113-76e578e132e2",
+   "metadata": {},
+   "source": [
+    "Set up the grid and associated data:\n",
+    "\n",
+    "- A Landlab `RasterModelGrid` object is used to represent the domain, a vertical slice through the ground\n",
+    "- Lateral boundaries are closed to the flow of heat\n",
+    "- An array of values for temperature, `T`, is defined for the grid nodes\n",
+    "- An array of values for heat flux, `q`, is defined for the grid *links*, which are directed line segments that connect each pair of adjacent nodes\n",
+    "- The temperature field is initialized to the equilibrium geothermal gradient\n",
+    "- An array of \"lake nodes\" is identified as a set of nodes across the center portion of the top boundary; their temperature will stay fixed at `T_talik_base`, while the temperature of the other surface nodes will vary sinusoidally, representing the seasonal cycle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b98e3ed-cabd-4a68-a5a5-74609d63dd96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create grid\n",
+    "grid = RasterModelGrid((nrows, ncols), dx)\n",
+    "\n",
+    "# (if we're not wrapping boundaries)\n",
+    "grid.set_closed_boundaries_at_grid_edges(True, False, True, False)\n",
+    "\n",
+    "# Create field(s)\n",
+    "T = grid.add_zeros(\"temperature\", at=\"node\")\n",
+    "q = grid.add_zeros(\"specific_heat_flux\", at=\"link\")\n",
+    "\n",
+    "# Initialize\n",
+    "T = Ts_mean + Tgrad_mean * grid.y_of_node\n",
+    "\n",
+    "# Set up lake and \"tundra\" nodes\n",
+    "lake_nodes = np.logical_and(\n",
+    "    grid.y_of_node==0.0,\n",
+    "    np.logical_and(\n",
+    "        grid.x_of_node > 0.5 * lake_width,\n",
+    "        grid.x_of_node < 1.5 * lake_width\n",
+    "    )\n",
+    ")\n",
+    "tundra_nodes = np.logical_and(\n",
+    "    grid.y_of_node==0.0,\n",
+    "    lake_nodes==False,\n",
+    ")\n",
+    "T[lake_nodes] = T_talik_base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acd9b0fc-0b9e-42ec-bcf9-0202f112212e",
+   "metadata": {},
+   "source": [
+    "Plot the initial temperature field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3d4315c6-dc3e-44ef-a1e4-09e710d3789c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "imshow_grid(\n",
+    "    grid,\n",
+    "    T,\n",
+    "    cmap=\"coolwarm\",\n",
+    "    vmin=-10.0,\n",
+    "    vmax=10.0,\n",
+    "    colorbar_label=\"Temperature (C)\",\n",
+    ")\n",
+    "plt.title(\"Initial temperature field\")\n",
+    "plt.xlabel(\"Distance (m)\")\n",
+    "plt.ylabel(\"Depth (m)\")\n",
+    "ax.invert_yaxis()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f78df4a-a2a2-46db-acd7-b5e07e253e67",
+   "metadata": {},
+   "source": [
+    "Next, run the time loop. The loop takes advantage of two of Landlab's numerical functions:\n",
+    "\n",
+    "- `calc_grad_at_link` calculates the gradient in the given quantity (in this case temperature) between each adjacent pair of grid nodes. The resulting gradient values are mapped to the *links* that connect the node pairs. Every link has a direction as well as a magnitude. For example, link 0, which connects nodes 0 and 1, \"points\" in the direction of node 1. Node 1 is said to be the \"head\" of link 0, and node 0 is said to be the \"tail\" of link 0. Here a positive value of gradient means that temperature increases in the direction of the link; a negative value means temperature decreases in the direction of the link.\n",
+    "\n",
+    "- `calc_flux_div_at_node` calculates the divergence of flux at each grid cell. The flux quantity (here representing heat flux per unit width) is a link-based array passed as an argument to the function. The function then adds up the total flux crossing each face of the grid cell, and divides the result by the cell area. To be consistent with the mathematical definition of divergence, the resulting flux divergence is positive when the net flux is outward, and negative when it is inward (into the cell). The result is then assigned to each cell's corresponding grid node. Nodes around the perimeter of the grid don't have cells, so these nodes are simply assigned zero. The function then returns an array of divergence values, where the length of the array is equal to the number of grid nodes.\n",
+    "\n",
+    "The algorithm in the time loop does the following:\n",
+    "\n",
+    "1. Update the surface temperature (outside the lake)\n",
+    "   \n",
+    "2. Calculate the temperature gradients at the links\n",
+    "   \n",
+    "3. Calculate heat fluxes at the \"active\" links (links along the side boundaries will have been flagged as \"inactive\", so this limitation to active links implements a no-flux condition along these boundaries)\n",
+    "\n",
+    "4. Calculate the rate of change of temperature at the nodes\n",
+    "\n",
+    "5. Update the temperature values at the \"core\" (i.e., non-boundary) nodes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54f9b1fd-d621-43cc-8724-631ea95af175",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(num_steps):\n",
+    "    T[tundra_nodes] = Ts_mean + Ts_amp * np.sin(2.0 * np.pi * i * dt / period)\n",
+    "    Tgrad = grid.calc_grad_at_link(T)\n",
+    "    q[grid.active_links] = -conductivity * Tgrad[grid.active_links]\n",
+    "    dTdt = -one_over_rho_cp * grid.calc_flux_div_at_node(q)\n",
+    "    T[grid.core_nodes] += dTdt[grid.core_nodes] * dt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22d957b0-342e-4442-ba17-27ede539fe5d",
+   "metadata": {},
+   "source": [
+    "Plot the final temperature field:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db7efdfd-89d2-4a56-af2a-597259cfca84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "imshow_grid(\n",
+    "    grid,\n",
+    "    T,\n",
+    "    cmap=\"coolwarm\",\n",
+    "    vmin=-10.0,\n",
+    "    vmax=10.0,\n",
+    "    colorbar_label=\"Temperature (C)\",\n",
+    ")\n",
+    "plt.title(\"TEMPERATURE FIELD AROUND AN ARCTIC TALIK\")\n",
+    "plt.xlabel(\"Distance (m)\")\n",
+    "plt.ylabel(\"Depth (m)\")\n",
+    "ax.invert_yaxis()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01a77832-da11-4b7c-bf05-ecea8613e6ef",
+   "metadata": {},
+   "source": [
+    "For more about Landlab, see [https://landlab.csdms.io](https://landlab.csdms.io)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/news/2173.docs
+++ b/news/2173.docs
@@ -1,0 +1,1 @@
+Add tutorial notebook demonstrating Landlab application in heat diffusion in permafrost.


### PR DESCRIPTION
## Pull Request Checklist

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

Adds a new tutorial notebook folder for "thermal" (for thermal-related processes) along with a notebook demonstrating a Landlab model of heat diffusion in permafrost beneath an Arctic lake. The resulting region of unfrozen ground under the lake represents a talik, hence the name. Addresses the need for a heat diffusion example in the Landlab tutorial collection, as well as an example of a Landlab grid that represents a vertical rather than horizontal domain.

## Related Issues

Closes #2173 