### PR TITLE
Improve error messages for invalid watersheds in ChannelProfiler

### DIFF
--- a/news/2177.misc
+++ b/news/2177.misc
@@ -1,0 +1,1 @@
+Improved the error messages for the ChannelProfiler.

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -636,24 +636,20 @@ class ChannelProfiler(_BaseProfiler):
                         f" ({len(outlet_nodes)})."
                     )
 
-        starting_da = self._channel_definition_field[outlet_nodes]
-        outlet_nodes = np.asarray(outlet_nodes)
+        thresholds = {
+            "minimum_outlet_threshold": minimum_outlet_threshold,
+            "minimum_channel_threshold": minimum_channel_threshold,
+        }
+        for name, value in thresholds.items():
+            try:
+                _raise_if_any_below_threshold(
+                    self._channel_definition_field, value, indices=outlet_nodes
+                )
+            except ChannelProfilerError as e:
+                e.add_note(f"You may need to increase the value of {name!r}.")
+                raise e
 
-        if np.any(starting_da <= minimum_outlet_threshold):
-            raise ChannelProfilerError(
-                "Some outlet nodes have drainage areas below the minimum outlet"
-                f" threshold ({minimum_outlet_threshold}). These may not represent"
-                " valid watersheds."
-            )
-
-        if np.any(starting_da <= minimum_channel_threshold):
-            raise ChannelProfilerError(
-                "Some outlet nodes have drainage areas below the minimum channel"
-                f" threshold ({minimum_channel_threshold}). The ChannelProfiler"
-                " requires a minimum area to define valid channel networks."
-            )
-
-        self._outlet_nodes = outlet_nodes
+        self._outlet_nodes = np.asarray(outlet_nodes)
 
     @property
     def data_structure(self):

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -543,35 +543,35 @@ class ChannelProfiler(_BaseProfiler):
         """
         Parameters
         ----------
-        grid : Landlab Model Grid instance
-        channel_definition_field : field name as string, optional
-            Name of field used to identify the outlet and headwater nodes of the
-            channel network. Default is "drainage_area".
+        grid : ModelGrid
+            A Landlab model grid instance on which the channel profiles will be
+            computed.
+        channel_definition_field : str, optional
+            Name of the field used to identify outlet and headwater nodes of the channel
+            network. Typically this is a drainage area field.
         minimum_outlet_threshold : float, optional
-            Minimum value of the *channel_definition_field* to define a
-            watershed outlet. Default is 0.
+            Minimum value of the `channel_definition_field` required to define a
+            watershed outlet.
         minimum_channel_threshold : float, optional
-            Value to use for the minimum drainage area associated with a
-            plotted channel segment. Default values 0.
-        number_of_watersheds : int, optional
-            Total number of watersheds to plot. Default value is 1. If value is
-            greater than 1 and outlet_nodes is not specified, then the
-            number_of_watersheds largest watersheds is based on the drainage
-            area at the model grid boundary. If given as None, then all grid
-            cells on the domain boundary with a stopping field (typically
-            drainage area) greater than the minimum_outlet_threshold in area are used.
-        main_channel_only : Boolean, optional
-            Flag to determine if only the main channel should be plotted, or if
-            all stream segments with drainage area less than threshold should
-            be plotted. Default value is True.
-        outlet_nodes : length number_of_watersheds iterable, optional
-            Length number_of_watersheds iterable containing the node IDs of
-            nodes to start the channel profiles from. If not provided, the
-            default is the number_of_watersheds node IDs on the model grid
-            boundary with the largest terminal drainage area.
+            Minimum value of the `channel_definition_field` for a stream segment to be
+            included in the plotted channel network.
+        number_of_watersheds : int or None, optional
+            Number of watersheds to profile. If greater than 1 and `outlet_nodes` is not
+            specified, the outlets are chosen as the `number_of_watersheds` boundary
+            nodes with the largest values of the `channel_definition_field`. If set to
+            `None`, all boundary nodes with values above `minimum_outlet_threshold` are
+            used.
+        main_channel_only : bool, optional
+            If `True`, only the main channel of each watershed is plotted. If `False`,
+            all stream segments with values above `minimum_channel_threshold` are
+            included.
+        outlet_nodes : iterable of int, optional
+            Iterable of node IDs to be used as outlet points for channel profiling.
+            The number of nodes must equal `number_of_watersheds`. If not provided,
+            the outlets are chosen automatically based on the
+            `channel_definition_field`.
         cmap : str, optional
-            A valid matplotlib cmap string. Default is "viridis".
-
+            Name of a Matplotlib colormap to use for plotting.
         """
         if number_of_watersheds is not None and number_of_watersheds <= 0:
             raise ValueError(

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -603,7 +603,7 @@ class ChannelProfiler(_BaseProfiler):
             threshold = max(minimum_outlet_threshold, minimum_channel_threshold)
             values = self._channel_definition_field
 
-            all_outlet_nodes = sort_with_mask(
+            all_outlet_nodes = _argsort_with_mask(
                 values,
                 mask=(grid.status_at_node != NodeStatus.CORE) & (values > threshold),
             )

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -594,14 +594,14 @@ class ChannelProfiler(_BaseProfiler):
         super().__init__(grid)
 
         self._cmap = plt.colormaps[cmap]
-        if channel_definition_field in grid.at_node:
-            self._channel_definition_field = grid.at_node[channel_definition_field]
-        else:
-            raise ValueError(
-                f"Required field {channel_definition_field!r} not present. "
-                "This field is required by the ChannelProfiler to define "
-                "the start and stop of channel networks."
+        if channel_definition_field not in grid.at_node:
+            raise ChannelProfilerError(
+                f"Missing required field {channel_definition_field!r}."
+                " The ChannelProfiler uses this field to determine the start and stop"
+                " points of channel networks."
             )
+
+        self._channel_definition_field = grid.at_node[channel_definition_field]
 
         self._flow_receiver = grid.at_node["flow__receiver_node"]
 

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -578,6 +578,7 @@ class ChannelProfiler(_BaseProfiler):
                 " If provided, the number of watersheds must be greater than zero"
             )
 
+        outlet_nodes = _validate_outlet_nodes(outlet_nodes)
         if outlet_nodes is not None:
             n_outlets = len(outlet_nodes)
             if n_outlets == 0:

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib import cm
 from numpy.typing import ArrayLike
+from numpy.typing import NDArray
 
 from landlab.components.profiler.base_profiler import _BaseProfiler
 from landlab.core.utils import as_id_array
@@ -853,6 +854,24 @@ class ChannelProfiler(_BaseProfiler):
                 ids = self._data_struct[outlet_id][segment_tuple]["ids"]
                 d = distance_upstream[ids]
                 self._data_struct[outlet_id][segment_tuple]["distances"] = d - offset
+
+
+def _validate_outlet_nodes(outlet_nodes: ArrayLike) -> NDArray[np.int_] | None:
+    if outlet_nodes is None:
+        return None
+
+    outlet_nodes = np.asarray(outlet_nodes)
+
+    if outlet_nodes.size == 0:
+        return np.array([], dtype=int)
+
+    if not np.issubdtype(outlet_nodes.dtype, np.integer):
+        raise ValueError(
+            "Expected an integer array suitable for indexing but got array of"
+            f" type {outlet_nodes.dtype}."
+        )
+
+    return outlet_nodes
 
 
 def _raise_if_any_below_threshold(

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -893,6 +893,44 @@ def _raise_if_any_below_threshold(
         raise error
 
 
+def _max_with_mask(values, mask=None):
+    """Find the largest value and its index in an array, optionally using a mask.
+
+    Identifies the largest value in the input array and its index. If a mask
+    is provided, only the values corresponding to `True` in the mask
+    are considered.
+
+    Parameters
+    ----------
+    values : array_like
+        Input array from which to find the largest value.
+    mask : array_like of bool, optional
+        A boolean mask indicating which elements of `values` to consider. If
+        `None`, all elements are considered.
+
+    Returns
+    -------
+    tuple
+        A tuple containing the largest value and its index. The index corresponds
+        to the position in the original array, even when a mask is applied.
+
+    Examples
+    --------
+    >>> _max_with_mask([1.0, 4.0, 3.0, 4.0])
+    (4.0, 1)
+    >>> _max_with_mask([1.0, 4.0, 3.0, 4.0], mask=[True, False, True, False])
+    (3.0, 2)
+    """
+    values = np.asarray(values)
+    if mask is None:
+        index_of_largest = np.argmax(values)
+        return values[index_of_largest], index_of_largest
+    else:
+        masked_values = values[mask]
+        index_of_largest = np.flatnonzero(mask)[np.argmax(masked_values)]
+        return np.max(masked_values), index_of_largest
+
+
 def _argsort_with_mask(values, mask=None):
     if mask is None:
         return np.argsort(values)

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -12,6 +12,10 @@ from landlab.core.utils import as_id_array
 from landlab.utils.flow__distance import calculate_flow__distance
 
 
+class ChannelProfilerError(Exception):
+    pass
+
+
 class ChannelProfiler(_BaseProfiler):
     """Extract and plot the channel profiles in drainage networks.
 

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -885,3 +885,14 @@ def _raise_if_any_below_threshold(
             f" at index {indices[index_of_largest]}."
         )
         raise error
+
+
+def _argsort_with_mask(values, mask=None):
+    if mask is None:
+        return np.argsort(values)
+
+    values = np.asarray(values)
+    masked_indices = np.flatnonzero(mask)
+    masked_values = values[masked_indices]
+
+    return masked_indices[np.argsort(masked_values)]

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -575,7 +575,7 @@ class ChannelProfiler(_BaseProfiler):
         """
         if number_of_watersheds is not None and number_of_watersheds <= 0:
             raise ValueError(
-                f"invalid number of watersheds ({number_of_watersheds})."
+                f"Invalid number of watersheds ({number_of_watersheds})."
                 " If provided, the number of watersheds must be greater than zero"
             )
         outlet_nodes = _validate_outlet_nodes(outlet_nodes)
@@ -585,7 +585,7 @@ class ChannelProfiler(_BaseProfiler):
         self._cmap = plt.colormaps[cmap]
         if channel_definition_field not in grid.at_node:
             raise ChannelProfilerError(
-                f"Missing required field {channel_definition_field!r}."
+                f"Missing required field ({channel_definition_field!r})."
                 " The ChannelProfiler uses this field to determine the start and stop"
                 " points of channel networks."
             )
@@ -627,17 +627,18 @@ class ChannelProfiler(_BaseProfiler):
 
         if outlet_nodes.size == 0:
             raise ChannelProfilerError(
-                "The number of outlet nodes must be greater than zero"
-                f" ({outlet_nodes.size})"
+                f"Invalid number of outlets ({outlet_nodes.size})."
+                " The number of outlet nodes must be greater than zero"
             )
         if (
             number_of_watersheds is not None
             and outlet_nodes.size != number_of_watersheds
         ):
             raise ChannelProfilerError(
-                f"Expected {number_of_watersheds} outlet nodes, but found "
-                f"{outlet_nodes.size}. The number of outlet nodes must match the "
-                "specified number of watersheds."
+                "Mismatch between the number of watersheds and the number of outlets"
+                f" ({number_of_watersheds} != {outlet_nodes.size})."
+                " The number of outlet nodes must match the specified number"
+                " of watersheds."
             )
 
         self._outlet_nodes = outlet_nodes
@@ -854,8 +855,8 @@ def _validate_outlet_nodes(outlet_nodes: ArrayLike) -> NDArray[np.int_] | None:
 
     if not np.issubdtype(outlet_nodes.dtype, np.integer):
         raise ValueError(
-            "Expected an integer array suitable for indexing but got array of"
-            f" type {outlet_nodes.dtype}."
+            "Invalid array of outlets. Expected an integer array suitable"
+            f" for indexing but got array of type {outlet_nodes.dtype}."
         )
 
     return outlet_nodes
@@ -882,10 +883,7 @@ def _raise_if_any_below_threshold(
 
         n = np.count_nonzero(is_below_threshold)
 
-        error = ChannelProfilerError(
-            "One or more values are at or below the specified threshold"
-            f" of {threshold}."
-        )
+        error = ChannelProfilerError(f"Values below threshold ({threshold}).")
         error.add_note(
             f"There {'is' if n == 1 else 'are'} {n} such value{'' if n == 1 else 's'}."
             f" The largest of which has a value of {value_of_largest} and is located"

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -577,20 +577,7 @@ class ChannelProfiler(_BaseProfiler):
                 f"invalid number of watersheds ({number_of_watersheds})."
                 " If provided, the number of watersheds must be greater than zero"
             )
-
         outlet_nodes = _validate_outlet_nodes(outlet_nodes)
-        if outlet_nodes is not None:
-            n_outlets = len(outlet_nodes)
-            if n_outlets == 0:
-                raise ChannelProfilerError(
-                    "The number of provided outlet nodes must be greater than zero"
-                )
-            if number_of_watersheds is not None and n_outlets != number_of_watersheds:
-                raise ChannelProfilerError(
-                    f"Expected {number_of_watersheds} outlet nodes, but found "
-                    f"{len(outlet_nodes)}. The number of outlet nodes must match the "
-                    "specified number of watersheds."
-                )
 
         super().__init__(grid)
 
@@ -650,7 +637,22 @@ class ChannelProfiler(_BaseProfiler):
                 e.add_note(f"You may need to increase the value of {name!r}.")
                 raise e
 
-        self._outlet_nodes = np.asarray(outlet_nodes)
+        if outlet_nodes.size == 0:
+            raise ChannelProfilerError(
+                "The number of outlet nodes must be greater than zero"
+                f" ({outlet_nodes.size})"
+            )
+        if (
+            number_of_watersheds is not None
+            and outlet_nodes.size != number_of_watersheds
+        ):
+            raise ChannelProfilerError(
+                f"Expected {number_of_watersheds} outlet nodes, but found "
+                f"{outlet_nodes.size}. The number of outlet nodes must match the "
+                "specified number of watersheds."
+            )
+
+        self._outlet_nodes = outlet_nodes
 
     @property
     def data_structure(self):

--- a/src/landlab/components/profiler/channel_profiler.py
+++ b/src/landlab/components/profiler/channel_profiler.py
@@ -876,8 +876,9 @@ def _raise_if_any_below_threshold(
 
     is_below_threshold = values <= threshold
     if np.any(is_below_threshold):
-        index_of_largest = np.argmax(is_below_threshold)
-        value_of_largest = values[index_of_largest]
+        value_of_largest, index_of_largest = _max_with_mask(
+            values, mask=is_below_threshold
+        )
 
         n = np.count_nonzero(is_below_threshold)
 

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -16,10 +16,26 @@ from landlab.components import FastscapeEroder
 from landlab.components import FlowAccumulator
 from landlab.components.profiler.channel_profiler import ChannelProfilerError
 from landlab.components.profiler.channel_profiler import _argsort_with_mask
+from landlab.components.profiler.channel_profiler import _max_with_mask
 from landlab.components.profiler.channel_profiler import _raise_if_any_below_threshold
 from landlab.components.profiler.channel_profiler import _validate_outlet_nodes
 
 matplotlib.use("agg")
+
+
+@pytest.mark.parametrize(
+    "mask,expected",
+    [
+        (None, (4.0, 1)),
+        ([True, True, True, True], (4.0, 1)),
+        ([True, False, True, False], (3.0, 2)),
+    ],
+)
+def test_max_with_mask(mask, expected):
+    array = [1.0, 4.0, 3.0, 4.0]
+    value, index = _max_with_mask(array, mask=mask)
+    assert (value, index) == expected
+    assert array[index] == value
 
 
 @pytest.mark.parametrize("value", (0, 0.5, 2, 2.5, np.inf))
@@ -92,6 +108,7 @@ def test_missing_channel_definition_field(field_name):
 
     assert str(excinfo.value).startswith("Missing required field")
     assert expected in str(excinfo.value)
+
 
 def test_invalid_outlet_nodes():
     grid = RasterModelGrid((4, 5))

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -18,6 +18,19 @@ from landlab.components.profiler.channel_profiler import ChannelProfilerError
 matplotlib.use("agg")
 
 
+@pytest.mark.parametrize("field_name", (None, "drainage_area", "foo"))
+def test_missing_channel_definition_field(field_name):
+    grid = RasterModelGrid((4, 5))
+    grid.add_zeros("flow__receiver_node", at="node", dtype=int)
+    grid.add_zeros("flow__link_to_receiver_node", at="node", dtype=int)
+
+    kwargs = {} if field_name is None else {"channel_definition_field": field_name}
+    with pytest.raises(ChannelProfilerError) as excinfo:
+        ChannelProfiler(grid, **kwargs)
+    expected = "drainage_area" if field_name is None else field_name
+    assert expected in str(excinfo.value)
+
+
 def test_invalid_outlet_nodes():
     grid = RasterModelGrid((4, 5))
     with pytest.raises(ChannelProfilerError):

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -59,7 +59,7 @@ def test_validate_outlet_nodes(array):
 def test_validate_outlet_nodes_bad_type():
     with pytest.raises(ValueError) as excinfo:
         _validate_outlet_nodes([0.0, 1, 2])
-    assert "indexing" in str(excinfo.value)
+    assert str(excinfo.value).startswith("Invalid array of outlets")
 
 
 def test_validate_outlet_nodes_with_none():
@@ -89,8 +89,9 @@ def test_missing_channel_definition_field(field_name):
     with pytest.raises(ChannelProfilerError) as excinfo:
         ChannelProfiler(grid, **kwargs)
     expected = "drainage_area" if field_name is None else field_name
-    assert expected in str(excinfo.value)
 
+    assert str(excinfo.value).startswith("Missing required field")
+    assert expected in str(excinfo.value)
 
 def test_invalid_outlet_nodes():
     grid = RasterModelGrid((4, 5))
@@ -133,7 +134,7 @@ def test_requesting_too_many_watersheds(n_watersheds):
     ChannelProfiler(grid, number_of_watersheds=1)
     with pytest.raises(ChannelProfilerError) as excinfo:
         ChannelProfiler(grid, number_of_watersheds=n_watersheds)
-    assert "must match" in str(excinfo.value)
+    assert str(excinfo.value).startswith("Mismatch between")
 
 
 @pytest.mark.parametrize("n_watersheds", (None, 1, 2))

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -16,9 +16,34 @@ from landlab.components import FastscapeEroder
 from landlab.components import FlowAccumulator
 from landlab.components.profiler.channel_profiler import ChannelProfilerError
 from landlab.components.profiler.channel_profiler import _argsort_with_mask
+from landlab.components.profiler.channel_profiler import _raise_if_any_below_threshold
 from landlab.components.profiler.channel_profiler import _validate_outlet_nodes
 
 matplotlib.use("agg")
+
+
+@pytest.mark.parametrize("value", (0, 0.5, 2, 2.5, np.inf))
+@pytest.mark.parametrize("indices", ([0, 1, 2], None))
+def test_raise_if_below_threshold(value, indices):
+    with pytest.raises(ChannelProfilerError):
+        _raise_if_any_below_threshold([0, 1, 2], threshold=value, indices=indices)
+
+
+@pytest.mark.parametrize("value", (-1, -1e-6, -np.inf))
+@pytest.mark.parametrize("indices", ([0, 1, 2], None))
+def test_raise_if_below_threshold_all_above(value, indices):
+    assert (
+        _raise_if_any_below_threshold([0, 1, 2], threshold=value, indices=indices)
+        is None
+    )
+
+
+@pytest.mark.parametrize("value", (0, 0.5, 2, 2.5, np.inf))
+def test_raise_if_below_threshold_subset(value):
+    with pytest.raises(ChannelProfilerError):
+        _raise_if_any_below_threshold(
+            [-0.5, 0, 1, 2.5, 2], threshold=value, indices=[1, 2, 4]
+        )
 
 
 @pytest.mark.parametrize("array", [[0, 1, 2], [], [-1, -2]])

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -7,6 +7,7 @@ Created on Tue Feb 27 16:25:11 2018
 import matplotlib
 import numpy as np
 import pytest
+from numpy.testing import assert_array_equal
 
 from landlab import FieldError
 from landlab import RasterModelGrid
@@ -14,8 +15,22 @@ from landlab.components import ChannelProfiler
 from landlab.components import FastscapeEroder
 from landlab.components import FlowAccumulator
 from landlab.components.profiler.channel_profiler import ChannelProfilerError
+from landlab.components.profiler.channel_profiler import _argsort_with_mask
 
 matplotlib.use("agg")
+
+
+@pytest.mark.parametrize(
+    "mask,expected",
+    [
+        (None, [3, 0, 2, 1]),
+        ([True, True, True, True], [3, 0, 2, 1]),
+        ([True, True, True, False], [0, 2, 1]),
+        ([False, False, False, False], []),
+    ],
+)
+def test_argsort_with_mask(mask, expected):
+    assert_array_equal(_argsort_with_mask([1, 3, 2, 0], mask=mask), expected)
 
 
 @pytest.mark.parametrize("field_name", (None, "drainage_area", "foo"))

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -16,8 +16,29 @@ from landlab.components import FastscapeEroder
 from landlab.components import FlowAccumulator
 from landlab.components.profiler.channel_profiler import ChannelProfilerError
 from landlab.components.profiler.channel_profiler import _argsort_with_mask
+from landlab.components.profiler.channel_profiler import _validate_outlet_nodes
 
 matplotlib.use("agg")
+
+
+@pytest.mark.parametrize("array", [[0, 1, 2], [], [-1, -2]])
+def test_validate_outlet_nodes(array):
+    expected = np.array(array, dtype=int)
+    actual = _validate_outlet_nodes(array)
+    assert_array_equal(actual, expected)
+
+    values = np.arange(4.0) + 0.5
+    assert_array_equal(values[array], values[actual])
+
+
+def test_validate_outlet_nodes_bad_type():
+    with pytest.raises(ValueError) as excinfo:
+        _validate_outlet_nodes([0.0, 1, 2])
+    assert "indexing" in str(excinfo.value)
+
+
+def test_validate_outlet_nodes_with_none():
+    assert _validate_outlet_nodes(None) is None
 
 
 @pytest.mark.parametrize(

--- a/tests/components/profiler/test_channel_profile.py
+++ b/tests/components/profiler/test_channel_profile.py
@@ -33,6 +33,14 @@ def test_missing_channel_definition_field(field_name):
 
 def test_invalid_outlet_nodes():
     grid = RasterModelGrid((4, 5))
+    grid.at_node["topographic__elevation"] = [
+        [5, 5, 5, 5, 5],
+        [5, 4, 5, 4, 5],
+        [5, 3, 2, 3, 5],
+        [5, 5, 1, 5, 5.0],
+    ]
+    flow_accumulator = FlowAccumulator(grid, flow_director="D4")
+    flow_accumulator.run_one_step()
     with pytest.raises(ChannelProfilerError):
         ChannelProfiler(grid, outlet_nodes=[])
 
@@ -50,7 +58,7 @@ def test_invalid_number_of_watersheds(number_of_watersheds):
 
 
 @pytest.mark.parametrize("n_watersheds", (2, 3, 4))
-def test_too_many_watersheds(n_watersheds):
+def test_requesting_too_many_watersheds(n_watersheds):
     grid = RasterModelGrid((4, 5))
     grid.at_node["topographic__elevation"] = [
         [5, 5, 5, 5, 5],
@@ -62,8 +70,9 @@ def test_too_many_watersheds(n_watersheds):
     flow_accumulator.run_one_step()
 
     ChannelProfiler(grid, number_of_watersheds=1)
-    with pytest.raises(ChannelProfilerError):
+    with pytest.raises(ChannelProfilerError) as excinfo:
         ChannelProfiler(grid, number_of_watersheds=n_watersheds)
+    assert "must match" in str(excinfo.value)
 
 
 @pytest.mark.parametrize("n_watersheds", (None, 1, 2))


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

Previously, the `ChannelProfiler` raised a generic and somewhat confusing error when a watershed was invalid. This could occur when no outlets were found, or when one or more outlet nodes drained basins below the required threshold.

This PR refactors the relevant checks to raise more specific and descriptive error messages that clarify exactly why a watershed is considered invalid.


<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
