### PR TITLE
Fix broken link to vtk formats

### DIFF
--- a/docs/source/tutorials/output/writing_legacy_vtk_files.ipynb
+++ b/docs/source/tutorials/output/writing_legacy_vtk_files.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "## The format\n",
     "\n",
-    "To quote from the VTK [documentation](https://docs.vtk.org/en/latest/design_documents/VTKFileFormats.html): \n",
+    "To quote from the VTK [documentation](https://docs.vtk.org/en/latest/vtk_file_formats): \n",
     "\n",
     "\"*The legacy VTK file formats consist of five basic parts.*\n",
     "\n",

--- a/noxfile.py
+++ b/noxfile.py
@@ -225,7 +225,7 @@ def docs_check_links(session: nox.Session) -> None:
     ]
 
     if broken_links:
-        print("\n".join(sorted(broken_links)))
+        print("\n".join(f"❌ {link}" for link in sorted(broken_links)))
         session.error(
             f"{len(broken_links)} broken links were found."
             f" see {output_json} for a complete log"


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

There was a broken link in the *vtk* notebook that pointed to a page on the [docs.vtk.org](https://docs.vtk.org) that was moved. I've updated the notebook to point to the new location.


---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
