### PR TITLE
Add nodata_value keyword to esrii_ascii.dump function

### DIFF
--- a/news/2204.feature
+++ b/news/2204.feature
@@ -1,0 +1,3 @@
+Added a `nodata_value` keyword to the `esri_ascii.dump` function,
+allowing users to specify a custom no-data value when exporting
+grid data to ESRI ASCII format.

--- a/src/landlab/io/esri_ascii.py
+++ b/src/landlab/io/esri_ascii.py
@@ -48,6 +48,7 @@ def dump(
     stream: TextIO | None = None,
     at: Literal["node", "patch", "corner", "cell"] = "node",
     name: str | None = None,
+    nodata_value: int | float = -9999,
 ) -> str | None:
     """Dump a grid field to ESRII ASCII format.
 
@@ -84,13 +85,13 @@ def dump(
     YLLCENTER 0.0
     NODATA_VALUE -9999
 
-    >>> print(esri_ascii.dump(grid, at="cell"))
+    >>> print(esri_ascii.dump(grid, at="cell", nodata_value=0))
     NROWS 1
     NCOLS 2
     CELLSIZE 2.0
     XLLCENTER 2.0
     YLLCENTER 2.0
-    NODATA_VALUE -9999
+    NODATA_VALUE 0
     """
     grid = _validate_grid(grid)
 
@@ -108,6 +109,7 @@ def dump(
         xllcenter=grid.xy_of_lower_left[0] - grid.dx * shift,
         yllcenter=grid.xy_of_lower_left[1] - grid.dx * shift,
         cellsize=grid.dx,
+        nodata_value=nodata_value,
     )
     lines = [str(header)]
 

--- a/src/landlab/io/esri_ascii.py
+++ b/src/landlab/io/esri_ascii.py
@@ -54,20 +54,22 @@ def dump(
 
     Parameters
     ----------
-    grid :
+    grid : ModelGrid
         A Landlab grid.
-    stream :
+    stream : file-like, optional
         A ``file_like`` object to write to. If ``None``, return
         a string containing the serialized grid.
-    at :
+    at : str, optional
         Where the field to be written is located on the grid.
-    name :
+    name : str, optional
         The name of the field to be written. If ``None``, only the header
         information will be written.
+    nodata_value : float or int, optional
+        The value to indicate there is no-data at this point.
 
     Returns
     -------
-    :
+    str or None
         The grid field in ESRI ASCII format or ``None`` if a ``file_like``
         object was provided.
 

--- a/tests/io/test_esri_ascii.py
+++ b/tests/io/test_esri_ascii.py
@@ -120,6 +120,24 @@ cellsize {cellsize}
         esri_ascii.loads(contents.format(**header))
 
 
+@pytest.mark.parametrize("nodata_value", (0, 1, -999))
+def test_dump_with_nodata_value(nodata_value):
+    grid = RasterModelGrid((4, 3), xy_spacing=10.0, xy_of_lower_left=(1.0, 2.0))
+    actual = esri_ascii.dump(grid, nodata_value=nodata_value)
+
+    assert (
+        actual
+        == f"""\
+NROWS 4
+NCOLS 3
+CELLSIZE 10.0
+XLLCENTER 1.0
+YLLCENTER 2.0
+NODATA_VALUE {nodata_value}
+"""
+    )
+
+
 def test_dump_to_string_no_data():
     grid = RasterModelGrid((4, 3), xy_spacing=10.0, xy_of_lower_left=(1.0, 2.0))
     actual = esri_ascii.dump(grid)


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [ ] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

As reported in #2201 by @lengri, the `esri_ascii.dump` function lacks the ability to modify the *no-data* value of a field. I've added a new keyword, `nodata_value`, to the `esri_ascii.dump` function to achieve this.

<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
