### PR TITLE
Fix esri_ascii lower left corner/center

### DIFF
--- a/news/2207.bugfix
+++ b/news/2207.bugfix
@@ -1,0 +1,2 @@
+Fixed an issue where the location of the lower left corner was
+being written by `esri_ascii.dump`.

--- a/src/landlab/io/esri_ascii.py
+++ b/src/landlab/io/esri_ascii.py
@@ -578,18 +578,24 @@ def _get_lower_left_shift(at="node", ref="center"):
         The unit shift between the lower left of an ESRI ASCII field
         and a ``RasterModelGrid``.
     """
-    if at == "node" or (at == "patch" and ref == "corner"):
-        return 0.0
-    elif (
-        at == "corner"
-        or (at == "patch" and ref == "center")
-        or (at == "cell" and ref == "corner")
-    ):
-        return -0.5
-    elif at == "cell" and ref == "center":
-        return -1.0
+    if ref not in ("center", "corner"):
+        raise ValueError(
+            f"Unrecognized reference location ({ref!r} not one of 'center', 'corner')"
+        )
 
-    raise RuntimeError(f"unreachable code ({at!r}, {ref!r}")
+    if at == "node":
+        return 0.0 if ref == "center" else 0.5
+    if at == "patch":
+        return -0.5 if ref == "center" else 0.0
+    if at == "corner":
+        return -0.5 if ref == "center" else 0.0
+    if at == "cell":
+        return -1.0 if ref == "center" else -0.5
+
+    raise ValueError(
+        f"Unrecognized grid location ({at!r} not one of"
+        " 'cell', 'corner', 'node', 'patch')"
+    )
 
 
 class _Header:

--- a/tests/io/test_esri_ascii.py
+++ b/tests/io/test_esri_ascii.py
@@ -342,3 +342,13 @@ def test_dump_unequal_spacing():
 
     with pytest.raises(esri_ascii.EsriAsciiError):
         esri_ascii.dump(grid)
+
+
+def test_reference_shift_with_bad_args():
+    with pytest.raises(ValueError) as exc_info:
+        esri_ascii._get_lower_left_shift(at="foo", ref="center")
+    assert str(exc_info.value).startswith("Unrecognized grid location")
+
+    with pytest.raises(ValueError) as exc_info:
+        esri_ascii._get_lower_left_shift(at="node", ref="foo")
+    assert str(exc_info.value).startswith("Unrecognized reference")


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [ ] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

As @lengri identified in #2203, there is an error in how *Landlab* reads/writes the reference coordinates in an *ESRI* ASCII file. I've fixed the `_get_lower_left_shift` function, which should fix the issue.

The following code now shows the expected behavior.  
```pycon
>>> from landlab.io import esri_ascii

>>> grid = esri_ascii.loads("""\
... nrows 3
... ncols 4
... cellsize 1.0
... xllcorner 0.0
... yllcorner 0.0
... """)
>>> grid.xy_of_lower_left
(np.float64(0.5), np.float64(0.5))

>>> print(esri_ascii.dump(grid))
NROWS 3
NCOLS 4
CELLSIZE 1.0
XLLCENTER 0.5
YLLCENTER 0.5
NODATA_VALUE -9999
```

<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
