### PR TITLE
Fix hypothesis error related to spacing_from_drainage_area test

### DIFF
--- a/src/landlab/grid/create_network.py
+++ b/src/landlab/grid/create_network.py
@@ -247,11 +247,11 @@ class AtMostNodes(SegmentReducer):
 
 
 def spacing_from_drainage_area(
-    drainage_area,
-    a=9.68,
-    b=0.32,
-    n_widths=20.0,
-):
+    drainage_area: npt.NDArray[np.floating] | float,
+    a: float = 9.68,
+    b: float = 0.32,
+    n_widths: float = 20.0,
+) -> npt.NDArray[np.floating] | float:
     """Calculate channel spacing based on upstream drainage area of each node.
 
     Parameters

--- a/src/landlab/grid/create_network.py
+++ b/src/landlab/grid/create_network.py
@@ -256,8 +256,12 @@ def spacing_from_drainage_area(
 
     Parameters
     ----------
-    drainage_area : number or ndarray
+    drainage_area : float or ndarray
         Upstream drainage area in km ** 2.
+    a, b : float, optional
+        Coefficient and exponent to use for channel width calculation.
+    n_widths: float, optional
+        Number of channel widths for the spacing.
 
     Returns
     -------

--- a/src/landlab/grid/create_network.py
+++ b/src/landlab/grid/create_network.py
@@ -268,7 +268,7 @@ def spacing_from_drainage_area(
     ndarray
         Node spacing in meters.
     """
-    return n_widths * (a * drainage_area / (1000**2)) ** b
+    return n_widths * (a * drainage_area / 1e6) ** b
 
 
 def _reduce_nodes(distance_along_segment, spacing=1.0):

--- a/tests/grid/test_create_network.py
+++ b/tests/grid/test_create_network.py
@@ -30,23 +30,37 @@ from landlab.grid.create_network import reindex_network_nodes
 from landlab.grid.create_network import spacing_from_drainage_area
 
 
-@given(
-    drainage_area=hynp.arrays(
-        dtype=hynp.floating_dtypes(),
-        shape=hynp.array_shapes(),
-        elements=floats(min_value=0, max_value=1000, width=16),
-    )
+@pytest.mark.parametrize(
+    "drainage_area",
+    (
+        0.0,
+        1.0,
+        1e6,
+        np.array([0.0]),
+        np.array([1.0]),
+        np.array([1e6]),
+        np.array([1, 2, 3, 4]),
+        np.array([1, 2, 3, 4, 5, 6]).reshape((3, 2)),
+    ),
 )
 def test_calc_spacing_always_positive(drainage_area):
     assert np.all(spacing_from_drainage_area(drainage_area) >= 0.0)
 
 
-@given(
-    drainage_area=hynp.arrays(
-        dtype=hynp.floating_dtypes(),
-        shape=hynp.array_shapes(),
-        elements=floats(min_value=0, width=16, allow_infinity=False),
-    )
+@pytest.mark.parametrize(
+    "drainage_area",
+    (
+        0.0,
+        1.0,
+        1e6,
+        1e9,
+        np.array([0.0]),
+        np.array([1.0]),
+        np.array([1e6]),
+        np.array([1e9]),
+        np.array([1, 2, 3, 4]),
+        np.array([1, 2, 3, 4, 5, 6]).reshape((3, 2)),
+    ),
 )
 def test_calc_spacing_unit_keywords(drainage_area):
     spacing = spacing_from_drainage_area(drainage_area, a=1, b=1, n_widths=1)


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [ ] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

With a newer version of *hypothesis* (), one of the tests for `spacing_from_drainage_area` is failing with the following error,
```
FAILED tests/grid/test_create_network.py::test_calc_spacing_unit_keywords - hypothesis.errors.FailedHealthCheck: It looks like this test is filtering out a lot of inputs. 7 inputs were generated successfully, while 50 inputs were filtered out. 

An input might be filtered out by calls to assume(), strategy.filter(...), or occasionally by Hypothesis internals.

Applying this much filtering makes input generation slow, since Hypothesis must discard inputs which are filtered out and try generating it again. It is also possible that applying this much filtering will distort the domain and/or distribution of the test, leaving your testing less rigorous than expected.

If you expect this many inputs to be filtered out during generation, you can disable this health check with @settings(suppress_health_check=[HealthCheck.filter_too_much]). See https://hypothesis.readthedocs.io/en/latest/reference/api.html#hypothesis.HealthCheck for details.
```
I've changed these tests so the we no longer use *hypothesis* with them but, instead, just parametrize the test with a fixed set of values. 

This closes #2216.

<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
