### PR TITLE
overland flow: add adjust_unstable_discharge

### DIFF
--- a/news/2318.misc
+++ b/news/2318.misc
@@ -1,0 +1,2 @@
+Refactored discharge stability adjustments in the overland flow component
+into a new *cython* function, `adjust_unstable_discharge`.

--- a/src/landlab/components/overland_flow/_calc.pyx
+++ b/src/landlab/components/overland_flow/_calc.pyx
@@ -28,6 +28,39 @@ def adjust_unstable_discharge(
     const id_t [::1] where,
     cython.floating [::1] out,
 ):
+    """Clamp discharge to maintain stability under a shallow-water CFL constraint.
+
+    Limit the magnitude of discharge such that it does not exceed a scaled
+    Courant–type stability threshold. The maximum allowable discharge is
+    determined as::
+
+        q_max = factor * (h / 4) * (dx / dt)
+
+    where ``dx`` is the grid spacing, ``dt`` is the timestep, ``h`` is water depth at
+    the link, and ``factor`` is a safety coefficient (currently set to ``0.8``). The
+    value of ``q_at_link`` is clamped to ``[-q_max, +q_max]`` while preserving its sign.
+
+    Parameters
+    ----------
+    q_at_link : ndarray of float, shape (n_links,)
+        Water discharge at each link.
+    h_at_link : ndarray of float, shape (n_links,)
+        Water depth at each link.
+    dx : float
+        Grid spacing (must be > 0).
+    dt : double
+        Timestep (must be > 0).
+    where : ndarray of int
+        Indices of links for which discharge should be adjusted.
+    out : ndarray of float, shape (n_links,)
+        Output array into which adjusted discharge values are written. May be the
+        same memory as ``q_at_link`` for in-place updates.
+
+    Returns
+    -------
+    ndarray of float
+        The adjusted discharge array.
+    """
     cdef Py_ssize_t n_links = where.shape[0]
     cdef Py_ssize_t i
     cdef id_t link

--- a/tests/components/overland_flow/test_calc_unstable_discharge.py
+++ b/tests/components/overland_flow/test_calc_unstable_discharge.py
@@ -1,0 +1,90 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_equal
+
+from landlab.components.overland_flow._calc import adjust_unstable_discharge
+
+
+def threshold_discharge(h, dx, dt):
+    return 0.25 * h * dx / dt * 0.8
+
+
+@pytest.mark.parametrize("dx", (1.0, 2.0))
+@pytest.mark.parametrize("dt", (1.0, 2.0))
+@pytest.mark.parametrize("h", (1.0, 2.0))
+def test_stable_discharge(dx, dt, h):
+    eps = 1e-6
+
+    q_max = threshold_discharge(h, dx, dt)
+
+    q = [-q_max - eps, -q_max + eps, q_max - eps, q_max + eps]
+    expected = [-q_max, -q_max + eps, q_max - eps, q_max]
+    actual = np.empty_like(q)
+
+    rtn = adjust_unstable_discharge(
+        np.asarray(q),
+        np.full_like(q, h),
+        dx=dx,
+        dt=dt,
+        where=np.arange(len(q)),
+        out=actual,
+    )
+    assert_equal(actual, expected)
+    assert rtn is actual
+
+
+@pytest.mark.parametrize(
+    "where",
+    (
+        [0, 0, 0, 0],
+        [1, 1, 1, 1],
+        [0, 0, 0, 1],
+        [1, 0, 0, 0],
+    ),
+)
+def test_stable_discharge_where(where):
+    where = np.asarray(where).astype(bool)
+    dx, dt, h = 1.0, 1.0, 1.0
+    eps = 1e-6
+
+    q_max = threshold_discharge(h, dx, dt)
+
+    q = [-q_max - eps, -q_max + eps, q_max - eps, q_max + eps]
+    expected = np.asarray([-q_max, -q_max + eps, q_max - eps, q_max])
+    actual = np.full_like(q, -999)
+
+    rtn = adjust_unstable_discharge(
+        np.asarray(q),
+        np.full_like(q, h),
+        dx=dx,
+        dt=dt,
+        where=np.flatnonzero(where),
+        out=actual,
+    )
+    assert_equal(actual[where], expected[where])
+    assert_equal(actual[~where], -999)
+    assert rtn is actual
+
+
+@pytest.mark.parametrize("dx", (1.0, 2.0))
+@pytest.mark.parametrize("dt", (1.0, 2.0))
+@pytest.mark.parametrize("h", (1.0, 2.0))
+@pytest.mark.parametrize("n_items", (1, 5))
+def test_stable_discharge_in_place(dx, dt, h, n_items):
+    q_max = threshold_discharge(h, dx, dt)
+
+    h = np.full(n_items, h, dtype=float)
+
+    q = np.full_like(h, q_max * (1 + 1e-6))
+    out = q
+    q_initial = q.copy()
+    expected = np.full_like(h, q_max)
+
+    rtn = adjust_unstable_discharge(
+        q, h, dx=dx, dt=dt, where=np.arange(n_items), out=out
+    )
+
+    assert rtn is out
+    assert_equal(out, expected)
+    assert_equal(q, expected)
+    assert np.all(q != q_initial)


### PR DESCRIPTION
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've refactored the adjustment of discharge for stability, fixing a small error (I think) and significantly speeding up the original block of code. I think it's also clearer to read.

This replaces the following code,
```python
                q_courant = q_at_link * dt_local / self._grid.dx
                water_div_4 = h_at_link / 4.0
                (positive_q,) = np.where(q_at_link > 0)
                (negative_q,) = np.where(q_at_link < 0)

                (water_logical,) = np.where(q_courant > water_div_4)
                (water_abs_logical,) = np.where(abs(q_courant) > water_div_4)

                self._if_statement_3 = np.intersect1d(positive_q, water_logical)
                self._if_statement_4 = np.intersect1d(negative_q, water_abs_logical)

                q_at_link[self._if_statement_3] = (
                    (h_at_link[self._if_statement_3] * self._grid.dx) / 5.0
                ) / dt_local

                q_at_link[self._if_statement_4] = (
                    0.0
                    - (h_at_link[self._if_statement_4] * self._grid.dx / 5.0) / dt_local
                )
```
I believe the only difference between this and my new version is when clamping is triggered. In the old version, `q` values are clamped when `abs(q) > 0.25 * h * dx / dt` and were clamped to `abs(q) = 0.2 * h * dx / dt`. In my new version, the trigger and the clamped values are the same (i.e. the trigger and the cap are both `abs(q) > 0.2 * h * dx / dt`). I think this is what we probably want. In the original, values between the cap and the trigger were unchanged.


<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

#2327

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
