### PR TITLE
Initialize spoke angles with nan's

### DIFF
--- a/news/2349.misc
+++ b/news/2349.misc
@@ -1,0 +1,2 @@
+Fixed the *numpy* "where without out" warnings in the spoke sorter and
+the concentration tracker.

--- a/src/landlab/components/concentration_tracker/concentration_tracker_for_diffusion.py
+++ b/src/landlab/components/concentration_tracker/concentration_tracker_for_diffusion.py
@@ -366,24 +366,31 @@ class ConcentrationTrackerForDiffusion(Component):
         # Calculate other components of mass balance equation
         is_soil = self._soil__depth > 0.0
 
-        old_depth_over_new = np.divide(
-            self._soil__depth_old, self._soil__depth, where=is_soil
+        old_depth_over_new = np.zeros_like(self._soil__depth)
+        np.divide(
+            self._soil__depth_old,
+            self._soil__depth,
+            where=is_soil,
+            out=old_depth_over_new,
         )
-        old_depth_over_new[~is_soil] = 0.0
 
-        dt_over_depth = np.divide(dt, self._soil__depth, where=is_soil)
-        dt_over_depth[~is_soil] = 0.0
+        dt_over_depth = np.zeros_like(self._soil__depth)
+        np.divide(dt, self._soil__depth, where=is_soil, out=dt_over_depth)
 
         conc_local = conc_old * old_depth_over_new
-        conc_from_weathering = np.divide(
-            self._conc_w * self._soil_prod_rate * dt, self._soil__depth, where=is_soil
+
+        conc_from_weathering = np.zeros_like(self._soil__depth)
+        np.divide(
+            self._conc_w * self._soil_prod_rate * dt,
+            self._soil__depth,
+            where=is_soil,
+            out=conc_from_weathering,
         )
 
         # Calculate concentration
         self._concentration[:] = (
             conc_local + conc_from_weathering + dt_over_depth * (-dqconc_dx)
         )
-
         self._concentration[~is_soil] = 0.0
 
     def start_tracking(self):

--- a/src/landlab/graph/sort/sort.py
+++ b/src/landlab/graph/sort/sort.py
@@ -721,7 +721,8 @@ def sort_spokes_at_hub(spokes_at_hub, xy_of_hub, xy_of_spokes, inplace=False):
     dx = np.subtract(xy_of_spokes[:, 0][spokes_at_hub], xy_of_hub[:, 0, None])
     dy = np.subtract(xy_of_spokes[:, 1][spokes_at_hub], xy_of_hub[:, 1, None])
 
-    angle_of_spoke_at_hub = np.arctan2(dy, dx, where=spokes_at_hub != -1)
+    angle_of_spoke_at_hub = np.full_like(spokes_at_hub, np.nan, dtype=float)
+    np.arctan2(dy, dx, where=spokes_at_hub != -1, out=angle_of_spoke_at_hub)
     angle_of_spoke_at_hub[angle_of_spoke_at_hub < 0.0] += np.pi * 2.0
 
     sort_id_array(spokes_at_hub, angle_of_spoke_at_hub, out)

--- a/tests/graph/sort/test_sort.py
+++ b/tests/graph/sort/test_sort.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from landlab.graph.sort.sort import sort_spokes_at_hub
+
+
+@pytest.mark.skipif(
+    np.lib.NumpyVersion(np.__version__) < "2.4.0",
+    reason="warning only present in numpy >= 2.4",
+)
+def test_no_numpy_warning(recwarn):
+    spokes_at_hub = np.asarray([[0, 1, 2, -1]])
+    xy_of_hub = np.asarray([[0.0, 0.0]])
+    xy_of_spokes = np.asarray(
+        [
+            [1.0, 0.0],
+            [-1.0, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    expected = [[0, 2, 1, -1]]
+    actual = sort_spokes_at_hub(spokes_at_hub, xy_of_hub, xy_of_spokes)
+    assert not any("'where' used without 'out'" in str(w.message) for w in recwarn)
+    assert_array_equal(actual, expected)


### PR DESCRIPTION
<!--
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---
-->
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

The following line,

```python
angle_of_spoke_at_hub = np.arctan2(dy, dx, where=spokes_at_hub != -1)
```
was producing the following warning from *numpy*,
```
src/landlab/graph/sort/sort.py:726: UserWarning: 'where' used without 'out', expect unitialized memory in output. If this is intentional, use out=None.
```
In our case, the uninitialized memory should never be used but, just to be safe, I've modified the code to create an output array that's initialized with *nan*s.

@tjhei this should fix the warning you are seeing when creating a `HexModelGrid`.

<!--
Provide a short summary of the change. Why is it needed? What does it do?
-->

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
