### PR TITLE
Change the CI to publish wheels when manually triggered

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,38 +3,26 @@ name: Test
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-
+  workflow_dispatch:
+    inputs:
+      publish_to:
+        description: "Where to publish"
+        type: choice
+        required: true
+        default: none
+        options:
+          - none
+          - testpypi
+          - pypi
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
 jobs:
-  check-tag:
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    outputs:
-      publish_url: ${{ steps.check-publish.outputs.publish_url }}
-
-    steps:
-      - name: Check if this is a release/prerelease
-        id: check-publish
-        run: |
-          tag_name="${GITHUB_REF#refs/tags/}"
-          if [[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+[ab][0-9]+$ ]]; then
-            publish_url="https://test.pypi.org/legacy/"
-          elif [[ "$tag_name" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            publish_url="https://upload.pypi.org/legacy/"
-          else
-            publish_url="none"
-          fi
-          echo "publish_url=$publish_url" >> "$GITHUB_OUTPUT"
-          echo "tag_name=$tag_name"
-          echo "publish_url=$publish_url"
-
   build-sdist:
     name: Build source distribution
-    needs: check-tag
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -49,7 +37,7 @@ jobs:
 
   build-wheels:
     name: Build wheels on ${{ matrix.cibw-only }}
-    needs: check-tag
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -81,7 +69,7 @@ jobs:
       - uses: ./.github/actions/build-bdist/
         env:
           CIBW_ENVIRONMENT: >-
-            LANDLAB_BUILD_RELEASE=${{ startsWith(needs.check-tag.outputs.publish_url, 'http') && '1' || '0' }}
+            LANDLAB_BUILD_RELEASE=${{ github.event_name == 'workflow_dispatch' && inputs.publish_to != 'none' && '1' || '0' }}
 
         with:
           cibw-only: ${{ matrix.cibw-only }}
@@ -106,7 +94,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           HYPOTHESIS_PROFILE: "ci"
           MPLBACKEND: "Agg"
-          PYTEST-ADDOPTS: "-m '${{ matrix.pytest-marker }}'"
+          PYTEST_ADDOPTS: "-m '${{ matrix.pytest-marker }}'"
         with:
           python-version: ${{ matrix.python-version }}
           nox-session: "test"
@@ -136,7 +124,6 @@ jobs:
           upload-name: ${{ matrix.os == 'macos-latest' && format('notebooks-{0}', matrix.pytest-marker) || '' }}
 
   check-links:
-    needs: check-tag
     runs-on: ubuntu-latest
 
     defaults:
@@ -215,26 +202,30 @@ jobs:
 
   publish:
     needs:
-      - check-tag
       - test-landlab
       - test-notebooks
       - build-sdist
     name: "Publish to PyPI/TestPyPI"
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_to != 'none'
+    env:
+      REPOSITORY_URL: ${{ inputs.publish_to == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}
 
     permissions:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@v8
         with:
           pattern: "build-*"
           merge-multiple: true
           path: ${{ github.workspace }}/dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
-        if: ${{ startsWith(needs.check-tag.outputs.publish_url, 'http') }}
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: ${{ needs.check-tag.outputs.publish_url }}
+          repository-url: ${{ env.REPOSITORY_URL }}
+          packages-dir: dist
           skip-existing: true
           print-hash: true
           verify-metadata: false

--- a/news/2376.misc
+++ b/news/2376.misc
@@ -1,0 +1,2 @@
+Modified the CI to publish to *PyPI* or *TestPyPI* on a manual
+trigger rather than on a version tag.


### PR DESCRIPTION
<!--
# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---
-->

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

Instead of having our CI publish to *PyPI* or *TestPyPI* based on a tag, I think it's easier to publish when a workflow is manually triggered.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
