### PR TITLE
First-pass grid compatibility audit for selected components

### DIFF
--- a/src/landlab/components/chi_index/channel_chi.py
+++ b/src/landlab/components/chi_index/channel_chi.py
@@ -3,11 +3,12 @@
 @author: dejh
 """
 
+import warnings
+
 import numpy as np
 
 from landlab import Component
 from landlab import RasterModelGrid
-import warnings
 
 try:
     from itertools import izip

--- a/src/landlab/components/chi_index/channel_chi.py
+++ b/src/landlab/components/chi_index/channel_chi.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from landlab import Component
 from landlab import RasterModelGrid
+import warnings
 
 try:
     from itertools import izip
@@ -185,8 +186,8 @@ class ChiFinder(Component):
         """
         Parameters
         ----------
-        grid : RasterModelGrid
-            A landlab RasterModelGrid.
+        grid : ModelGrid
+            A landlab grid. RasterModelGrid is the primary supported grid type.
         reference_concavity : float
             The reference concavity to use in the calculation.
         min_drainage_area : float (m**2)
@@ -205,6 +206,14 @@ class ChiFinder(Component):
 
         """
         super().__init__(grid)
+
+        if not isinstance(self._grid, RasterModelGrid):
+            warnings.warn(
+                "ChiFinder is primarily supported for RasterModelGrid; "
+                "other grid types are not fully tested.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         if grid.at_node["flow__receiver_node"].size != grid.size("node"):
             raise NotImplementedError(

--- a/src/landlab/components/diffusion/diffusion.py
+++ b/src/landlab/components/diffusion/diffusion.py
@@ -177,6 +177,17 @@ class LinearDiffuser(Component):
         """
         super().__init__(grid)
 
+        # NOTE: Diffusion component has partial support for different grid types.
+        # Some methods (e.g., resolve_on_patches) and configurations require
+        # RasterModelGrid specifically.
+
+        if not isinstance(grid, RasterModelGrid):
+            # Allow non-raster grids only for simple method with node-based diffusivity
+            if method != "simple":
+                raise TypeError(
+            "Diffusion component only supports non-Raster grids with method='simple'."
+                )
+
         self._bc_set_code = self._grid.bc_set_code
         method = self._validate_method(method)
 

--- a/src/landlab/components/diffusion/diffusion.py
+++ b/src/landlab/components/diffusion/diffusion.py
@@ -185,7 +185,7 @@ class LinearDiffuser(Component):
             # Allow non-raster grids only for simple method with node-based diffusivity
             if method != "simple":
                 raise TypeError(
-            "Diffusion component only supports non-Raster grids with method='simple'."
+                    "Diffusion component only supports non-Raster grids with method='simple'."
                 )
 
         self._bc_set_code = self._grid.bc_set_code

--- a/src/landlab/components/tectonics/listric_kinematic_extender.py
+++ b/src/landlab/components/tectonics/listric_kinematic_extender.py
@@ -139,8 +139,8 @@ class ListricKinematicExtender(Component):
 
         Parameters
         ----------
-        grid: RasterModelGrid
-            A landlab grid.
+        grid : RasterModelGrid or HexModelGrid
+            A landlab raster or hex grid.
         extension_rate_x: float, optional
             Rate of x-directed horizontal motion of hangingwall relative to footwall
             (m / y), default 0.001 m/y.

--- a/src/landlab/components/tectonics/listric_kinematic_extender.py
+++ b/src/landlab/components/tectonics/listric_kinematic_extender.py
@@ -163,7 +163,7 @@ class ListricKinematicExtender(Component):
             by calculating upwind links only once.
         """
         if not (isinstance(grid, RasterModelGrid) or isinstance(grid, HexModelGrid)):
-            raise (TypeError, "grid must be a RasterModelGrid or HexModelGrid")
+            raise TypeError("grid must be a RasterModelGrid or HexModelGrid")
 
         fields_to_advect = [] if fields_to_advect is None else fields_to_advect
 

--- a/tests/components/advection_solver/test_advection_solver.py
+++ b/tests/components/advection_solver/test_advection_solver.py
@@ -255,6 +255,44 @@ def test_step_function_with_single_named_quantity():
     # verify that field "flux_of_one_advected__quantity" has been created
     assert len(grid.at_link["flux_of_one_advected__quantity"]) == grid.number_of_links
 
+def test_step_function_with_no_quantity_named_hex():
+    grid = HexModelGrid((3, 4), orientation="horizontal")
+    u = grid.add_zeros("advection__velocity", at="link")
+    u[grid.orientation_of_link == LinkOrientation.E] = 1.0
+
+    advector = AdvectionSolverTVD(grid, advection_direction_is_steady=True)
+    C = grid.at_node["advected__quantity"]
+    C[grid.x_of_node < np.median(grid.x_of_node)] = 1.0
+
+    for _ in range(10):
+        advector.run_one_step(0.1)
+
+    assert np.all(np.isfinite(C))
+
+    # verify that "advection__flux" field has been created
+    assert len(grid.at_link["advection__flux"]) == grid.number_of_links
+
+def test_step_function_with_single_named_quantity_hex():
+    grid = HexModelGrid((3, 4), orientation="horizontal")
+    C = grid.add_zeros("one_advected__quantity", at="node")
+    C[grid.x_of_node < np.median(grid.x_of_node)] = 1.0
+
+    u = grid.add_zeros("advection__velocity", at="link")
+    u[grid.orientation_of_link == LinkOrientation.E] = 1.0
+
+    advector = AdvectionSolverTVD(
+        grid,
+        fields_to_advect="one_advected__quantity",
+        advection_direction_is_steady=True,
+    )
+
+    for _ in range(10):
+        advector.run_one_step(0.1)
+
+    assert np.all(np.isfinite(C))
+
+    # verify that field "flux_of_one_advected__quantity" has been created
+    assert len(grid.at_link["flux_of_one_advected__quantity"]) == grid.number_of_links
 
 def test_with_two_advected_fields():
     grid = RasterModelGrid((3, 7))

--- a/tests/components/advection_solver/test_advection_solver.py
+++ b/tests/components/advection_solver/test_advection_solver.py
@@ -255,6 +255,7 @@ def test_step_function_with_single_named_quantity():
     # verify that field "flux_of_one_advected__quantity" has been created
     assert len(grid.at_link["flux_of_one_advected__quantity"]) == grid.number_of_links
 
+
 def test_step_function_with_no_quantity_named_hex():
     grid = HexModelGrid((3, 4), orientation="horizontal")
     u = grid.add_zeros("advection__velocity", at="link")
@@ -271,6 +272,7 @@ def test_step_function_with_no_quantity_named_hex():
 
     # verify that "advection__flux" field has been created
     assert len(grid.at_link["advection__flux"]) == grid.number_of_links
+
 
 def test_step_function_with_single_named_quantity_hex():
     grid = HexModelGrid((3, 4), orientation="horizontal")
@@ -293,6 +295,7 @@ def test_step_function_with_single_named_quantity_hex():
 
     # verify that field "flux_of_one_advected__quantity" has been created
     assert len(grid.at_link["flux_of_one_advected__quantity"]) == grid.number_of_links
+
 
 def test_with_two_advected_fields():
     grid = RasterModelGrid((3, 7))

--- a/tests/components/chi_index/test_chi_finder.py
+++ b/tests/components/chi_index/test_chi_finder.py
@@ -35,9 +35,7 @@ def test_functions_with_Hex():
     fa = FlowAccumulator(mg)
     fa.run_one_step()
 
-    with pytest.warns(
-        UserWarning, match="primarily supported for RasterModelGrid"
-    ):
+    with pytest.warns(UserWarning, match="primarily supported for RasterModelGrid"):
         ch = ChiFinder(mg, min_drainage_area=1.0, reference_concavity=1.0)
 
     ch.calculate_chi()

--- a/tests/components/chi_index/test_chi_finder.py
+++ b/tests/components/chi_index/test_chi_finder.py
@@ -35,5 +35,9 @@ def test_functions_with_Hex():
     fa = FlowAccumulator(mg)
     fa.run_one_step()
 
-    ch = ChiFinder(mg, min_drainage_area=1.0, reference_concavity=1.0)
+    with pytest.warns(
+        UserWarning, match="primarily supported for RasterModelGrid"
+    ):
+        ch = ChiFinder(mg, min_drainage_area=1.0, reference_concavity=1.0)
+
     ch.calculate_chi()

--- a/tests/components/diffusion/test_sniff_diffusion.py
+++ b/tests/components/diffusion/test_sniff_diffusion.py
@@ -90,6 +90,13 @@ def test_diffusion_with_resolve_on_patches():
             grid, linear_diffusivity="diffusivity", method="resolve_on_patches"
         )
 
+def test_link_diffusivity_requires_raster_grid():
+    grid = HexModelGrid((5, 5))
+    grid.add_ones("topographic__elevation", at="node")
+    k = grid.add_ones("diffusivity", at="link")
+
+    with pytest.raises(TypeError, match="RasterModelGrid"):
+        LinearDiffuser(grid, linear_diffusivity=k, method="simple")
 
 def test_diffusion():
     dt = 1.0

--- a/tests/components/diffusion/test_sniff_diffusion.py
+++ b/tests/components/diffusion/test_sniff_diffusion.py
@@ -90,6 +90,7 @@ def test_diffusion_with_resolve_on_patches():
             grid, linear_diffusivity="diffusivity", method="resolve_on_patches"
         )
 
+
 def test_link_diffusivity_requires_raster_grid():
     grid = HexModelGrid((5, 5))
     grid.add_ones("topographic__elevation", at="node")
@@ -97,6 +98,7 @@ def test_link_diffusivity_requires_raster_grid():
 
     with pytest.raises(TypeError, match="RasterModelGrid"):
         LinearDiffuser(grid, linear_diffusivity=k, method="simple")
+
 
 def test_diffusion():
     dt = 1.0


### PR DESCRIPTION
Hi,

This PR is part of Issue #2336 on grid compatibility.

In this first pass, I focused on improving how grid compatibility is surfaced and tested for a small set of related components.

## Completed in this PR
- [x] Improved validation logic in `LinearDiffuser`
- [x] Added a grid compatibility test for link-based diffusivity in `LinearDiffuser`
- [x] Updated `ChiFinder` to warn when used with non-raster grids
- [x] Updated `ChiFinder` tests accordingly
- [x] Standardized a grid type error in `ListricKinematicExtender`
- [x] Clarified supported grid types in `ListricKinematicExtender` docs
- [x] Added `HexModelGrid` integration tests for `AdvectionSolverTVD`

## Notes
- `AdvectionSolverTVD` was reviewed as a related component.
- In this pass, I focused on adding missing solver-level Hex coverage rather than introducing new restrictions without a broader audit.

Feedback is very welcome. Thanks!