### PR TITLE
NST pvelocity & dmean bugfix

### DIFF
--- a/news/2408.bugfix
+++ b/news/2408.bugfix
@@ -1,0 +1,1 @@
+Fixed errors in `NetworkSedimentTransporter` handling of: 1) parcel velocity and 2) mean grain size calculations, which will make parcel transport accurately reflect fluxes calculated via Wilcock and Crowe (2003).

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -21,6 +21,7 @@ from numpy.typing import NDArray
 
 from landlab.components.flow_director.flow_director_steepest import FlowDirectorSteepest
 from landlab.core.model_component import Component
+from landlab.data_record.aggregators import aggregate_items_as_gmean
 from landlab.data_record.aggregators import aggregate_items_as_mean
 from landlab.data_record.aggregators import aggregate_items_as_sum
 from landlab.data_record.data_record import DataRecord
@@ -389,6 +390,9 @@ class NetworkSedimentTransporter(Component):
         self.initialize_output_fields()
         self._channel_slope = self._grid.at_link["channel_slope"]
 
+        self._d_mean_active = np.full(self.grid.number_of_links, np.nan)
+        self._rhos_mean_active = np.full(self.grid.number_of_links, np.nan)
+
         # Adjust topographic elevation based on the parcels present.
         # Note that at present FlowDirector is just used for network connectivity.
         # get alluvium depth and calculate topography from br+alluvium, then update slopes.
@@ -406,12 +410,12 @@ class NetworkSedimentTransporter(Component):
         return self._time
 
     @property
-    def d_mean_active(self) -> float:
-        """Mean parcel grain size of active parcels aggregated at link."""
+    def d_mean_active(self) -> NDArray[np.floating]:
+        """Geometric mean parcel grain size of active parcels aggregated at link."""
         return self._d_mean_active
 
     @property
-    def rhos_mean_active(self) -> float:
+    def rhos_mean_active(self) -> NDArray[np.floating]:
         """Mean parcel density of active parcels aggregated at link."""
         return self._rhos_mean_active
 
@@ -463,18 +467,34 @@ class NetworkSedimentTransporter(Component):
 
     def _calculate_mean_D_and_rho(self) -> None:
         """Calculate mean grain size and density on each link"""
-        self._rhos_mean_active = aggregate_items_as_mean(
+        self._rhos_mean_active[:] = aggregate_items_as_mean(
             self._parcels.dataset["element_id"].values[:, -1].astype(int),
-            self._parcels.dataset["density"].values.reshape(-1),
+            self._parcels.dataset["density"].values,
             weights=self._parcels.dataset["volume"].values[:, -1],
             size=self._grid.number_of_links,
         )
-        self._d_mean_active = aggregate_items_as_mean(
-            self._parcels.dataset["element_id"].values[:, -1].astype(int),
-            self._parcels.dataset["D"].values.reshape(-1),
-            weights=self._parcels.dataset["volume"].values[:, -1],
-            size=self._grid.number_of_links,
+
+        ids = self._parcels.dataset.element_id.values[:, -1].astype(int)
+        parcel_diameter = self._parcels.dataset.D.values[:, -1]
+        parcel_volume = self._parcels.dataset.volume.values[:, -1]
+        is_active = self._parcels.dataset.active_layer[:, -1] == 1
+
+        self._d_mean_active.fill(np.nan)
+        aggregate_items_as_gmean(
+            ids,
+            parcel_diameter,
+            weights=parcel_volume,
+            where=is_active,
+            out=self._d_mean_active,
         )
+
+        largest_d = np.nanmax(self._d_mean_active)
+        if largest_d > 2.0:
+            warnings.warn(
+                f"Maximum link D_mean_active exceeds 2 m ({largest_d})",
+                UserWarning,
+                stacklevel=2,
+            )
 
     def _partition_active_and_storage_layers(self) -> None:
         """For each parcel in the network, determines whether it is in the
@@ -665,14 +685,9 @@ class NetworkSedimentTransporter(Component):
 
         # parcel attribute arrays from DataRecord
 
-        Darray = self._parcels.dataset.D[:, self._time_idx]
-        Activearray = self._parcels.dataset.active_layer[:, self._time_idx].values
-        Rhoarray = self._parcels.dataset.density.values
-        Volarray = self._parcels.dataset.volume[:, self._time_idx].values
-        # link that the parcel is currently in
-        Linkarray = self._parcels.dataset.element_id[:, self._time_idx].values
+        parcel_density = self._parcels.dataset.density.values
 
-        R = (Rhoarray - self._fluid_density) / self._fluid_density
+        R = (parcel_density - self._fluid_density) / self._fluid_density
 
         # parcel attribute arrays to populate below
         frac_sand_array = np.zeros(self._num_parcels)
@@ -680,6 +695,7 @@ class NetworkSedimentTransporter(Component):
         Sarray = np.zeros(self._num_parcels)
         Harray = np.zeros(self._num_parcels)
         Larray = np.zeros(self._num_parcels)
+        Warray = np.zeros(self._num_parcels)
 
         D_mean_activearray = np.full(self._num_parcels, np.nan)
         active_layer_thickness_array = np.full(self._num_parcels, np.nan)
@@ -706,48 +722,59 @@ class NetworkSedimentTransporter(Component):
         )
         frac_sand[np.isnan(frac_sand)] = 0.0
 
+        ids = self._parcels.dataset.element_id.values[:, -1].astype(int)
+        parcel_diameter = self._parcels.dataset.D.values[:, -1]
+        parcel_volume = self._parcels.dataset.volume.values[:, -1]
+        is_active = self._parcels.dataset.active_layer[:, -1] == 1
+
+        self._d_mean_active.fill(np.nan)
+        aggregate_items_as_gmean(
+            ids,
+            np.ascontiguousarray(parcel_diameter),
+            weights=np.ascontiguousarray(parcel_volume),
+            where=is_active,
+            out=self._d_mean_active,
+        )
+
         # Calc attributes for each link, map to parcel arrays
         for i in range(self._grid.number_of_links):
-            active_here = np.nonzero(
-                np.logical_and(Linkarray == i, Activearray == _ACTIVE)
-            )[0]
-            d_act_i = Darray[active_here]
-            vol_act_i = Volarray[active_here]
-            rhos_act_i = Rhoarray[active_here]
+            this_link = ids == i
+            active_here = np.flatnonzero(this_link & is_active)
+            vol_act_i = parcel_volume[active_here]
+            rhos_act_i = parcel_density[active_here]
             vol_act_tot_i: float = np.sum(vol_act_i)
 
-            self._d_mean_active[i] = np.sum(d_act_i * vol_act_i) / (vol_act_tot_i)
             if vol_act_tot_i > 0:
                 self._rhos_mean_active[i] = np.sum(rhos_act_i * vol_act_i) / (
                     vol_act_tot_i
                 )
             else:
                 self._rhos_mean_active[i] = np.nan
-            D_mean_activearray[Linkarray == i] = self._d_mean_active[i]
-            frac_sand_array[Linkarray == i] = frac_sand[i]
-            vol_act_array[Linkarray == i] = self._vol_act[i]
-            Sarray[Linkarray == i] = self._grid.at_link["channel_slope"][i]
-            Harray[Linkarray == i] = self._grid.at_link["flow_depth"][i]
-            Larray[Linkarray == i] = self._grid.at_link["reach_length"][i]
-            active_layer_thickness_array[Linkarray == i] = self._active_layer_thickness[
-                i
-            ]
+
+            D_mean_activearray[this_link] = self._d_mean_active[i]
+            frac_sand_array[this_link] = frac_sand[i]
+            vol_act_array[this_link] = self._vol_act[i]
+            Sarray[this_link] = self._grid.at_link["channel_slope"][i]
+            Harray[this_link] = self._grid.at_link["flow_depth"][i]
+            Larray[this_link] = self._grid.at_link["reach_length"][i]
+            Warray[this_link] = self._grid.at_link["channel_width"][i]
+            active_layer_thickness_array[this_link] = self._active_layer_thickness[i]
 
         # Wilcock and Crowe calculate transport for all parcels (active and inactive)
         taursg = _calculate_reference_shear_stress(
             self._fluid_density, R, self._g, D_mean_activearray, frac_sand_array
         )
 
-        frac_parcel = np.nan * np.zeros_like(Volarray)
+        frac_parcel = np.nan * np.zeros_like(parcel_volume)
         frac_parcel[vol_act_array != 0.0] = (
-            Volarray[vol_act_array != 0.0] / vol_act_array[vol_act_array != 0.0]
+            parcel_volume[vol_act_array != 0.0] / vol_act_array[vol_act_array != 0.0]
         )
 
-        b = 0.67 / (1.0 + np.exp(1.5 - Darray / D_mean_activearray))
+        b = 0.67 / (1.0 + np.exp(1.5 - parcel_diameter / D_mean_activearray))
 
         tau = np.atleast_1d(self._fluid_density * self._g * Harray * Sarray)
 
-        taur = taursg * (Darray / D_mean_activearray) ** b
+        taur = taursg * (parcel_diameter / D_mean_activearray) ** b
         tautaur = tau / taur
         self._tautaur = tautaur.copy()  # use below for xport dependent abrasion
         tautaur_cplx = tautaur.astype(np.complex128)
@@ -758,18 +785,27 @@ class NetworkSedimentTransporter(Component):
             (1 - (0.894 / np.sqrt(tautaur_cplx.real[tautaur >= 1.35]))), 4.5
         )
 
-        active_parcel_idx = Activearray == _ACTIVE
+        active_parcel_idx = is_active
 
-        # compute parcel virtual velocity, m/s
-        self._pvelocity[active_parcel_idx] = (
+        # Calculate sediment fluxes
+        qbi = np.zeros(self._num_parcels)
+
+        qbi[active_parcel_idx] = (
             W.real[active_parcel_idx]
-            * (tau[active_parcel_idx] ** (3.0 / 2.0))
             * frac_parcel[active_parcel_idx]
-            / (self._fluid_density ** (3.0 / 2.0))
+            * (tau[active_parcel_idx] / self._fluid_density) ** (3 / 2)
+            / (parcel_density[active_parcel_idx] / self._fluid_density - 1)
             / self._g
-            / R[active_parcel_idx]
-            / active_layer_thickness_array[active_parcel_idx]
-        )
+        )  # (m2/s) WC eqn 2
+
+        self._qbi = qbi
+
+        self._pvelocity[active_parcel_idx] = (
+            Larray[active_parcel_idx]
+            * qbi[active_parcel_idx]
+            * Warray[active_parcel_idx]
+            / parcel_volume[active_parcel_idx]
+        )  # (m/s)# Bug fix 4/2026
 
         self._pvelocity[np.isnan(self._pvelocity)] = 0.0
 

--- a/tests/components/network_sediment_transporter/test_filo.py
+++ b/tests/components/network_sediment_transporter/test_filo.py
@@ -97,6 +97,13 @@ def test_first_in_last_out():
         last_in_parcel, :
     ]
 
+    # The "OUT_OF_NETWORK" link = -2, so we'll edit those link indices
+    # for the following calculation, recognizing them as downstream
+
+    link_of_last_in_parcel[link_of_last_in_parcel == nst.OUT_OF_NETWORK] = (
+        np.max(nmg_constant_slope.number_of_links) + 2
+    )
+
     First_in_lags_behind = np.greater_equal(
         link_of_last_in_parcel, link_of_first_in_parcel
     )

--- a/tests/components/network_sediment_transporter/test_parcel_leaves.py
+++ b/tests/components/network_sediment_transporter/test_parcel_leaves.py
@@ -36,7 +36,7 @@ def test_parcel_leaves(example_nmg, example_flow_director):
 
     timesteps = 10
 
-    example_nmg.at_link["flow_depth"] = example_nmg.at_link["flow_depth"] * 20
+    example_nmg.at_link["flow_depth"] = example_nmg.at_link["flow_depth"] * 30
 
     nst = NetworkSedimentTransporter(
         example_nmg,

--- a/tests/components/network_sediment_transporter/test_transport.py
+++ b/tests/components/network_sediment_transporter/test_transport.py
@@ -1,10 +1,12 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 
 from landlab.components import FlowDirectorSteepest
 from landlab.components import NetworkSedimentTransporter
 from landlab.data_record import DataRecord
+from landlab.data_record.aggregators import aggregate_items_as_sum
 from landlab.grid.network import NetworkModelGrid
 
 
@@ -48,6 +50,23 @@ def test_no_flow_no_transport(example_nmg, example_parcels, example_flow_directo
     )
 
 
+def test_warn_parcels_so_big(example_nmg, example_parcels, example_flow_director):
+    example_nmg.at_link["flow_depth"] = np.ones(example_nmg.size("link"))
+
+    # Turn gravel to boulders...
+    example_parcels.dataset["D"].values = example_parcels.dataset["D"].values + 2
+
+    with pytest.warns(UserWarning, match="^Maximum link D_mean_active exceeds 2"):
+        NetworkSedimentTransporter(
+            example_nmg,
+            example_parcels,
+            example_flow_director,
+            bed_porosity=0.03,
+            g=9.81,
+            fluid_density=1000,
+        )
+
+
 def test_defined_parcel_transport():
     y_of_node = (0, 0, 0, 0)
     x_of_node = (0, 100, 200, 300)
@@ -55,38 +74,45 @@ def test_defined_parcel_transport():
 
     nmg_constant_slope = NetworkModelGrid((y_of_node, x_of_node), nodes_at_link)
 
+    reach_length = 100.0
+
     # add variables to nmg
     nmg_constant_slope.at_node["topographic__elevation"] = [3.0, 2.0, 1.0, 0.0]
     nmg_constant_slope.at_node["bedrock__elevation"] = [3.0, 2.0, 1.0, 0.0]
-    nmg_constant_slope.at_link["channel_slope"] = [0.001, 0.001, 0.001]
-    nmg_constant_slope.at_link["reach_length"] = [100.0, 100.0, 100.0]  # m
+    nmg_constant_slope.at_link["channel_slope"] = [0.01, 0.01, 0.01]
+    nmg_constant_slope.at_link["reach_length"] = reach_length * np.ones(
+        nmg_constant_slope.size("link")
+    )  # m
     nmg_constant_slope.at_link["channel_width"] = 15 * np.ones(
         nmg_constant_slope.size("link")
     )
-    nmg_constant_slope.at_link["flow_depth"] = 2 * np.ones(
+    nmg_constant_slope.at_link["flow_depth"] = 0.5 * np.ones(
         nmg_constant_slope.size("link")
     )
 
     flow_director = FlowDirectorSteepest(nmg_constant_slope)
     flow_director.run_one_step()
 
-    timesteps = 11
+    timesteps = 3
 
     time = [0.0]
 
-    items = {"grid_element": "link", "element_id": np.array([[0]])}
-
     initial_volume = np.array([[1]])
     abrasion_rate = np.array([0])
+    D = 0.05
+    rhos = 2650
+    parcel_grid_element = 1  # place parcel on link 1
+
+    items = {"grid_element": "link", "element_id": np.array([[parcel_grid_element]])}
 
     variables = {
         "starting_link": (["item_id"], np.array([0])),
         "abrasion_rate": (["item_id"], abrasion_rate),
-        "density": (["item_id"], np.array([2650])),
+        "density": (["item_id"], np.array([rhos])),
         "time_arrival_in_link": (["item_id", "time"], np.array([[0.71518937]])),
         "active_layer": (["item_id", "time"], np.array([[1]])),
         "location_in_link": (["item_id", "time"], np.array([[0]])),
-        "D": (["item_id", "time"], np.array([[0.05]])),
+        "D": (["item_id", "time"], np.array([[D]])),
         "volume": (["item_id", "time"], initial_volume),
     }
 
@@ -117,22 +143,60 @@ def test_defined_parcel_transport():
         nst.run_one_step(dt)
         assert len(nst._distance_traveled_cumulative) == 1
         distance_traveled[int(t / dt)] = nst._distance_traveled_cumulative[0]
-    # NEED TO CALCULATE THINGS HERE.
-    # Transport distance should match?
-    Distance_Traveled_Should_Be = [
-        21.61998527,
-        43.23997054,
-        64.85995581,
-        86.47994109,
-        108.09992636,
-        129.71991163,
-        151.3398969,
-        172.95988217,
-        194.57986744,
-        216.19985272,
-        237.81983799,
-    ]
 
-    assert_array_almost_equal(
-        Distance_Traveled_Should_Be, distance_traveled, decimal=-1
+    # Baseline: "by hand" calculation of W&C transport for link 1 (where parcel resides)
+    S = np.abs(
+        (
+            nmg_constant_slope.at_node["bedrock__elevation"][2]
+            - nmg_constant_slope.at_node["bedrock__elevation"][1]
+        )
+        / (x_of_node[2] - x_of_node[1])
     )
+    h = nmg_constant_slope.at_link["flow_depth"][parcel_grid_element]
+    w = nmg_constant_slope.at_link["channel_width"][parcel_grid_element]
+    g = 9.81
+    rho = 1000
+
+    tau = rho * g * h * S
+    # tau_star_rm = rho/
+
+    tau_star_rm = 0.036  # no sand reference Shields
+
+    tau_rm = tau_star_rm * (rhos - rho) * g * D  # reference *shear*
+
+    tau_ri = tau_rm  # uniform D hiding function goes to 1
+
+    phi = tau / tau_ri  #
+
+    # phi > 1.35
+    Wstar = 14 * (1 - 0.894 / np.sqrt(phi)) ** 4.5
+
+    ustar = np.sqrt(tau / rho)
+
+    # qb calc per unit width, should match nst._qb
+    qb_calc = (Wstar * (ustar**3)) / (
+        (rhos / rho - 1) * g
+    )  # single parcel, so qb = qbi
+
+    # TEST A:
+    nst_qb = aggregate_items_as_sum(
+        nst._parcels.dataset["element_id"].values[:, -1].astype(int),
+        nst._qbi,
+        size=nst._grid.number_of_links,
+    )  # total sediment flux per unit width, m2/s
+
+    # TEST B: transport via sum of parcel motion
+    # nst._qb should match sum(parcel velocities * parcel volumes) / link length
+
+    Qb_parcelmotion = (
+        np.sum(nst._pvelocity * initial_volume)
+        / nmg_constant_slope.at_link["reach_length"][parcel_grid_element]
+    )
+
+    qb_parcelmotion = Qb_parcelmotion / w
+
+    # ASSERT these three are equal
+
+    assert_array_almost_equal(nst_qb[parcel_grid_element], qb_calc, decimal=7)
+
+    assert_array_almost_equal(nst_qb[parcel_grid_element], qb_parcelmotion, decimal=7)


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

This PR fixes two errors in the NetworkSedimentTransporter that impact parcel (sediment) transport rates: 

1) Parcel velocity calculations followed Czuba (2018), which has an error in the calculation of parcel velocity (see Eqn 11 therein). This made parcel transport dependent on each parcel's fraction of the total active sediment volume on a link, such that more parcels (but the same total volume of active sediment) led to less transport. The correction has been checked and tests have been updated that will catch discrepancies between calculated sediment fluxes and sediment fluxes accomplished by sediment transport. 

2) Wilcock and Crowe (2003) reference "mean" grain sizes in their sediment transport formulae, but a circulated correction to the paper clarifies that these are geometric, rather than arithmetic, means. This NST update implements this change in the parcel transport calculations, where `nst._d_mean_active` will now provide the user with the _geometric_ mean grain size.


---

## Related Issues


Closes #2408

