### PR TITLE
Refactor data record merge

### DIFF
--- a/news/2410.feature
+++ b/news/2410.feature
@@ -1,0 +1,4 @@
+Refactored `DataRecord.add_record` and `DataRecord.add_item` to avoid
+`xarray.merge` when adding records or items. Missing item locations now use
+different fill values for `element_id` and `grid_element`, preserving data
+types.

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -557,6 +557,15 @@ class DataRecord:
                 " instead."
             )
 
+        new_record = norm_data_vars({} if new_record is None else dict(new_record))
+
+        self._fill_value |= prepare_fill_specs(
+            fill_value,
+            var_spec=new_record,
+            forbidden=self._dataset,
+            policy=self._fill_policy,
+        )
+
         coords_to_add = {}
         new_data_vars = {}
 
@@ -606,15 +615,6 @@ class DataRecord:
 
         ds_to_add = xr.Dataset(data_vars=new_data_vars, coords=coords_to_add)
 
-        self._fill_value = merge_fill_values(
-            self._fill_value,
-            new=(
-                infer_fill_values({name: ds_to_add[name] for name in new_record})
-                if fill_value is None
-                else fill_value
-            ),
-            allowed=set(new_record),
-        )
 
         # If new times are being added, extend the dataset first.
         if time is not None:
@@ -735,12 +735,16 @@ class DataRecord:
         >>> dr.dataset["size"][:, 1].values
         array([nan, nan, 10.,  5.])
         """
-        new_item_spec = {} if new_item_spec is None else dict(new_item_spec)
+        new_item_spec = norm_data_vars(
+            {} if new_item_spec is None else dict(new_item_spec)
+        )
 
-        if self._fill_policy == "legacy":
-            if fill_value != "legacy":
-                raise ValueError()
-            fill_value = {name: MISSING_NAN for name in set(new_item_spec)}
+        self._fill_value |= prepare_fill_specs(
+            fill_value,
+            var_spec=new_item_spec,
+            forbidden=self._dataset,
+            policy=self._fill_policy,
+        )
 
         has_time = "time" in self._dataset
 
@@ -788,15 +792,6 @@ class DataRecord:
         # Dataset of new record:
         ds_to_add = xr.Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
-        self._fill_value = merge_fill_values(
-            self._fill_value,
-            new=(
-                infer_fill_values({name: ds_to_add[name] for name in new_item_spec})
-                if fill_value is None
-                else fill_value
-            ),
-            allowed=set(new_item_spec),
-        )
 
         self._dataset = xr.concat(
             [self._dataset, ds_to_add],
@@ -1394,7 +1389,7 @@ def prepare_fill_specs(
     policy: FillPolicy = FillPolicy.LEGACY,
 ):
     forbidden = set() if forbidden is None else set(forbidden)
-    var_spec = dict() if var_spec is None else var_spec
+    var_spec = {} if var_spec is None else var_spec
     allowed = set(var_spec) - forbidden
 
     if policy is FillPolicy.LEGACY:

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -405,7 +405,7 @@ class DataRecord:
         else:
             fill_value |= {"element_id": MISSING_ID, "grid_element": MISSING_ELEMENT}
 
-        self._fill_value = norm_fill_values(
+        self._fill_value = norm_fill_specs(
             infer_fill_values(values=self._dataset) | fill_value
         )
 
@@ -1364,7 +1364,7 @@ class DataRecord:
             return sorted(self.time_coordinates)[-2]
 
 
-def norm_fill_values(
+def norm_fill_specs(
     fill_value: Mapping[str, MissingValue | ArrayLike],
 ) -> dict[str, MissingValue]:
     return {

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1422,6 +1422,10 @@ def prepare_fill_specs(
     )
 
 
+def resolve_fill_values(specs: Mapping[str, MissingValue]):
+    return {name: spec.fill_value for name, spec in specs.items()}
+
+
 def filled_array(
     values: xr.DataArray,
     dataset: xr.Dataset,

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1421,6 +1421,33 @@ def resolve_fill_values(specs: Mapping[str, MissingValue]):
     return {name: spec.fill_value for name, spec in specs.items()}
 
 
+def find_new_coords(
+    new: xr.Dataset,
+    existing: xr.Dataset,
+) -> dict[str, NDArray]:
+    new_coords = {}
+
+    if "item_id" in new.coords:
+        if "item_id" in existing.coords:
+            values = find_new_items(new["item_id"], existing["item_id"])
+        else:
+            values = np.asarray(new["item_id"])
+
+        if values.size:
+            new_coords["item_id"] = values
+
+    if "time" in new.coords:
+        if "time" in existing.coords:
+            values = find_new_times(new["time"], existing["time"])
+        else:
+            values = np.asarray(new["time"])
+
+        if values.size:
+            new_coords["time"] = values
+
+    return new_coords
+
+
 def filled_array(
     values: xr.DataArray,
     dataset: xr.Dataset,

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1381,33 +1381,40 @@ def infer_fill_values(
     return {name: spec_from_value(array) for name, array in values.items()}
 
 
-def merge_fill_values(
-    existing: Mapping[str, MissingValue | ArrayLike],
+def prepare_fill_specs(
+    fill_value: Mapping[str, MissingValue | ArrayLike] | None,
     *,
-    new: Mapping[str, MissingValue | ArrayLike] | None = None,
-    allowed: Collection[str] | None = None,
+    var_spec: Mapping[str, xr.DataArray] | None = None,
+    forbidden: Collection[str] | None = None,
+    policy: FillPolicy = FillPolicy.LEGACY,
 ):
-    new = {} if new is None else new
-    allowed = set() if allowed is None else set(allowed)
+    forbidden = set() if forbidden is None else set(forbidden)
+    var_spec = dict() if var_spec is None else var_spec
+    allowed = set(var_spec) - forbidden
 
-    old_names = set(existing)
-    new_names = set(new)
+    if policy is FillPolicy.LEGACY:
+        if fill_value is not None:
+            raise ValueError("fill_value is not supported with legacy fill policy")
+        return {name: MISSING_NAN for name in allowed}
 
-    disallowed = new_names - allowed
-    if disallowed:
-        names = ", ".join(sorted(disallowed))
+    fill_value = {} if fill_value is None else dict(fill_value)
+
+    if set(fill_value) & forbidden:
+        names = [repr(name) for name in sorted(set(fill_value) & forbidden)]
         raise ValueError(
-            f"fill_value must correspond to variables in new_record: {names}"
+            f"fill_value provided for existing variables: {', '.join(names)}"
         )
 
-    conflicts = new_names & old_names
-    if conflicts:
-        names = ", ".join(sorted(conflicts))
+    if set(fill_value) - set(var_spec):
+        names = [repr(name) for name in sorted(set(fill_value) - set(var_spec))]
         raise ValueError(
-            f"fill_value cannot be provided for existing variables: {names}"
+            f"fill_value provided for unknown variables: {', '.join(names)}"
         )
 
-    return norm_fill_values(dict(existing) | new)
+    vars_to_infer = allowed - set(fill_value)
+    return norm_fill_specs(
+        infer_fill_values({name: var_spec[name] for name in vars_to_infer}) | fill_value
+    )
 
 
 def filled_array(

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
+import warnings
+from collections.abc import Callable
+from collections.abc import Collection
 from collections.abc import Iterable
 from collections.abc import Mapping
+from dataclasses import dataclass
+from numbers import Number
 from typing import Any
 
 import numpy as np
@@ -14,6 +19,42 @@ from requireit import require_dtype
 from requireit import require_one_of
 from requireit import require_shape
 from requireit import require_sorted
+
+
+@dataclass(frozen=True)
+class MissingValue:
+    fill_value: Any
+    is_missing: Callable[[NDArray[Any]], NDArray[np.bool_]] | None = None
+
+    def __post_init__(self):
+        fill_value = self.fill_value
+
+        def equals_fill(values):
+            return np.asarray(values) == fill_value
+
+        if self.is_missing is None:
+            if isinstance(fill_value, float) and np.isnan(fill_value):
+                func = np.isnan
+            else:
+                func = equals_fill
+
+            object.__setattr__(self, "is_missing", func)
+
+
+MISSING_NAN = MissingValue(fill_value=np.nan)
+MISSING_ID = MissingValue(fill_value=-1)
+MISSING_ELEMENT = MissingValue(fill_value="nan")
+
+
+def spec_from_value(value: ArrayLike) -> MissingValue:
+    dtype = np.asarray(value).dtype
+    if np.issubdtype(dtype, np.integer):
+        return MISSING_ID
+    elif np.issubdtype(dtype, np.bool_):
+        return MissingValue(False)
+    elif np.issubdtype(dtype, np.str_):
+        return MISSING_ELEMENT
+    return MISSING_NAN
 
 
 class DataRecord:
@@ -82,6 +123,7 @@ class DataRecord:
         items=None,
         data_vars=None,
         attrs=None,
+        fill_value: str | Mapping[str, MissingValue | ArrayLike] | None = "legacy",
     ):
         """
         Parameters
@@ -145,6 +187,13 @@ class DataRecord:
         attrs : dict (optional)
             Dictionary of global attributes on the DataRecord (metadata).
             Example: {'time_units' : 'y'}
+        fill_value : {"legacy"} or mapping or None, optional
+            Control how missing values are represented when the dataset is expanded.
+            Unspecified variables use inferred behavior unless ``"legacy"`` is used.
+
+            * ``"legacy"`` (default): use ``np.nan`` for missing values.
+            * ``None``: infer dtype-preserving missing values from the data.
+            * mapping: specify per-variable missing values or ``MissingValue`` specs.
 
         Examples
         --------
@@ -226,6 +275,15 @@ class DataRecord:
         1       0.0          link           3
 
         """
+        fill_value = {} if fill_value is None else fill_value
+        if fill_value == "legacy":
+            warnings.warn(
+                "The default fill_value='legacy' will change in a future release. "
+                "Use fill_value=None to adopt the new dtype-preserving behavior.",
+                FutureWarning,
+                stacklevel=2,
+            )
+
         with_time = False
         if time is not None:
             with_time = True
@@ -324,6 +382,25 @@ class DataRecord:
         # create an xarray Dataset:
         self._dataset = xr.Dataset(data_vars=data_vars_dict, coords=coords, attrs=attrs)
 
+        self._fill_policy = "legacy" if fill_value == "legacy" else None
+        fill_value = {} if fill_value is None else fill_value
+
+        if fill_value == "legacy":
+            premitted = np.fromiter(self._permitted_locations, dtype=object)
+            MISSING_ELEMENT_LEGACY = MissingValue(
+                fill_value=np.nan, is_missing=lambda v: ~np.isin(v, premitted)
+            )
+            fill_value = {name: MISSING_NAN for name in self._dataset} | {
+                "element_id": MISSING_NAN,
+                "grid_element": MISSING_ELEMENT_LEGACY,
+            }
+        else:
+            fill_value |= {"element_id": MISSING_ID, "grid_element": MISSING_ELEMENT}
+
+        self._fill_value = norm_fill_values(
+            infer_fill_values(values=self._dataset) | fill_value
+        )
+
     def _norm_time(self, time: ArrayLike) -> NDArray[np.floating]:
         time = np.atleast_1d(time)
         with raise_as(TypeError):
@@ -385,6 +462,7 @@ class DataRecord:
         item_id: ArrayLike | None = None,
         new_item_loc: dict[str, Any] | None = None,
         new_record: dict[str, Any] | None = None,
+        fill_value: Mapping[str, MissingValue | ArrayLike] | None = None,
     ) -> None:
         """Add data to the DataRecord.
 
@@ -428,7 +506,7 @@ class DataRecord:
         Note that both arrays have 2 dimensions as they vary along dimensions
         'time' and 'item_id'.
 
-        >>> dr = DataRecord(grid, time=0.0, items=items)
+        >>> dr = DataRecord(grid, time=0.0, items=items, fill_value=None)
 
         Records relating to pre-existing items can be added to the DataRecord
         using the method 'add_record':
@@ -459,6 +537,11 @@ class DataRecord:
         2.0         NaN
         50.0      110.0
         """
+        if self._fill_policy == "legacy":
+            if fill_value is not None:
+                raise ValueError()
+            fill_value = {name: MISSING_NAN for name in set(new_record)}
+
         if time is not None and "time" not in self._dataset:
             raise KeyError("this DataRecord is time-independent; time must be None.")
         if item_id is not None and "item_id" not in self._dataset:
@@ -520,6 +603,16 @@ class DataRecord:
 
         ds_to_add = xr.Dataset(data_vars=new_data_vars, coords=coords_to_add)
 
+        self._fill_value = merge_fill_values(
+            self._fill_value,
+            new=(
+                infer_fill_values({name: ds_to_add[name] for name in new_record})
+                if fill_value is None
+                else fill_value
+            ),
+            allowed=set(new_record),
+        )
+
         # If new times are being added, extend the dataset first.
         if time is not None:
             time = self._norm_time(time)
@@ -529,7 +622,10 @@ class DataRecord:
             if len(new_times) > 0:
                 all_times = np.concatenate([existing, new_times])
                 self._dataset = self._dataset.reindex(
-                    time=all_times, fill_value={"grid_element": "nan", "element_id": -1}
+                    time=all_times,
+                    fill_value={
+                        name: spec.fill_value for name, spec in self._fill_value.items()
+                    },
                 )
 
         # Overwrite / insert values at the requested coordinates.
@@ -539,17 +635,22 @@ class DataRecord:
         if time is not None:
             indexers["time"] = time
 
+        missing_vars = set(ds_to_add) - set(self._dataset)
+        for name in missing_vars:
+            fill = self._fill_value[name].fill_value
+            self._dataset[name] = filled_array(
+                ds_to_add[name], self._dataset, fill_value=fill
+            )
+
         for name, value in ds_to_add.data_vars.items():
-            if name in self._dataset:
-                self._dataset[name].loc[indexers] = value
-            else:
-                self._dataset[name] = value
+            self._dataset[name].loc[indexers] = value
 
     def add_item(
         self,
         time: ArrayLike | None = None,
         new_item: dict[str, Any] | None = None,
         new_item_spec: dict[str, Any] | None = None,
+        fill_value: str | Mapping[str, MissingValue | ArrayLike] | None = "legacy",
     ) -> None:
         """Add new items to a DataRecord.
 
@@ -631,6 +732,13 @@ class DataRecord:
         >>> dr.dataset["size"][:, 1].values
         array([nan, nan, 10.,  5.])
         """
+        new_item_spec = {} if new_item_spec is None else dict(new_item_spec)
+
+        if self._fill_policy == "legacy":
+            if fill_value != "legacy":
+                raise ValueError()
+            fill_value = {name: MISSING_NAN for name in set(new_item_spec)}
+
         has_time = "time" in self._dataset
 
         if time is None and has_time:
@@ -641,8 +749,6 @@ class DataRecord:
             raise TypeError("new_item must be a mapping")
 
         time = self._norm_time(time) if has_time else None
-
-        new_item_spec = {} if new_item_spec is None else dict(new_item_spec)
 
         with raise_as(KeyError):
             require_contains(
@@ -679,6 +785,16 @@ class DataRecord:
         # Dataset of new record:
         ds_to_add = xr.Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
+        self._fill_value = merge_fill_values(
+            self._fill_value,
+            new=(
+                infer_fill_values({name: ds_to_add[name] for name in new_item_spec})
+                if fill_value is None
+                else fill_value
+            ),
+            allowed=set(new_item_spec),
+        )
+
         self._dataset = xr.concat(
             [self._dataset, ds_to_add],
             dim="item_id",
@@ -686,7 +802,9 @@ class DataRecord:
             coords="minimal",
             compat="override",
             join="outer",
-            fill_value={"grid_element": "nan", "element_id": -1},
+            fill_value={
+                name: spec.fill_value for name, spec in self._fill_value.items()
+            },
         )
 
     def get_data(self, time=None, item_id=None, data_variable=None):
@@ -1059,7 +1177,7 @@ class DataRecord:
         Note that both arrays have 2 dimensions as they vary along dimensions
         'time' and 'item_id'.
 
-        >>> dr3 = DataRecord(grid, time=[0.0], items=my_items3)
+        >>> dr3 = DataRecord(grid, time=[0.0], items=my_items3, fill_value=None)
 
         Records relating to pre-existing items can be added to the DataRecord
         using the method 'add_record':
@@ -1099,7 +1217,7 @@ class DataRecord:
         ...     "grid_element": np.array([["node"], ["link"]]),
         ...     "element_id": np.array([[1], [3]]),
         ... }
-        >>> dr3 = DataRecord(grid, time=[0.0], items=my_items3)
+        >>> dr3 = DataRecord(grid, time=[0.0], items=my_items3, fill_value=None)
         >>> dr3.dataset["element_id"].values
         array([[1], [3]])
         >>> dr3.dataset["grid_element"].values
@@ -1182,12 +1300,12 @@ class DataRecord:
 
         n_rows, n_cols = ids.shape
         for col in range(1, n_cols):
-            bad_vals = ids[:, col] == -1
+            bad_vals = self._fill_value["element_id"].is_missing(ids[:, col])
             ids[bad_vals, col] = ids[bad_vals, col - 1]
 
         elements = self._dataset["grid_element"].values
         for col in range(1, n_cols):
-            bad_vals = elements[:, col] == "nan"
+            bad_vals = self._fill_value["grid_element"].is_missing(elements[:, col])
             elements[bad_vals, col] = elements[bad_vals, col - 1]
 
     @property
@@ -1241,6 +1359,65 @@ class DataRecord:
             return np.nan
         else:
             return sorted(self.time_coordinates)[-2]
+
+
+def norm_fill_values(
+    fill_value: Mapping[str, MissingValue | ArrayLike],
+) -> dict[str, MissingValue]:
+    return {
+        name: (
+            value if isinstance(value, MissingValue) else MissingValue(fill_value=value)
+        )
+        for name, value in fill_value.items()
+    }
+
+
+def infer_fill_values(
+    values: Mapping[str, ArrayLike],
+) -> dict[str, MissingValue]:
+    return {name: spec_from_value(array) for name, array in values.items()}
+
+
+def merge_fill_values(
+    existing: Mapping[str, MissingValue | ArrayLike],
+    *,
+    new: Mapping[str, MissingValue | ArrayLike] | None = None,
+    allowed: Collection[str] | None = None,
+):
+    new = {} if new is None else new
+    allowed = set() if allowed is None else set(allowed)
+
+    old_names = set(existing)
+    new_names = set(new)
+
+    disallowed = new_names - allowed
+    if disallowed:
+        names = ", ".join(sorted(disallowed))
+        raise ValueError(
+            f"fill_value must correspond to variables in new_record: {names}"
+        )
+
+    conflicts = new_names & old_names
+    if conflicts:
+        names = ", ".join(sorted(conflicts))
+        raise ValueError(
+            f"fill_value cannot be provided for existing variables: {names}"
+        )
+
+    return norm_fill_values(dict(existing) | new)
+
+
+def filled_array(
+    values: xr.DataArray,
+    dataset: xr.Dataset,
+    fill_value: str | Number,
+) -> xr.DataArray:
+    dims = values.dims
+    shape = tuple(dataset.sizes[dim] for dim in dims)
+    coords = {dim: dataset.coords[dim] for dim in dims}
+    data = np.full(shape, fill_value, dtype=values.dtype)
+
+    return xr.DataArray(data, dims=dims, coords=coords)
 
 
 def norm_element_id(ids: ArrayLike) -> NDArray[np.intp]:

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1588,6 +1588,42 @@ def norm_grid_element(
     return elements
 
 
+def find_new_items(
+    needles: ArrayLike,
+    haystack: ArrayLike,
+) -> NDArray[np.integer]:
+    needles = np.asarray(needles)
+    require_shape(needles, shape=("n",), name="needles")
+    require_dtype(needles, dtype=np.integer, name="needles")
+
+    haystack = np.asarray(haystack)
+    require_shape(haystack, shape=("n",), name="haystack")
+    require_dtype(haystack, dtype=np.integer, name="haystack")
+
+    found = np.isin(needles, haystack)
+    return needles[~found]
+
+
+def find_new_times(
+    needles: ArrayLike,
+    haystack: ArrayLike,
+) -> NDArray[np.integer | np.floating]:
+    needles = np.asarray(needles)
+    require_shape(needles, shape=("n",), name="needles")
+
+    haystack = np.asarray(haystack)
+    require_shape(haystack, shape=("n",), name="haystack")
+
+    new = []
+    for needle in needles:
+        try:
+            _find_time(needle, haystack)
+        except IndexError:
+            new.append(needle)
+
+    return np.asarray(new, dtype=needles.dtype)
+
+
 def _find_time(time: float | int, times: ArrayLike) -> int:
     """Find the index of a time value in an array of times.
 

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -615,28 +615,14 @@ class DataRecord:
 
         ds_to_add = xr.Dataset(data_vars=new_data_vars, coords=coords_to_add)
 
+        coords_to_extend = find_new_coords(ds_to_add, self._dataset)
 
-        # If new times are being added, extend the dataset first.
-        if time is not None:
-            time = self._norm_time(time)
-            # all_times = np.unique(all_times)
-            existing = np.asarray(self._dataset["time"].values, dtype=float)
-            new_times = time[~np.isin(time, existing)]
-            if len(new_times) > 0:
-                all_times = np.concatenate([existing, new_times])
-                self._dataset = self._dataset.reindex(
-                    time=all_times,
-                    fill_value={
-                        name: spec.fill_value for name, spec in self._fill_value.items()
-                    },
-                )
-
-        # Overwrite / insert values at the requested coordinates.
-        indexers = {}
-        if item_id is not None:
-            indexers["item_id"] = item_id
-        if time is not None:
-            indexers["time"] = time
+        self._dataset = extend_dimensions(
+            self._dataset,
+            coords_to_extend,
+            fill_value=resolve_fill_values(self._fill_value),
+            policy=self._fill_policy,
+        )
 
         missing_vars = set(ds_to_add) - set(self._dataset)
         for name in missing_vars:
@@ -645,8 +631,9 @@ class DataRecord:
                 ds_to_add[name], self._dataset, fill_value=fill
             )
 
-        for name, value in ds_to_add.data_vars.items():
-            self._dataset[name].loc[indexers] = value
+        for name, da in ds_to_add.data_vars.items():
+            coords = _coords_for(self._dataset, da)
+            self._dataset[name].loc[coords] = da
 
     def add_item(
         self,
@@ -792,18 +779,23 @@ class DataRecord:
         # Dataset of new record:
         ds_to_add = xr.Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
+        coords_to_extend = find_new_coords(ds_to_add, self._dataset)
 
-        self._dataset = xr.concat(
-            [self._dataset, ds_to_add],
-            dim="item_id",
-            data_vars="all",
-            coords="minimal",
-            compat="override",
-            join="outer",
-            fill_value={
-                name: spec.fill_value for name, spec in self._fill_value.items()
-            },
+        self._dataset = extend_dimensions(
+            self._dataset,
+            coords_to_extend,
+            fill_value=resolve_fill_values(self._fill_value),
+            policy=self._fill_policy,
         )
+
+        for name, da in ds_to_add.data_vars.items():
+            if name not in self._dataset:
+                fill = self._fill_value[name].fill_value
+                self._dataset[name] = filled_array(da, self._dataset, fill_value=fill)
+
+        for name, da in ds_to_add.data_vars.items():
+            coords = _coords_for(self._dataset, da)
+            self._dataset[name].loc[coords] = da
 
     def get_data(self, time=None, item_id=None, data_variable=None):
         """Return values of a variable at a given time and/or for selected items.

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1364,6 +1364,11 @@ class DataRecord:
             return sorted(self.time_coordinates)[-2]
 
 
+def norm_data_vars(data_vars: Mapping[str, Any]) -> dict[str, xr.DataArray]:
+    ds = xr.Dataset(data_vars=data_vars)
+    return dict(ds.data_vars)
+
+
 def norm_fill_specs(
     fill_value: Mapping[str, MissingValue | ArrayLike],
 ) -> dict[str, MissingValue]:

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -5,6 +5,7 @@ from collections.abc import Collection
 from collections.abc import Iterable
 from collections.abc import Mapping
 from dataclasses import dataclass
+from enum import StrEnum
 from numbers import Number
 from typing import Any
 
@@ -55,6 +56,11 @@ def spec_from_value(value: ArrayLike) -> MissingValue:
     elif np.issubdtype(dtype, np.str_):
         return MISSING_ELEMENT
     return MISSING_NAN
+
+
+class FillPolicy(StrEnum):
+    DEFAULT = "default"
+    LEGACY = "legacy"
 
 
 class DataRecord:
@@ -276,13 +282,16 @@ class DataRecord:
 
         """
         fill_value = {} if fill_value is None else fill_value
-        if fill_value == "legacy":
+        if isinstance(fill_value, str) and fill_value == FillPolicy.LEGACY:
+            self._fill_policy = FillPolicy.LEGACY
             warnings.warn(
                 "The default fill_value='legacy' will change in a future release. "
                 "Use fill_value=None to adopt the new dtype-preserving behavior.",
                 FutureWarning,
                 stacklevel=2,
             )
+        else:
+            self._fill_policy = FillPolicy.DEFAULT
 
         with_time = False
         if time is not None:
@@ -382,10 +391,9 @@ class DataRecord:
         # create an xarray Dataset:
         self._dataset = xr.Dataset(data_vars=data_vars_dict, coords=coords, attrs=attrs)
 
-        self._fill_policy = "legacy" if fill_value == "legacy" else None
         fill_value = {} if fill_value is None else fill_value
 
-        if fill_value == "legacy":
+        if self._fill_policy is FillPolicy.LEGACY:
             premitted = np.fromiter(self._permitted_locations, dtype=object)
             MISSING_ELEMENT_LEGACY = MissingValue(
                 fill_value=np.nan, is_missing=lambda v: ~np.isin(v, premitted)
@@ -537,11 +545,6 @@ class DataRecord:
         2.0         NaN
         50.0      110.0
         """
-        if self._fill_policy == "legacy":
-            if fill_value is not None:
-                raise ValueError()
-            fill_value = {name: MISSING_NAN for name in set(new_record)}
-
         if time is not None and "time" not in self._dataset:
             raise KeyError("this DataRecord is time-independent; time must be None.")
         if item_id is not None and "item_id" not in self._dataset:
@@ -1459,6 +1462,7 @@ def norm_grid_element(
     elements: ArrayLike,
     *,
     allowed: Iterable[str] = (),
+    policy: FillPolicy = FillPolicy.LEGACY,
 ) -> NDArray[np.str_]:
     """Normalize grid element names to a NumPy string array.
 
@@ -1493,7 +1497,11 @@ def norm_grid_element(
     """
     allowed = set(allowed)
 
-    ge_dtype = f"<U{max(len(x) for x in allowed)}" if allowed else str
+    if policy is FillPolicy.LEGACY:
+        ge_dtype = object
+    else:
+        ge_dtype = f"<U{max(len(x) for x in allowed)}" if allowed else str
+
     elements = np.asarray(
         [elements] if isinstance(elements, str) else elements,
         dtype=ge_dtype,

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1485,6 +1485,24 @@ def extend_dimensions(
     return extended
 
 
+def _coords_for(
+    dataset: xr.Dataset,
+    da: xr.DataArray,
+) -> dict[str, xr.DataArray]:
+    coords = {}
+
+    for dim in da.dims:
+        if dim == "time":
+            indices = np.array(
+                [_find_time(t, dataset["time"].values) for t in da[dim].values]
+            )
+            coords[dim] = dataset[dim].isel({dim: indices})
+        else:
+            coords[dim] = da[dim]
+
+    return coords
+
+
 def filled_array(
     values: xr.DataArray,
     dataset: xr.Dataset,

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -653,7 +653,7 @@ class DataRecord:
         time: ArrayLike | None = None,
         new_item: dict[str, Any] | None = None,
         new_item_spec: dict[str, Any] | None = None,
-        fill_value: str | Mapping[str, MissingValue | ArrayLike] | None = "legacy",
+        fill_value: Mapping[str, MissingValue | ArrayLike] | None = None,
     ) -> None:
         """Add new items to a DataRecord.
 

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -1448,6 +1448,43 @@ def find_new_coords(
     return new_coords
 
 
+def extend_dimensions(
+    dataset: xr.Dataset,
+    coords_to_add: Mapping[str, xr.DataArray],
+    *,
+    fill_value: dict[str, str | Number] | None = None,
+    policy: FillPolicy = FillPolicy.LEGACY,
+) -> xr.Dataset:
+    if not coords_to_add:
+        return dataset
+
+    object_vars = (
+        {name for name, var in dataset.items() if var.dtype.kind in "OUS"}
+        if policy is FillPolicy.LEGACY
+        else {}
+    )
+
+    new_coords = {}
+    for dim, values in coords_to_add.items():
+        values = np.asarray(values)
+
+        if dim in dataset.coords:
+            new_coords[dim] = np.concatenate([dataset[dim].values, values])
+        else:
+            new_coords[dim] = values
+
+    extended = dataset.reindex(new_coords, fill_value=fill_value)
+
+    for name in object_vars:
+        extended[name] = extended[name].astype(object).copy()
+
+    for name, var in extended.items():
+        if not var.values.flags.writeable:
+            extended[name] = var.copy(deep=True)
+
+    return extended
+
+
 def filled_array(
     values: xr.DataArray,
     dataset: xr.Dataset,

--- a/src/landlab/data_record/data_record.py
+++ b/src/landlab/data_record/data_record.py
@@ -443,8 +443,8 @@ class DataRecord:
         ...     new_record={"item_size": (["item_id", "time"], [[0.2]])},
         ... )
         >>> dr.dataset["element_id"].values
-        array([[ 1.,  6.],
-               [ 3., nan]])
+        array([[ 1,  6],
+               [ 3, -1]])
         >>> dr.get_data([2.0], [0], "item_size")
         array([0.2])
 
@@ -520,7 +520,30 @@ class DataRecord:
 
         ds_to_add = xr.Dataset(data_vars=new_data_vars, coords=coords_to_add)
 
-        self._dataset = xr.merge((self._dataset, ds_to_add), compat="no_conflicts")
+        # If new times are being added, extend the dataset first.
+        if time is not None:
+            time = self._norm_time(time)
+            # all_times = np.unique(all_times)
+            existing = np.asarray(self._dataset["time"].values, dtype=float)
+            new_times = time[~np.isin(time, existing)]
+            if len(new_times) > 0:
+                all_times = np.concatenate([existing, new_times])
+                self._dataset = self._dataset.reindex(
+                    time=all_times, fill_value={"grid_element": "nan", "element_id": -1}
+                )
+
+        # Overwrite / insert values at the requested coordinates.
+        indexers = {}
+        if item_id is not None:
+            indexers["item_id"] = item_id
+        if time is not None:
+            indexers["time"] = time
+
+        for name, value in ds_to_add.data_vars.items():
+            if name in self._dataset:
+                self._dataset[name].loc[indexers] = value
+            else:
+                self._dataset[name] = value
 
     def add_item(
         self,
@@ -656,8 +679,15 @@ class DataRecord:
         # Dataset of new record:
         ds_to_add = xr.Dataset(data_vars=data_vars_dict, coords=coords_to_add)
 
-        # Merge new record and original dataset:
-        self._dataset = xr.merge((self._dataset, ds_to_add), compat="no_conflicts")
+        self._dataset = xr.concat(
+            [self._dataset, ds_to_add],
+            dim="item_id",
+            data_vars="all",
+            coords="minimal",
+            compat="override",
+            join="outer",
+            fill_value={"grid_element": "nan", "element_id": -1},
+        )
 
     def get_data(self, time=None, item_id=None, data_variable=None):
         """Return values of a variable at a given time and/or for selected items.
@@ -1044,11 +1074,11 @@ class DataRecord:
         for these time coordinates.
 
         >>> dr3.dataset["grid_element"].values
-        array([['node', nan, nan],
-               ['link', nan, nan]], dtype=object)
+        array([['node', 'nan', 'nan'],
+               ['link', 'nan', 'nan']], dtype='<U6')
         >>> dr3.dataset["element_id"].values
-        array([[ 1., nan, nan],
-               [ 3., nan, nan]])
+        array([[ 1, -1, -1],
+               [ 3, -1, -1]])
 
         To fill these values with the last valid value, use the method
         ffill_grid_element_and_id:
@@ -1056,10 +1086,10 @@ class DataRecord:
         >>> dr3.ffill_grid_element_and_id()
         >>> dr3.dataset["grid_element"].values
         array([['node', 'node', 'node'],
-               ['link', 'link', 'link']], dtype=object)
+               ['link', 'link', 'link']], dtype='<U6')
         >>> dr3.dataset["element_id"].values
-        array([[1., 1., 1.],
-               [3., 3., 3.]])
+        array([[1, 1, 1],
+               [3, 3, 3]])
 
         In some applications, there may be no prior valid value. Under these
         circumstances, those values will stay as NaN. That is, this only
@@ -1093,77 +1123,72 @@ class DataRecord:
         >>> dr3.time_coordinates
         [0.0, 1.0]
         >>> dr3.dataset["element_id"].values
-        array([[ 1., nan],
-               [ 3., nan],
-               [nan,  4.],
-               [nan,  4.]])
+        array([[ 1, -1],
+               [ 3, -1],
+               [-1,  4],
+               [-1,  4]])
         >>> dr3.dataset["grid_element"].values
-        array([['node', nan],
-               ['link', nan],
-               [nan, 'node'],
-               [nan, 'node']], dtype=object)
+        array([['node', 'nan'],
+               ['link', 'nan'],
+               ['nan', 'node'],
+               ['nan', 'node']], dtype='<U6')
 
         We expect that the NaN's to the left of the 4.s will stay NaN. And they
         do.
 
         >>> dr3.ffill_grid_element_and_id()
         >>> dr3.dataset["element_id"].values
-        array([[ 1.,  1.],
-               [ 3.,  3.],
-               [nan,  4.],
-               [nan,  4.]])
+        array([[ 1,  1],
+               [ 3,  3],
+               [-1,  4],
+               [-1,  4]])
         >>> dr3.dataset["grid_element"].values
         array([['node', 'node'],
                ['link', 'link'],
-               [nan, 'node'],
-               [nan, 'node']], dtype=object)
+               ['nan', 'node'],
+               ['nan', 'node']], dtype='<U6')
 
         Finally, if we add a new time, we see that we need to fill in the
         full time column.
 
         >>> dr3.add_record(time=[2])
         >>> dr3.dataset["element_id"].values
-        array([[ 1.,  1., nan],
-               [ 3.,  3., nan],
-               [nan,  4., nan],
-               [nan,  4., nan]])
+        array([[ 1,  1, -1],
+               [ 3,  3, -1],
+               [-1,  4, -1],
+               [-1,  4, -1]])
         >>> dr3.dataset["grid_element"].values
-        array([['node', 'node', nan],
-               ['link', 'link', nan],
-               [nan, 'node', nan],
-               [nan, 'node', nan]], dtype=object)
+        array([['node', 'node', 'nan'],
+               ['link', 'link', 'nan'],
+               ['nan', 'node', 'nan'],
+               ['nan', 'node', 'nan']], dtype='<U6')
 
         And that forward filling fills everything as expected.
 
         >>> dr3.ffill_grid_element_and_id()
         >>> dr3.dataset["element_id"].values
-        array([[ 1.,  1.,  1.],
-               [ 3.,  3.,  3.],
-               [nan,  4.,  4.],
-               [nan,  4.,  4.]])
+        array([[ 1,  1,  1],
+               [ 3,  3,  3],
+               [-1,  4,  4],
+               [-1,  4,  4]])
 
         >>> dr3.dataset["grid_element"].values
         array([['node', 'node', 'node'],
                ['link', 'link', 'link'],
-               [nan, 'node', 'node'],
-               [nan, 'node', 'node']], dtype=object)
+               ['nan', 'node', 'node'],
+               ['nan', 'node', 'node']], dtype='<U6')
         """
+        ids = self._dataset["element_id"].values
 
-        ei = self._dataset["element_id"].values
+        n_rows, n_cols = ids.shape
+        for col in range(1, n_cols):
+            bad_vals = ids[:, col] == -1
+            ids[bad_vals, col] = ids[bad_vals, col - 1]
 
-        for i in range(ei.shape[0]):
-            for j in range(1, ei.shape[1]):
-                if np.isnan(ei[i, j]):
-                    ei[i, j] = ei[i, j - 1]
-
-        self._dataset["element_id"] = (["item_id", "time"], ei)
-
-        ge = self._dataset["grid_element"].values
-        for i in range(ge.shape[0]):
-            for j in range(1, ge.shape[1]):
-                if ge[i, j] not in self._permitted_locations:
-                    ge[i, j] = ge[i, j - 1]
-        self._dataset["grid_element"] = (["item_id", "time"], ge)
+        elements = self._dataset["grid_element"].values
+        for col in range(1, n_cols):
+            bad_vals = elements[:, col] == "nan"
+            elements[bad_vals, col] = elements[bad_vals, col - 1]
 
     @property
     def dataset(self):

--- a/tests/data_record/test_missing_values.py
+++ b/tests/data_record/test_missing_values.py
@@ -2,11 +2,61 @@ import numpy as np
 import pytest
 from numpy.testing import assert_array_equal
 
+from landlab import RasterModelGrid
+from landlab.data_record.data_record import DataRecord
 from landlab.data_record.data_record import MissingValue
 from landlab.data_record.data_record import infer_fill_values
-from landlab.data_record.data_record import merge_fill_values
 from landlab.data_record.data_record import norm_fill_values
 from landlab.data_record.data_record import spec_from_value
+
+
+def test_data_record():
+    grid = RasterModelGrid((4, 5))
+    items = {
+        "grid_element": [["node"], ["link"]],
+        "element_id": [[1], [3]],
+    }
+    data_vars = {
+        "mean_elevation": (["time"], [110.0]),
+        "item_size": (["item_id", "time"], [[0.3], [0.4]]),
+    }
+    data_record = DataRecord(
+        grid=grid, time=0.0, items=items, data_vars=data_vars, fill_value=None
+    )
+    data_record.add_record(
+        time=50.0,
+        new_record={
+            "int-var": (["time"], [120]),
+            "float-var": (["time"], [120.0]),
+            "foo": (["time"], [120]),
+        },
+        fill_value={"foo": -2},
+    )
+    assert_array_equal(data_record.dataset["int-var"].values, [-1, 120])
+    assert_array_equal(data_record.dataset["float-var"].values, [np.nan, 120.0])
+    assert_array_equal(data_record.dataset["foo"].values, [-2, 120])
+
+    data_record.add_item(
+        time=0.0,
+        new_item={
+            "grid_element": [["node"], ["node"]],
+            "element_id": [[2], [5]],
+        },
+        new_item_spec={
+            "size": (["item_id", "time"], [[10], [5]]),
+        },
+    )
+
+    assert_array_equal(
+        data_record.dataset["size"],
+        [
+            [-1, -1],
+            [-1, -1],
+            [10, -1],
+            [5, -1],
+        ],
+    )
+    assert_array_equal(data_record.dataset["foo"], [-2, 120])
 
 
 def test_missing_value():
@@ -72,10 +122,3 @@ def test_infer_fill_values():
     spec = infer_fill_values({"foo": [1.0, -2.0], "bar": -2})
     assert np.isnan(spec["foo"].fill_value)
     assert spec["bar"].fill_value == -1
-
-
-@pytest.mark.parametrize("fill", (2, MissingValue(2)))
-def test_merge_fill_values_noop(fill):
-    spec = merge_fill_values({"foo": fill})
-    assert set(spec) == {"foo"}
-    assert spec["foo"].fill_value == 2

--- a/tests/data_record/test_missing_values.py
+++ b/tests/data_record/test_missing_values.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from landlab.data_record.data_record import MissingValue
+from landlab.data_record.data_record import infer_fill_values
+from landlab.data_record.data_record import merge_fill_values
+from landlab.data_record.data_record import norm_fill_values
+from landlab.data_record.data_record import spec_from_value
+
+
+def test_missing_value():
+    spec = MissingValue(-1)
+    assert_array_equal(spec.is_missing([0, -2, -1, 5]), [False, False, True, False])
+
+    spec = MissingValue(-1, is_missing=lambda x: np.asarray(x) < 0)
+    assert_array_equal(spec.is_missing([0, -2, -1, 5]), [False, True, True, False])
+
+
+@pytest.mark.parametrize("val", (1, 0, [2], [[-1]], np.int8(1)))
+def test_spec_from_value_int(val):
+    spec = spec_from_value(val)
+    assert spec.fill_value == -1
+    assert_array_equal(spec.is_missing([0, -1, -2, 1]), [False, True, False, False])
+
+
+@pytest.mark.parametrize("val", (1.0, 0.0, np.nan, np.inf, [2.0], [[-1.0]]))
+def test_spec_from_value_float(val):
+    spec = spec_from_value(val)
+    assert np.isnan(spec.fill_value)
+    assert_array_equal(spec.is_missing([0, np.nan, -2, 1]), [False, True, False, False])
+
+
+@pytest.mark.parametrize("val", (True, False))
+def test_spec_from_value_bool(val):
+    spec = spec_from_value(val)
+    assert not spec.fill_value
+    assert_array_equal(
+        spec.is_missing([True, False, True, True]), [False, True, False, False]
+    )
+
+
+@pytest.mark.parametrize("val", ("foo", "", ["foo", "bar", "foobar"]))
+def test_spec_from_value_str(val):
+    spec = spec_from_value(val)
+    assert spec.fill_value == "nan"
+    assert_array_equal(
+        spec.is_missing(["foo", "nan", "bar", "bar"]), [False, True, False, False]
+    )
+
+
+def test_norm_fill_values_empty():
+    assert norm_fill_values({}) == {}
+
+
+@pytest.mark.parametrize("fill_value", ({}, {"foo": -1}, {"bar": MissingValue(np.nan)}))
+def test_norm_fill_values_makes_instances(fill_value):
+    spec = norm_fill_values(fill_value)
+    assert np.all(isinstance(x, MissingValue) for x in spec.values())
+
+
+@pytest.mark.parametrize(
+    "name, value", (("foo", -2), ("element_id", -5), ("grid_element", 12))
+)
+def test_norm_fill_values(name, value):
+    spec = norm_fill_values({name: value})
+    assert set(spec) == {name}
+    assert spec[name].fill_value == value
+
+
+def test_infer_fill_values():
+    spec = infer_fill_values({"foo": [1.0, -2.0], "bar": -2})
+    assert np.isnan(spec["foo"].fill_value)
+    assert spec["bar"].fill_value == -1
+
+
+@pytest.mark.parametrize("fill", (2, MissingValue(2)))
+def test_merge_fill_values_noop(fill):
+    spec = merge_fill_values({"foo": fill})
+    assert set(spec) == {"foo"}
+    assert spec["foo"].fill_value == 2


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've refactored `DataRecord.add_record` and `DataRecord.add_item` to avoid using `xarray.merge` when inserting records or items. `add_item` now concatenates along the `item_id` dimension, while `add_record` extends the time coordinate as needed and assigns new values into the requested coordinate locations.

The change also uses different fill values for missing items depending on the variable:
* `-1` for `element_id`
* `"nan"` for `grid_element`
This preserves integer dtype for `element_id` instead of allowing xarray reindexing to promote it to floating point with `NaN` values.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
