### PR TITLE
NetworkSedimentTransporter bugfix head & outlet BCs

### DIFF
--- a/news/2413.bugfix
+++ b/news/2413.bugfix
@@ -1,1 +1,1 @@
-Fixed handling of head and outlet node elevations in the NetworkSedimentTransporter, as well as bug that removed all active parcels from the outlet link within a single timestep. 
+Fixed handling of head and outlet node elevations in the NetworkSedimentTransporter, as well as bug that removed all active parcels from the outlet link within a single timestep.

--- a/news/2413.bugfix
+++ b/news/2413.bugfix
@@ -1,0 +1,1 @@
+Fixed handling of head and outlet node elevations in the NetworkSedimentTransporter, as well as bug that removed all active parcels from the outlet link within a single timestep. 

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -624,46 +624,48 @@ class NetworkSedimentTransporter(Component):
         """Adjusts slope for each link based on parcel motions from last
         timestep and additions from this timestep.
         """
-
-        number_of_contributors = np.sum(
-            self._fd.flow_link_incoming_at_node() == 1, axis=1
-        )
-        downstream_link_id = self._fd.link_to_flow_receiving_node
-
-        upstream_contributing_links_at_node = np.where(
-            self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
-        )
-
         channel_width = self._grid.at_link["channel_width"]
         reach_length = self._grid.at_link["reach_length"]
+        elevation = self._grid.at_node["topographic__elevation"]
+        bedrock = self._grid.at_node["bedrock__elevation"]
+
+        is_incoming_link = self._fd.flow_link_incoming_at_node() == 1
+        downstream_link_id = self._fd.link_to_flow_receiving_node
+
+        number_of_contributors = np.sum(is_incoming_link, axis=1)
+
+        upstream_contributing_links_at_node = np.where(
+            is_incoming_link, self._grid.links_at_node, -1
+        )
+
+        is_head = number_of_contributors == 0
+        is_outlet = downstream_link_id == self._grid.BAD_INDEX
 
         # Update the node topographic elevations depending on the quantity of stored sediment
-        for n in range(self._grid.number_of_nodes):
-            downstream_link = downstream_link_id[n]
-
-            upstream_links = upstream_contributing_links_at_node[n]
-            real_upstream_links = upstream_links[upstream_links != self._grid.BAD_INDEX]
+        for node, downstream_link in enumerate(downstream_link_id):
+            upstream_links = upstream_contributing_links_at_node[node]
+            upstream_links = upstream_links[upstream_links != self._grid.BAD_INDEX]
 
             # Upstream links attributes
-            if number_of_contributors[n] == 0:  # head node
+            if is_head[node]:
                 length_of_upstream_links = reach_length[downstream_link]
                 width_of_upstream_links = channel_width[downstream_link]
             else:
-                length_of_upstream_links = reach_length[real_upstream_links]
-                width_of_upstream_links = channel_width[real_upstream_links]
+                length_of_upstream_links = reach_length[upstream_links]
+                width_of_upstream_links = channel_width[upstream_links]
 
             # Downstream link attributes
-            if downstream_link == self._grid.BAD_INDEX:  # outlet node
+            if is_outlet[node]:
                 # assign elevation based on upstream link volume (b/c no downstream exists)
-                volume_downstream = np.sum(self._vol_tot[real_upstream_links])
-                length_of_downstream_link = np.sum(reach_length[real_upstream_links])
-                width_of_downstream_link = np.sum(channel_width[real_upstream_links])
+                volume_downstream = np.sum(self._vol_tot[upstream_links])
+                length_of_downstream_link = np.sum(reach_length[upstream_links])
+                width_of_downstream_link = np.sum(channel_width[upstream_links])
             else:
                 volume_downstream = self._vol_tot[downstream_link]
                 length_of_downstream_link = reach_length[downstream_link]
                 width_of_downstream_link = channel_width[downstream_link]
 
-            alluvium__depth = _calculate_alluvium_depth(
+            alluvium_depth = _calculate_alluvium_depth(
                 volume_downstream,
                 width_of_upstream_links,
                 length_of_upstream_links,
@@ -672,9 +674,7 @@ class NetworkSedimentTransporter(Component):
                 self._bed_porosity,
             )
 
-            self._grid.at_node["topographic__elevation"][n] = (
-                self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
-            )
+            elevation[node] = bedrock[node] + alluvium_depth
 
     def _calc_transport_wilcock_crowe(self) -> None:
         """Method to determine the transport time for each parcel in the active

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -642,20 +642,18 @@ class NetworkSedimentTransporter(Component):
             downstream_link = downstream_link_id[n]
 
             upstream_links = upstream_contributing_links_at_node[n]
-            real_upstream_links = upstream_links[
-                upstream_links != self._grid.BAD_INDEX
-            ]
-            
+            real_upstream_links = upstream_links[upstream_links != self._grid.BAD_INDEX]
+
             # Upstream links attributes
-            if number_of_contributors[n] == 0: # head node
+            if number_of_contributors[n] == 0:  # head node
                 length_of_upstream_links = reach_length[downstream_link]
                 width_of_upstream_links = channel_width[downstream_link]
-            else: 
+            else:
                 length_of_upstream_links = reach_length[real_upstream_links]
                 width_of_upstream_links = channel_width[real_upstream_links]
 
             # Downstream link attributes
-            if downstream_link == self._grid.BAD_INDEX: # outlet node 
+            if downstream_link == self._grid.BAD_INDEX:  # outlet node
                 # assign elevation based on upstream link volume (b/c no downstream exists)
                 volume_downstream = np.sum(self._vol_tot[real_upstream_links])
                 length_of_downstream_link = np.sum(reach_length[real_upstream_links])
@@ -664,7 +662,7 @@ class NetworkSedimentTransporter(Component):
                 volume_downstream = self._vol_tot[downstream_link]
                 length_of_downstream_link = reach_length[downstream_link]
                 width_of_downstream_link = channel_width[downstream_link]
-            
+
             alluvium__depth = _calculate_alluvium_depth(
                 volume_downstream,
                 width_of_upstream_links,

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -647,19 +647,21 @@ class NetworkSedimentTransporter(Component):
             real_upstream_links = upstream_links[
                 upstream_links != self._grid.BAD_INDEX
             ]
-
-            if number_of_contributors[n] == 0: 
-                width_of_upstream_links = channel_width[downstream_link]
+            
+            # Upstream links attributes
+            if number_of_contributors[n] == 0: # head node
                 length_of_upstream_links = reach_length[downstream_link]
+                width_of_upstream_links = channel_width[downstream_link]
             else: 
-                width_of_upstream_links = channel_width[real_upstream_links]
                 length_of_upstream_links = reach_length[real_upstream_links]
+                width_of_upstream_links = channel_width[real_upstream_links]
 
-            if downstream_link == self._grid.BAD_INDEX:
+            # Downstream link attributes
+            if downstream_link == self._grid.BAD_INDEX: # outlet node 
                 # assign elevation based on upstream link volume (b/c no downstream exists)
-                volume_downstream = np.sum(self._vol_tot[upstream_links])
-                length_of_downstream_link = np.sum(reach_length[upstream_links])
-                width_of_downstream_link = np.sum(channel_width[upstream_links])
+                volume_downstream = np.sum(self._vol_tot[real_upstream_links])
+                length_of_downstream_link = np.sum(reach_length[real_upstream_links])
+                width_of_downstream_link = np.sum(channel_width[real_upstream_links])
             else:
                 volume_downstream = self._vol_tot[downstream_link]
                 length_of_downstream_link = reach_length[downstream_link]

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -402,6 +402,41 @@ class NetworkSedimentTransporter(Component):
 
         self._partition_active_and_storage_layers()
         self._adjust_node_elevation()
+
+        ### Manually set head node elevs via sed thickness of downstream link
+        # these do not get updated in run_one_step
+        # #XXX Eric please help check syntax 
+
+        number_of_contributors = np.sum(
+            self._fd.flow_link_incoming_at_node() == 1, axis=1
+        )
+        
+        downstream_link_ids = self._fd.link_to_flow_receiving_node
+
+        for n in range(self._grid.number_of_nodes):
+            if number_of_contributors[n] == 0:  
+                downstream_link = downstream_link_ids[n]
+
+                width_of_downstream_links = self._grid.at_link["channel_width"][
+                    downstream_link
+                ]
+                length_of_downstream_links = self._grid.at_link["reach_length"][
+                    downstream_link
+                ]
+                volume_at_downstream_links = self._vol_stor[
+                    downstream_link
+                ]
+                alluvium__depth = (
+                    volume_at_downstream_links
+                    /length_of_downstream_links
+                    /width_of_downstream_links
+                    /(1 - self._bed_porosity)
+                )
+                
+                self._grid.at_node["topographic__elevation"][n] = (
+                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
+                )
+
         self._update_channel_slopes()
 
     @property
@@ -634,6 +669,8 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
+        vol_tot = self._vol_tot.copy()
+
         # Update the node topographic elevations depending on the quantity of stored sediment
         for n in range(self._grid.number_of_nodes):
             if number_of_contributors[n] > 0:  # we don't update head node elevations
@@ -652,6 +689,22 @@ class NetworkSedimentTransporter(Component):
                     # I'm sure there's a better way to do this, but...
                     length_of_downstream_link = 0
                     width_of_downstream_link = 0
+
+                # #     # ignore ghost node parcels. Instead,
+                # #     # set "downstream" link attributes as upstream values 
+                #     length_of_downstream_link = self._grid.at_link["reach_length"][
+                #         real_upstream_links
+                #     ][0] # XXX WHY did I have to add [0] to get it to work  in Sklar? there's only one upstream
+                #     width_of_downstream_link = self._grid.at_link["channel_width"][
+                #         real_upstream_links
+                #     ][0]
+                # #     # XXX Check with Eric -- what if 2 upstream links? sum(voltot) didn't work
+                # #     print('vol_tot =', vol_tot)
+                # #     print('downstream_link_id = ', downstream_link_id)
+                # #     print('n = ', n)
+                #     vol_tot[downstream_link_id][n] = vol_tot[real_upstream_links][0]
+                    
+
                 else:
                     length_of_downstream_link = self._grid.at_link["reach_length"][
                         downstream_link_id
@@ -661,6 +714,7 @@ class NetworkSedimentTransporter(Component):
                     ][n]
 
                 alluvium__depth = _calculate_alluvium_depth(
+                    vol_tot[downstream_link_id][n],
                     self._vol_stor[downstream_link_id][n],
                     width_of_upstream_links,
                     length_of_upstream_links,
@@ -669,9 +723,9 @@ class NetworkSedimentTransporter(Component):
                     self._bed_porosity,
                 )
 
-                self._grid.at_node["topographic__elevation"][n] = (
-                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
-                )
+            self._grid.at_node["topographic__elevation"][n] = (
+                self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
+            )
 
     def _calc_transport_wilcock_crowe(self) -> None:
         """Method to determine the transport time for each parcel in the active

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -924,10 +924,8 @@ class NetworkSedimentTransporter(Component):
                 # assign new values to current link.
                 current_link[moving_downstream] = downstream_link[moving_downstream]
 
-                # find and address those links who have moved out of network.
-                #moved_oon = downstream_link == self._grid.BAD_INDEX
+                # find and address those parcels who have moved out of network.
                 in_outlet_link = downstream_link == self._grid.BAD_INDEX
-
                 moved_oon = moving_downstream * in_outlet_link
 
                 if np.any(moved_oon):

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -888,10 +888,8 @@ class NetworkSedimentTransporter(Component):
                 # assign new values to current link.
                 current_link[moving_downstream] = downstream_link[moving_downstream]
 
-                # find and address those links who have moved out of network.
-                #moved_oon = downstream_link == self._grid.BAD_INDEX
+                # find and address those parcels who have moved out of network.
                 in_outlet_link = downstream_link == self._grid.BAD_INDEX
-
                 moved_oon = moving_downstream * in_outlet_link
 
                 if np.any(moved_oon):

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -622,20 +622,18 @@ class NetworkSedimentTransporter(Component):
             downstream_link = downstream_link_id[n]
 
             upstream_links = upstream_contributing_links_at_node[n]
-            real_upstream_links = upstream_links[
-                upstream_links != self._grid.BAD_INDEX
-            ]
-            
+            real_upstream_links = upstream_links[upstream_links != self._grid.BAD_INDEX]
+
             # Upstream links attributes
-            if number_of_contributors[n] == 0: # head node
+            if number_of_contributors[n] == 0:  # head node
                 length_of_upstream_links = reach_length[downstream_link]
                 width_of_upstream_links = channel_width[downstream_link]
-            else: 
+            else:
                 length_of_upstream_links = reach_length[real_upstream_links]
                 width_of_upstream_links = channel_width[real_upstream_links]
 
             # Downstream link attributes
-            if downstream_link == self._grid.BAD_INDEX: # outlet node 
+            if downstream_link == self._grid.BAD_INDEX:  # outlet node
                 # assign elevation based on upstream link volume (b/c no downstream exists)
                 volume_downstream = np.sum(self._vol_tot[real_upstream_links])
                 length_of_downstream_link = np.sum(reach_length[real_upstream_links])
@@ -644,7 +642,7 @@ class NetworkSedimentTransporter(Component):
                 volume_downstream = self._vol_tot[downstream_link]
                 length_of_downstream_link = reach_length[downstream_link]
                 width_of_downstream_link = channel_width[downstream_link]
-            
+
             alluvium__depth = _calculate_alluvium_depth(
                 volume_downstream,
                 width_of_upstream_links,
@@ -889,7 +887,7 @@ class NetworkSedimentTransporter(Component):
                 current_link[moving_downstream] = downstream_link[moving_downstream]
 
                 # find and address those links who have moved out of network.
-                #moved_oon = downstream_link == self._grid.BAD_INDEX
+                # moved_oon = downstream_link == self._grid.BAD_INDEX
                 in_outlet_link = downstream_link == self._grid.BAD_INDEX
 
                 moved_oon = moving_downstream * in_outlet_link

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -627,19 +627,21 @@ class NetworkSedimentTransporter(Component):
             real_upstream_links = upstream_links[
                 upstream_links != self._grid.BAD_INDEX
             ]
-
-            if number_of_contributors[n] == 0: 
-                width_of_upstream_links = channel_width[downstream_link]
+            
+            # Upstream links attributes
+            if number_of_contributors[n] == 0: # head node
                 length_of_upstream_links = reach_length[downstream_link]
+                width_of_upstream_links = channel_width[downstream_link]
             else: 
-                width_of_upstream_links = channel_width[real_upstream_links]
                 length_of_upstream_links = reach_length[real_upstream_links]
+                width_of_upstream_links = channel_width[real_upstream_links]
 
-            if downstream_link == self._grid.BAD_INDEX:
+            # Downstream link attributes
+            if downstream_link == self._grid.BAD_INDEX: # outlet node 
                 # assign elevation based on upstream link volume (b/c no downstream exists)
-                volume_downstream = np.sum(self._vol_tot[upstream_links])
-                length_of_downstream_link = np.sum(reach_length[upstream_links])
-                width_of_downstream_link = np.sum(channel_width[upstream_links])
+                volume_downstream = np.sum(self._vol_tot[real_upstream_links])
+                length_of_downstream_link = np.sum(reach_length[real_upstream_links])
+                width_of_downstream_link = np.sum(channel_width[real_upstream_links])
             else:
                 volume_downstream = self._vol_tot[downstream_link]
                 length_of_downstream_link = reach_length[downstream_link]

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -920,7 +920,10 @@ class NetworkSedimentTransporter(Component):
                 current_link[moving_downstream] = downstream_link[moving_downstream]
 
                 # find and address those links who have moved out of network.
-                moved_oon = downstream_link == self._grid.BAD_INDEX
+                #moved_oon = downstream_link == self._grid.BAD_INDEX
+                in_outlet_link = downstream_link == self._grid.BAD_INDEX
+
+                moved_oon = moving_downstream * in_outlet_link
 
                 if np.any(moved_oon):
                     # print('  {x} exiting network'.format(x=np.sum(moved_oon)))

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -402,41 +402,6 @@ class NetworkSedimentTransporter(Component):
 
         self._partition_active_and_storage_layers()
         self._adjust_node_elevation()
-
-        ### Manually set head node elevs via sed thickness of downstream link
-        # these do not get updated in run_one_step
-        # #XXX Eric please help check syntax 
-
-        number_of_contributors = np.sum(
-            self._fd.flow_link_incoming_at_node() == 1, axis=1
-        )
-        
-        downstream_link_ids = self._fd.link_to_flow_receiving_node
-
-        for n in range(self._grid.number_of_nodes):
-            if number_of_contributors[n] == 0:  
-                downstream_link = downstream_link_ids[n]
-
-                width_of_downstream_links = self._grid.at_link["channel_width"][
-                    downstream_link
-                ]
-                length_of_downstream_links = self._grid.at_link["reach_length"][
-                    downstream_link
-                ]
-                volume_at_downstream_links = self._vol_stor[
-                    downstream_link
-                ]
-                alluvium__depth = (
-                    volume_at_downstream_links
-                    /length_of_downstream_links
-                    /width_of_downstream_links
-                    /(1 - self._bed_porosity)
-                )
-                
-                self._grid.at_node["topographic__elevation"][n] = (
-                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
-                )
-
         self._update_channel_slopes()
 
     @property
@@ -669,59 +634,45 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
-        vol_tot = self._vol_tot.copy()
+        # vol_tot = self._vol_tot.copy()
+
+        channel_width = self._grid.at_link["channel_width"]
+        reach_length = self._grid.at_link["reach_length"]
 
         # Update the node topographic elevations depending on the quantity of stored sediment
         for n in range(self._grid.number_of_nodes):
-            if number_of_contributors[n] > 0:  # we don't update head node elevations
-                upstream_links = upstream_contributing_links_at_node[n]
-                real_upstream_links = upstream_links[
-                    upstream_links != self._grid.BAD_INDEX
-                ]
-                width_of_upstream_links = self._grid.at_link["channel_width"][
-                    real_upstream_links
-                ]
-                length_of_upstream_links = self._grid.at_link["reach_length"][
-                    real_upstream_links
-                ]
+            downstream_link = downstream_link_id[n]
 
-                if downstream_link_id[n] == self._grid.BAD_INDEX:
-                    # I'm sure there's a better way to do this, but...
-                    length_of_downstream_link = 0
-                    width_of_downstream_link = 0
+            upstream_links = upstream_contributing_links_at_node[n]
+            real_upstream_links = upstream_links[
+                upstream_links != self._grid.BAD_INDEX
+            ]
 
-                # #     # ignore ghost node parcels. Instead,
-                # #     # set "downstream" link attributes as upstream values 
-                #     length_of_downstream_link = self._grid.at_link["reach_length"][
-                #         real_upstream_links
-                #     ][0] # XXX WHY did I have to add [0] to get it to work  in Sklar? there's only one upstream
-                #     width_of_downstream_link = self._grid.at_link["channel_width"][
-                #         real_upstream_links
-                #     ][0]
-                # #     # XXX Check with Eric -- what if 2 upstream links? sum(voltot) didn't work
-                # #     print('vol_tot =', vol_tot)
-                # #     print('downstream_link_id = ', downstream_link_id)
-                # #     print('n = ', n)
-                #     vol_tot[downstream_link_id][n] = vol_tot[real_upstream_links][0]
-                    
+            if number_of_contributors[n] == 0: 
+                width_of_upstream_links = channel_width[downstream_link]
+                length_of_upstream_links = reach_length[downstream_link]
+            else: 
+                width_of_upstream_links = channel_width[real_upstream_links]
+                length_of_upstream_links = reach_length[real_upstream_links]
 
-                else:
-                    length_of_downstream_link = self._grid.at_link["reach_length"][
-                        downstream_link_id
-                    ][n]
-                    width_of_downstream_link = self._grid.at_link["channel_width"][
-                        downstream_link_id
-                    ][n]
-
-                alluvium__depth = _calculate_alluvium_depth(
-                    vol_tot[downstream_link_id][n],
-                    self._vol_stor[downstream_link_id][n],
-                    width_of_upstream_links,
-                    length_of_upstream_links,
-                    width_of_downstream_link,
-                    length_of_downstream_link,
-                    self._bed_porosity,
-                )
+            if downstream_link == self._grid.BAD_INDEX:
+                # assign elevation based on upstream link volume (b/c no downstream exists)
+                volume_downstream = np.sum(self._vol_tot[upstream_links])
+                length_of_downstream_link = np.sum(reach_length[upstream_links])
+                width_of_downstream_link = np.sum(channel_width[upstream_links])
+            else:
+                volume_downstream = self._vol_tot[downstream_link]
+                length_of_downstream_link = reach_length[downstream_link]
+                width_of_downstream_link = channel_width[downstream_link]
+            
+            alluvium__depth = _calculate_alluvium_depth(
+                volume_downstream,
+                width_of_upstream_links,
+                length_of_upstream_links,
+                width_of_downstream_link,
+                length_of_downstream_link,
+                self._bed_porosity,
+            )
 
             self._grid.at_node["topographic__elevation"][n] = (
                 self._grid.at_node["bedrock__elevation"][n] + alluvium__depth

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -398,6 +398,41 @@ class NetworkSedimentTransporter(Component):
 
         self._partition_active_and_storage_layers()
         self._adjust_node_elevation()
+
+        ### Manually set head node elevs via sed thickness of downstream link
+        # these do not get updated in run_one_step
+        # #XXX Eric please help check syntax 
+
+        number_of_contributors = np.sum(
+            self._fd.flow_link_incoming_at_node() == 1, axis=1
+        )
+        
+        downstream_link_ids = self._fd.link_to_flow_receiving_node
+
+        for n in range(self._grid.number_of_nodes):
+            if number_of_contributors[n] == 0:  
+                downstream_link = downstream_link_ids[n]
+
+                width_of_downstream_links = self._grid.at_link["channel_width"][
+                    downstream_link
+                ]
+                length_of_downstream_links = self._grid.at_link["reach_length"][
+                    downstream_link
+                ]
+                volume_at_downstream_links = self._vol_stor[
+                    downstream_link
+                ]
+                alluvium__depth = (
+                    volume_at_downstream_links
+                    /length_of_downstream_links
+                    /width_of_downstream_links
+                    /(1 - self._bed_porosity)
+                )
+                
+                self._grid.at_node["topographic__elevation"][n] = (
+                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
+                )
+
         self._update_channel_slopes()
 
     @property
@@ -614,6 +649,8 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
+        vol_tot = self._vol_tot.copy()
+
         # Update the node topographic elevations depending on the quantity of stored sediment
         for n in range(self._grid.number_of_nodes):
             if number_of_contributors[n] > 0:  # we don't update head node elevations
@@ -632,6 +669,22 @@ class NetworkSedimentTransporter(Component):
                     # I'm sure there's a better way to do this, but...
                     length_of_downstream_link = 0
                     width_of_downstream_link = 0
+
+                # #     # ignore ghost node parcels. Instead,
+                # #     # set "downstream" link attributes as upstream values 
+                #     length_of_downstream_link = self._grid.at_link["reach_length"][
+                #         real_upstream_links
+                #     ][0] # XXX WHY did I have to add [0] to get it to work  in Sklar? there's only one upstream
+                #     width_of_downstream_link = self._grid.at_link["channel_width"][
+                #         real_upstream_links
+                #     ][0]
+                # #     # XXX Check with Eric -- what if 2 upstream links? sum(voltot) didn't work
+                # #     print('vol_tot =', vol_tot)
+                # #     print('downstream_link_id = ', downstream_link_id)
+                # #     print('n = ', n)
+                #     vol_tot[downstream_link_id][n] = vol_tot[real_upstream_links][0]
+                    
+
                 else:
                     length_of_downstream_link = self._grid.at_link["reach_length"][
                         downstream_link_id
@@ -641,6 +694,7 @@ class NetworkSedimentTransporter(Component):
                     ][n]
 
                 alluvium__depth = _calculate_alluvium_depth(
+                    vol_tot[downstream_link_id][n],
                     self._vol_stor[downstream_link_id][n],
                     width_of_upstream_links,
                     length_of_upstream_links,
@@ -649,9 +703,9 @@ class NetworkSedimentTransporter(Component):
                     self._bed_porosity,
                 )
 
-                self._grid.at_node["topographic__elevation"][n] = (
-                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
-                )
+            self._grid.at_node["topographic__elevation"][n] = (
+                self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
+            )
 
     def _calc_transport_wilcock_crowe(self) -> None:
         """Method to determine the transport time for each parcel in the active

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -884,7 +884,10 @@ class NetworkSedimentTransporter(Component):
                 current_link[moving_downstream] = downstream_link[moving_downstream]
 
                 # find and address those links who have moved out of network.
-                moved_oon = downstream_link == self._grid.BAD_INDEX
+                #moved_oon = downstream_link == self._grid.BAD_INDEX
+                in_outlet_link = downstream_link == self._grid.BAD_INDEX
+
+                moved_oon = moving_downstream * in_outlet_link
 
                 if np.any(moved_oon):
                     # print('  {x} exiting network'.format(x=np.sum(moved_oon)))

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -614,8 +614,6 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
-        # vol_tot = self._vol_tot.copy()
-
         channel_width = self._grid.at_link["channel_width"]
         reach_length = self._grid.at_link["reach_length"]
 

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -634,8 +634,6 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
-        # vol_tot = self._vol_tot.copy()
-
         channel_width = self._grid.at_link["channel_width"]
         reach_length = self._grid.at_link["reach_length"]
 

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -398,41 +398,6 @@ class NetworkSedimentTransporter(Component):
 
         self._partition_active_and_storage_layers()
         self._adjust_node_elevation()
-
-        ### Manually set head node elevs via sed thickness of downstream link
-        # these do not get updated in run_one_step
-        # #XXX Eric please help check syntax 
-
-        number_of_contributors = np.sum(
-            self._fd.flow_link_incoming_at_node() == 1, axis=1
-        )
-        
-        downstream_link_ids = self._fd.link_to_flow_receiving_node
-
-        for n in range(self._grid.number_of_nodes):
-            if number_of_contributors[n] == 0:  
-                downstream_link = downstream_link_ids[n]
-
-                width_of_downstream_links = self._grid.at_link["channel_width"][
-                    downstream_link
-                ]
-                length_of_downstream_links = self._grid.at_link["reach_length"][
-                    downstream_link
-                ]
-                volume_at_downstream_links = self._vol_stor[
-                    downstream_link
-                ]
-                alluvium__depth = (
-                    volume_at_downstream_links
-                    /length_of_downstream_links
-                    /width_of_downstream_links
-                    /(1 - self._bed_porosity)
-                )
-                
-                self._grid.at_node["topographic__elevation"][n] = (
-                    self._grid.at_node["bedrock__elevation"][n] + alluvium__depth
-                )
-
         self._update_channel_slopes()
 
     @property
@@ -649,59 +614,45 @@ class NetworkSedimentTransporter(Component):
             self._fd.flow_link_incoming_at_node() == 1, self._grid.links_at_node, -1
         )
 
-        vol_tot = self._vol_tot.copy()
+        # vol_tot = self._vol_tot.copy()
+
+        channel_width = self._grid.at_link["channel_width"]
+        reach_length = self._grid.at_link["reach_length"]
 
         # Update the node topographic elevations depending on the quantity of stored sediment
         for n in range(self._grid.number_of_nodes):
-            if number_of_contributors[n] > 0:  # we don't update head node elevations
-                upstream_links = upstream_contributing_links_at_node[n]
-                real_upstream_links = upstream_links[
-                    upstream_links != self._grid.BAD_INDEX
-                ]
-                width_of_upstream_links = self._grid.at_link["channel_width"][
-                    real_upstream_links
-                ]
-                length_of_upstream_links = self._grid.at_link["reach_length"][
-                    real_upstream_links
-                ]
+            downstream_link = downstream_link_id[n]
 
-                if downstream_link_id[n] == self._grid.BAD_INDEX:
-                    # I'm sure there's a better way to do this, but...
-                    length_of_downstream_link = 0
-                    width_of_downstream_link = 0
+            upstream_links = upstream_contributing_links_at_node[n]
+            real_upstream_links = upstream_links[
+                upstream_links != self._grid.BAD_INDEX
+            ]
 
-                # #     # ignore ghost node parcels. Instead,
-                # #     # set "downstream" link attributes as upstream values 
-                #     length_of_downstream_link = self._grid.at_link["reach_length"][
-                #         real_upstream_links
-                #     ][0] # XXX WHY did I have to add [0] to get it to work  in Sklar? there's only one upstream
-                #     width_of_downstream_link = self._grid.at_link["channel_width"][
-                #         real_upstream_links
-                #     ][0]
-                # #     # XXX Check with Eric -- what if 2 upstream links? sum(voltot) didn't work
-                # #     print('vol_tot =', vol_tot)
-                # #     print('downstream_link_id = ', downstream_link_id)
-                # #     print('n = ', n)
-                #     vol_tot[downstream_link_id][n] = vol_tot[real_upstream_links][0]
-                    
+            if number_of_contributors[n] == 0: 
+                width_of_upstream_links = channel_width[downstream_link]
+                length_of_upstream_links = reach_length[downstream_link]
+            else: 
+                width_of_upstream_links = channel_width[real_upstream_links]
+                length_of_upstream_links = reach_length[real_upstream_links]
 
-                else:
-                    length_of_downstream_link = self._grid.at_link["reach_length"][
-                        downstream_link_id
-                    ][n]
-                    width_of_downstream_link = self._grid.at_link["channel_width"][
-                        downstream_link_id
-                    ][n]
-
-                alluvium__depth = _calculate_alluvium_depth(
-                    vol_tot[downstream_link_id][n],
-                    self._vol_stor[downstream_link_id][n],
-                    width_of_upstream_links,
-                    length_of_upstream_links,
-                    width_of_downstream_link,
-                    length_of_downstream_link,
-                    self._bed_porosity,
-                )
+            if downstream_link == self._grid.BAD_INDEX:
+                # assign elevation based on upstream link volume (b/c no downstream exists)
+                volume_downstream = np.sum(self._vol_tot[upstream_links])
+                length_of_downstream_link = np.sum(reach_length[upstream_links])
+                width_of_downstream_link = np.sum(channel_width[upstream_links])
+            else:
+                volume_downstream = self._vol_tot[downstream_link]
+                length_of_downstream_link = reach_length[downstream_link]
+                width_of_downstream_link = channel_width[downstream_link]
+            
+            alluvium__depth = _calculate_alluvium_depth(
+                volume_downstream,
+                width_of_upstream_links,
+                length_of_upstream_links,
+                width_of_downstream_link,
+                length_of_downstream_link,
+                self._bed_porosity,
+            )
 
             self._grid.at_node["topographic__elevation"][n] = (
                 self._grid.at_node["bedrock__elevation"][n] + alluvium__depth


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [ ] All tests pass locally (`pytest`, or `nox -s test`)
- [ ] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

This PR resolves two boundary condition - related issues in the `NetworkSedimentTransporter`:

1. The NST boundary conditions are handled oddly:
    Currently, in `_adjust_node_elevations` the head nodes have fixed elevations at the bedrock, while the outlet node elevations evolve according to the sediment volume on the "ghost" link. This is foolish, since in the absence of parcel recycling, it leads to systematic aggradation at the downstream end of the network.

--> Here, we've changed the handling such that the upstream nodes aggrade according to their downstream link sediment volumes, by assuming that the (imaginary) upstream link length and width are equal to those in the downstream link. We apply a similar logic at the downstream end, assuming the upstream link volume 

2. The NST `_move_parcel_downstream` has a bug that results in all active parcels in the outlet node being sent to the "ghost" link, aka OUT_OF_NETWORK:
    The `moved_oon` mask, which selects parcels to be moved `OUT_OF_NETWORK`, doesn't filter for `moving_downstream` (parcels that move to the next link, so all active parcels in the outlet link are moved Out of Network. 

--> This has been fixed, and resolves anomalous incision at downstream end of networks. 

@mcflugen 

---
## Related Issues

Closes #2412 
