### PR TITLE
Add grouped geometric mean aggregator, aggregate_items_as_gmean

### DIFF
--- a/news/2414.feature
+++ b/news/2414.feature
@@ -1,0 +1,2 @@
+Added `aggregate_items_as_gmean` for computing weighted geometric means of
+values grouped by IDs.

--- a/src/landlab/data_record/_aggregators.pyx
+++ b/src/landlab/data_record/_aggregators.pyx
@@ -1,5 +1,8 @@
 cimport cython
 from cython.parallel cimport prange
+from libc.math cimport exp
+from libc.math cimport log
+from libc.stdint cimport uint8_t
 from libc.stdlib cimport free
 from libc.stdlib cimport malloc
 
@@ -97,3 +100,50 @@ cpdef void aggregate_items_as_mean(
                 out[element] = out[element] / total_weight_at_element[element]
     finally:
         free(total_weight_at_element)
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+cpdef void aggregate_items_as_gmean(
+    cython.floating [::1] out,
+    const id_t [::1] element_of_item,
+    const float_or_int [::1] value_of_item,
+    const float_or_int_weights [::1] weight_of_item,
+    const uint8_t[::1] where,
+) noexcept nogil:
+    cdef Py_ssize_t number_of_elements = len(out)
+    cdef Py_ssize_t number_of_items = len(element_of_item)
+    cdef Py_ssize_t item
+    cdef Py_ssize_t element
+    cdef double weight
+    cdef double* total_weight = <double*>malloc(
+        number_of_elements * sizeof(double)
+    )
+    cdef double* total_weighted_log = <double*>malloc(
+        number_of_elements * sizeof(double)
+    )
+
+    try:
+        for element in prange(number_of_elements, nogil=True, schedule="static"):
+            total_weighted_log[element] = 0.0
+            total_weight[element] = 0.0
+
+        for item in range(number_of_items):
+            if not where[item]:
+                continue
+
+            element = element_of_item[item]
+            if element >= 0:
+                weight = weight_of_item[item]
+                total_weighted_log[element] = (
+                    total_weighted_log[element] + weight * log(value_of_item[item])
+                )
+                total_weight[element] = total_weight[element] + weight
+
+        for element in range(number_of_elements):
+            if total_weight[element] > 0.0:
+                out[element] = exp(total_weighted_log[element] / total_weight[element])
+    finally:
+        free(total_weight)
+        free(total_weighted_log)

--- a/src/landlab/data_record/aggregators.py
+++ b/src/landlab/data_record/aggregators.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import numpy as np
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
+from requireit import require_array
+from requireit import require_greater_than
+from requireit import require_greater_than_or_equal
+from requireit import require_length_at_least
 
 from landlab.data_record._aggregators import (
     aggregate_items_as_count as _aggregate_items_as_count,
+)
+from landlab.data_record._aggregators import (
+    aggregate_items_as_gmean as _aggregate_items_as_gmean,
 )
 from landlab.data_record._aggregators import (
     aggregate_items_as_mean as _aggregate_items_as_mean,
@@ -110,6 +117,103 @@ def aggregate_items_as_mean(
     assert len(values) == len(weights)
 
     _aggregate_items_as_mean(out, ids, values, weights)
+
+    return out
+
+
+def aggregate_items_as_gmean(
+    ids: ArrayLike,
+    values: ArrayLike,
+    *,
+    weights: ArrayLike | None = None,
+    where: ArrayLike | None = None,
+    out: NDArray[np.floating] | None = None,
+) -> NDArray[np.floating]:
+    """Compute a weighted geometric mean of values grouped by integer IDs.
+
+    Group ``values`` by ``ids`` and compute the weighted geometric mean
+    for each group.
+
+    Parameters
+    ----------
+    ids : array_like of int, shape (n,)
+        Integer group labels for each value. Negative IDs are ignored.
+    values : array_like, shape (n,)
+        Values to aggregate. Must be strictly positive.
+    weights : array_like, shape (n,), optional
+        Weights associated with each value. If not provided, all weights
+        are taken to be 1.
+    where : array_like of bool, shape (n,), optional
+        Boolean mask indicating which items to include. If not provided,
+        all items are included.
+    out : ndarray of float, shape (n_groups,), optional
+        Output array. If provided, results are written in-place.
+
+    Returns
+    -------
+    out : ndarray of float, shape (n_groups,)
+        Weighted geometric mean for each group. Elements with no valid
+        items are left unchanged in ``out`` if provided, or contain
+        uninitialized values if ``out`` was created internally.
+
+    Examples
+    --------
+    >>> import numpy as np
+
+    >>> ids = [0, 0, 1, 1, 1]
+    >>> values = [1.0, 4.0, 1.0, 3.0, 9.0]
+    >>> weights = [1.0, 1.0, 1.0, 2.0, 1.0]
+
+    >>> aggregate_items_as_gmean(ids, values, weights=weights)
+    array([2., 3.])
+
+    Use ``where`` to filter items:
+
+    >>> where = [True, True, False, False, True]
+    >>> aggregate_items_as_gmean(ids, values, where=where)
+    array([2., 9.])
+
+    Reuse an output array:
+
+    >>> out = np.full(2, np.nan)
+    >>> where = [True, True, False, False, False]
+    >>> aggregate_items_as_gmean(ids, values, out=out, where=where)
+    array([ 2., nan])
+    >>> out
+    array([ 2., nan])
+    """
+    ids, values = np.asarray(ids), np.asarray(values)
+
+    require_array(ids, dtype=np.integer, contiguous=True, shape=("n",), name="ids")
+
+    n_items, max_id = ids.shape[0], np.max(ids)
+
+    max_id = np.max(ids)
+    if out is None:
+        out = np.empty(max_id + 1, dtype=float)
+    out = require_array(np.asarray(out), shape=("n_items",), name="out")
+    require_length_at_least(out, max_id + 1, name="out")
+
+    if where is None:
+        where = np.full(n_items, True, dtype=np.bool_)
+    where = require_array(np.asarray(where), shape=(n_items,), name="where")
+
+    if not np.any(where):
+        return out
+
+    if weights is None:
+        weights = np.ones(n_items, dtype=float)
+    weights = np.asarray(weights)
+
+    out = require_array(out, writable=True, contiguous=True, dtype=float, name="out")
+    values = require_array(values, shape=(n_items,), contiguous=True, name="values")
+    weights = require_array(weights, shape=(n_items,), contiguous=True, name="weights")
+    where = require_array(where, contiguous=True, dtype=np.bool_, name="where")
+
+    require_greater_than(values[where], 0.0, name="values")
+    require_greater_than_or_equal(weights[where], 0.0, name="weights")
+
+    _aggregate_items_as_gmean(out, ids, values, weights, where)
 
     return out
 

--- a/tests/data_record/test_aggregators.py
+++ b/tests/data_record/test_aggregators.py
@@ -1,6 +1,9 @@
 import numpy as np
 import pytest
+import requireit
+from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
+from scipy.stats import gmean
 
 from landlab.data_record._aggregators import (
     aggregate_items_as_count as _aggregate_items_as_count,
@@ -12,6 +15,7 @@ from landlab.data_record._aggregators import (
     aggregate_items_as_sum as _aggregate_items_as_sum,
 )
 from landlab.data_record.aggregators import aggregate_items_as_count
+from landlab.data_record.aggregators import aggregate_items_as_gmean
 from landlab.data_record.aggregators import aggregate_items_as_mean
 from landlab.data_record.aggregators import aggregate_items_as_sum
 
@@ -151,3 +155,119 @@ def test_mean_with_negative_links():
     )
 
     assert_array_equal(out, 0.0)
+
+
+def test_aggregate_items_as_gmean():
+    ids = np.asarray([0, 0, 1, 1])
+    values = np.asarray([1.0, 4.0, 3.0, 12.0])
+
+    actual = aggregate_items_as_gmean(ids, values)
+    expected = [gmean(values[ids == 0]), gmean(values[ids == 1])]
+
+    assert_allclose(actual, expected)
+
+
+def test_aggregate_items_as_gmean_with_weights():
+    ids = np.array([0, 0, 1, 1, 1])
+    values = np.array([1.0, 4.0, 1.0, 3.0, 9.0])
+    weights = np.array([1.0, 1.0, 1.0, 2.0, 1.0])
+
+    actual = aggregate_items_as_gmean(ids, values, weights=weights)
+    expected = [
+        gmean(values[ids == 0], weights=weights[ids == 0]),
+        gmean(values[ids == 1], weights=weights[ids == 1]),
+    ]
+
+    assert_allclose(actual, expected)
+
+
+def test_aggregate_items_as_gmean_with_where():
+    ids = np.array([0, 0, 1, 1, 1])
+    values = np.array([1.0, 4.0, 1.0, 3.0, 9.0])
+    where = np.array([True, True, False, False, True])
+
+    actual = aggregate_items_as_gmean(ids, values, where=where)
+    expected = [gmean(values[(ids == 0) & where]), gmean(values[(ids == 1) & where])]
+
+    assert_allclose(actual, expected)
+
+
+def test_aggregate_items_as_gmean_ignores_negative_ids():
+    ids = [0, -1, 0, 1]
+    values = [2.0, 100.0, 8.0, 9.0]
+
+    actual = aggregate_items_as_gmean(ids, values)
+
+    assert_allclose(actual, [4.0, 9.0])
+
+
+def test_aggregate_items_as_gmean_leaves_unselected_out_values_unchanged():
+    ids = np.array([0, 2])
+    values = np.array([4.0, 9.0])
+    out = np.array([-1.0, -2.0, -3.0, -4.0])
+
+    actual = aggregate_items_as_gmean(ids, values, out=out)
+
+    assert actual is out
+    assert_allclose(actual, [4.0, -2.0, 9.0, -4.0])
+
+
+def test_aggregate_items_as_gmean_nowhere_is_noop():
+    ids = [0, 1, 2]
+    values = [4.0, 9.0, 16.0]
+    where = [False, False, False]
+    out = np.array([-1.0, -2.0, -3.0])
+
+    actual = aggregate_items_as_gmean(ids, values, where=where, out=out)
+
+    assert actual is out
+    assert_array_equal(actual, [-1.0, -2.0, -3.0])
+
+
+def test_aggregate_items_as_gmean_only_validates_selected_values():
+    ids = [0, 1]
+    values = [4.0, -1.0]
+    where = [True, False]
+
+    actual = aggregate_items_as_gmean(ids, values, where=where, out=np.full(2, np.nan))
+
+    assert_allclose(actual, [4.0, np.nan], equal_nan=True)
+
+
+@pytest.mark.parametrize("bad_values", [[0.0], [-1.0]])
+def test_aggregate_items_as_gmean_rejects_nonpositive_selected_values(bad_values):
+    with pytest.raises(requireit.ValidationError):
+        aggregate_items_as_gmean([0], bad_values)
+
+
+def test_aggregate_items_as_gmean_rejects_negative_selected_weights():
+    with pytest.raises(requireit.ValidationError):
+        aggregate_items_as_gmean([0], [1.0], weights=[-1.0])
+
+
+def test_aggregate_items_as_gmean_allows_zero_weight():
+    actual = aggregate_items_as_gmean([0, 0], [2.0, 8.0], weights=[0.0, 1.0])
+
+    assert_allclose(actual, [8.0])
+
+
+def test_aggregate_items_as_gmean_rejects_out_that_is_too_small():
+    out = np.empty(2, dtype=float)
+    with pytest.raises(requireit.ValidationError):
+        aggregate_items_as_gmean([0, 2], [1.0, 4.0], out=out)
+
+
+@pytest.mark.parametrize(
+    "kwds",
+    [
+        pytest.param({"values": [1.0, 2.0]}, id="values"),
+        pytest.param({"weights": [1.0, 1.0]}, id="weights"),
+        pytest.param({"where": [True, False]}, id="where"),
+    ],
+)
+def test_aggregate_items_as_gmean_rejects_shape_mismatch(kwds):
+    args = {"ids": [0], "values": [1.0]}
+    args.update(kwds)
+
+    with pytest.raises(requireit.ValidationError):
+        aggregate_items_as_gmean(**args)


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've added `aggregate_items_as_gmean`, a grouped weighted geometric-mean aggregator for DataRecord-style item aggregation that mirrors the existing aggregators.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
