### PR TITLE
Drop support for Python 3.11

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -21,7 +21,7 @@ runs:
         path: ${{ github.workspace }}/dist
 
     - name: Test
-      shell: bash -l {0}
+      shell: bash
       run: |
         pip install nox
         nox --verbose -s ${{ inputs.nox-session }} \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,23 +43,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: macos-15-intel, cibw-only: cp311-macosx_x86_64 }
           - { os: macos-15-intel, cibw-only: cp312-macosx_x86_64 }
           - { os: macos-15-intel, cibw-only: cp313-macosx_x86_64 }
           - { os: macos-15-intel, cibw-only: cp314-macosx_x86_64 }
-          - { os: macos-latest, cibw-only: cp311-macosx_arm64 }
           - { os: macos-latest, cibw-only: cp312-macosx_arm64 }
           - { os: macos-latest, cibw-only: cp313-macosx_arm64 }
           - { os: macos-latest, cibw-only: cp314-macosx_arm64 }
-          - { os: ubuntu-latest, cibw-only: cp311-manylinux_x86_64 }
           - { os: ubuntu-latest, cibw-only: cp312-manylinux_x86_64 }
           - { os: ubuntu-latest, cibw-only: cp313-manylinux_x86_64 }
           - { os: ubuntu-latest, cibw-only: cp314-manylinux_x86_64 }
-          - { os: ubuntu-24.04-arm, cibw-only: cp311-manylinux_aarch64 }
           - { os: ubuntu-24.04-arm, cibw-only: cp312-manylinux_aarch64 }
           - { os: ubuntu-24.04-arm, cibw-only: cp313-manylinux_aarch64 }
           - { os: ubuntu-24.04-arm, cibw-only: cp314-manylinux_aarch64 }
-          - { os: windows-2022, cibw-only: cp311-win_amd64 }
           - { os: windows-2022, cibw-only: cp312-win_amd64 }
           - { os: windows-2022, cibw-only: cp313-win_amd64 }
           - { os: windows-2022, cibw-only: cp314-win_amd64 }
@@ -84,7 +79,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-15-intel, macos-latest, windows-latest]
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13", "3.14"]
         pytest-marker: ["slow", "not slow"]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,14 +30,13 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Cython",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: Implementation :: CPython",
   "Topic :: Scientific/Engineering :: Physics",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
   "bmipy",
   "importlib-resources; python_version < '3.12'",


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've removed Python 3.11 from our CI testing. Landlab now requires Python >= 3.12.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
