### PR TITLE
Add masked aggregation support to the DataRecord aggregators

### DIFF
--- a/news/2418.feature
+++ b/news/2418.feature
@@ -1,0 +1,2 @@
+Added support for masked aggregation, through a `where` argument, to DataRecord
+aggregation helpers.

--- a/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
+++ b/src/landlab/components/network_sediment_transporter/network_sediment_transporter.py
@@ -392,6 +392,7 @@ class NetworkSedimentTransporter(Component):
 
         self._d_mean_active = np.full(self.grid.number_of_links, np.nan)
         self._rhos_mean_active = np.full(self.grid.number_of_links, np.nan)
+        self._vol_tot = np.full(self.grid.number_of_links, np.nan)
 
         # Adjust topographic elevation based on the parcels present.
         # Note that at present FlowDirector is just used for network connectivity.
@@ -467,24 +468,27 @@ class NetworkSedimentTransporter(Component):
 
     def _calculate_mean_D_and_rho(self) -> None:
         """Calculate mean grain size and density on each link"""
-        self._rhos_mean_active[:] = aggregate_items_as_mean(
-            self._parcels.dataset["element_id"].values[:, -1].astype(int),
-            self._parcels.dataset["density"].values,
-            weights=self._parcels.dataset["volume"].values[:, -1],
-            size=self._grid.number_of_links,
-        )
-
         ids = self._parcels.dataset.element_id.values[:, -1].astype(int)
         parcel_diameter = self._parcels.dataset.D.values[:, -1]
         parcel_volume = self._parcels.dataset.volume.values[:, -1]
-        is_active = self._parcels.dataset.active_layer[:, -1] == 1
+        is_active = self._parcels.dataset.active_layer[:, -1].astype(bool)
+        is_valid = is_active & (ids >= 0)
+
+        self._rhos_mean_active.fill(np.nan)
+        aggregate_items_as_mean(
+            ids,
+            self._parcels.dataset["density"].values,
+            weights=parcel_volume,
+            where=is_valid,
+            out=self._rhos_mean_active,
+        )
 
         self._d_mean_active.fill(np.nan)
         aggregate_items_as_gmean(
             ids,
             parcel_diameter,
             weights=parcel_volume,
-            where=is_active,
+            where=is_valid,
             out=self._d_mean_active,
         )
 
@@ -501,11 +505,12 @@ class NetworkSedimentTransporter(Component):
         active or storage layer during this timestep, then updates node
         elevations.
         """
-        self._vol_tot = aggregate_items_as_sum(
-            self._parcels.dataset["element_id"].values[:, -1].astype(int),
-            self._parcels.dataset["volume"].values[:, -1],
-            size=self._grid.number_of_links,
-        )
+        ids = self._parcels.dataset["element_id"].values[:, -1].astype(int)
+        parcel_volume = self._parcels.dataset["volume"].values[:, -1]
+        is_valid = ids >= 0
+
+        self._vol_tot.fill(0.0)
+        aggregate_items_as_sum(ids, parcel_volume, where=is_valid, out=self._vol_tot)
 
         if self._active_layer_method == "WongParker":
             # Wong et al. (2007) approximation for active layer thickness.
@@ -601,19 +606,15 @@ class NetworkSedimentTransporter(Component):
                 active_inactive[make_active] = _ACTIVE
 
         self._parcels.dataset.active_layer[:, -1] = active_inactive
+        is_active = self._parcels.dataset.active_layer[:, -1].astype(bool)
+        parcel_volumes = self._parcels.dataset.volume.values[:, -1]
 
-        # set active here. reference it below in wilcock crowe
-        self._active_parcel_records = (
-            self._parcels.dataset.active_layer == _ACTIVE
-        ) * (self._this_timesteps_parcels)
-
-        parcel_volumes = self._parcels.dataset.volume.values[:, -1].copy()
-        parcel_volumes[~self._active_parcel_records.values[:, -1].astype(bool)] = 0.0
-
-        self._vol_act = aggregate_items_as_sum(
-            self._parcels.dataset["element_id"].values[:, -1].astype(int),
+        self._vol_act = np.full(self.grid.number_of_links, 0.0, dtype=float)
+        aggregate_items_as_sum(
+            ids,
             parcel_volumes,
-            size=self._grid.number_of_links,
+            where=is_active & is_valid,
+            out=self._vol_act,
         )
 
         self._vol_stor = (
@@ -700,20 +701,19 @@ class NetworkSedimentTransporter(Component):
         D_mean_activearray = np.full(self._num_parcels, np.nan)
         active_layer_thickness_array = np.full(self._num_parcels, np.nan)
 
-        # find active sand
-        # since find active already sets all prior timesteps to False, we
-        # can use D for all timesteps here.
-        findactivesand = (
-            self._parcels.dataset.D < _SAND_SIZE
-        ) * self._active_parcel_records
+        is_active = self._parcels.dataset.active_layer[:, -1].astype(bool)
+        parcel_volume = self._parcels.dataset.volume.values[:, -1]
+        parcel_diameter = self._parcels.dataset.D.values[:, -1]
+        ids = self._parcels.dataset["element_id"].values[:, -1].astype(int)
 
-        parcel_volumes = self._parcels.dataset.volume.values[:, -1].copy()
-        parcel_volumes[~findactivesand[:, -1].astype(bool)] = 0.0
+        is_valid = is_active & (ids >= 0)
 
-        vol_act_sand = aggregate_items_as_sum(
-            self._parcels.dataset["element_id"].values[:, -1].astype(int),
-            parcel_volumes,
-            size=self._grid.number_of_links,
+        vol_act_sand = np.full(self.grid.number_of_links, np.nan)
+        aggregate_items_as_sum(
+            ids,
+            parcel_volume,
+            where=is_valid & (parcel_diameter < _SAND_SIZE),
+            out=vol_act_sand,
         )
 
         frac_sand = np.zeros_like(self._vol_act)
@@ -722,17 +722,12 @@ class NetworkSedimentTransporter(Component):
         )
         frac_sand[np.isnan(frac_sand)] = 0.0
 
-        ids = self._parcels.dataset.element_id.values[:, -1].astype(int)
-        parcel_diameter = self._parcels.dataset.D.values[:, -1]
-        parcel_volume = self._parcels.dataset.volume.values[:, -1]
-        is_active = self._parcels.dataset.active_layer[:, -1] == 1
-
         self._d_mean_active.fill(np.nan)
         aggregate_items_as_gmean(
             ids,
-            np.ascontiguousarray(parcel_diameter),
-            weights=np.ascontiguousarray(parcel_volume),
-            where=is_active,
+            parcel_diameter,
+            weights=parcel_volume,
+            where=is_valid,
             out=self._d_mean_active,
         )
 

--- a/src/landlab/data_record/_aggregators.pyx
+++ b/src/landlab/data_record/_aggregators.pyx
@@ -28,122 +28,170 @@ ctypedef fused float_or_int_weights:
     cython.floating
 
 
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef void aggregate_items_as_count(
-    integral_out_t [:] out,
-    const id_t [:] element_of_item,
-) noexcept nogil:
-    cdef long number_of_elements = len(out)
-    cdef long number_of_items = len(element_of_item)
-    cdef int item, element
+ctypedef enum AggregateItemsError:
+    OK = 0
+    MEMORY_ERROR = 1
+    ZERO_TOTAL_WEIGHT_ERROR = 2
 
-    for element in prange(number_of_elements, nogil=True, schedule="static"):
-        out[element] = 0
-
-    for item in range(number_of_items):
-        element = element_of_item[item]
-        if element >= 0:
-            out[element] = out[element] + 1
+AGGREGATE_ITEMS_OK = <uint8_t>OK
+AGGREGATE_ITEMS_MEMORY_ERROR = <uint8_t>MEMORY_ERROR
+AGGREGATE_ITEMS_ZERO_TOTAL_WEIGHT = <uint8_t>ZERO_TOTAL_WEIGHT_ERROR
 
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef void aggregate_items_as_sum(
-    cython.floating [:] out,
-    const id_t [:] element_of_item,
-    const float_or_int [:] value_of_item,
-) noexcept nogil:
-    cdef long number_of_elements = len(out)
-    cdef long number_of_items = len(element_of_item)
-    cdef int item, element
-
-    for element in prange(number_of_elements, nogil=True, schedule="static"):
-        out[element] = 0
-
-    for item in range(number_of_items):
-        element = element_of_item[item]
-        if element >= 0:
-            out[element] = out[element] + value_of_item[item]
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-cpdef void aggregate_items_as_mean(
-    cython.floating [:] out,
-    const id_t [:] element_of_item,
-    const float_or_int [:] value_of_item,
-    const float_or_int_weights [:] weight_of_item,
-) noexcept nogil:
-    cdef long number_of_elements = len(out)
-    cdef long number_of_items = len(element_of_item)
-    cdef int item, element
-    cdef double * total_weight_at_element = <double *>malloc(
-        number_of_elements * sizeof(double)
-    )
-
-    try:
-        for element in prange(number_of_elements, nogil=True, schedule="static"):
-            out[element] = 0.0
-            total_weight_at_element[element] = 0.0
-
-        for item in range(number_of_items):
-            element = element_of_item[item]
-            if element >= 0:
-                out[element] = out[element] + value_of_item[item] * weight_of_item[item]
-                total_weight_at_element[element] = (
-                    total_weight_at_element[element] + weight_of_item[item]
-                )
-
-        for element in range(number_of_elements):
-            if total_weight_at_element[element] > 0:
-                out[element] = out[element] / total_weight_at_element[element]
-    finally:
-        free(total_weight_at_element)
-
-
-@cython.boundscheck(False)
-@cython.wraparound(False)
-@cython.nonecheck(False)
-cpdef void aggregate_items_as_gmean(
-    cython.floating [::1] out,
+cpdef uint8_t aggregate_items_as_count(
+    integral_out_t [::1] out,
     const id_t [::1] element_of_item,
-    const float_or_int [::1] value_of_item,
-    const float_or_int_weights [::1] weight_of_item,
     const uint8_t[::1] where,
 ) noexcept nogil:
     cdef Py_ssize_t number_of_elements = len(out)
     cdef Py_ssize_t number_of_items = len(element_of_item)
     cdef Py_ssize_t item
     cdef Py_ssize_t element
+
+    for element in prange(number_of_elements, nogil=True, schedule="static"):
+        out[element] = 0
+
+    for item in range(number_of_items):
+        if not where[item]:
+            continue
+        element = element_of_item[item]
+        out[element] = out[element] + 1
+
+    return OK
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cpdef uint8_t aggregate_items_as_sum(
+    cython.floating [::1] out,
+    const id_t [::1] element_of_item,
+    const float_or_int [::1] value_of_item,
+    const uint8_t[::1] where,
+) noexcept nogil:
+    cdef long number_of_elements = len(out)
+    cdef long number_of_items = len(element_of_item)
+    cdef int item, element
+
+    for element in prange(number_of_elements, nogil=True, schedule="static"):
+        out[element] = 0
+
+    for item in range(number_of_items):
+        if not where[item]:
+            continue
+        element = element_of_item[item]
+        out[element] = out[element] + value_of_item[item]
+
+    return OK
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+cpdef uint8_t aggregate_items_as_mean(
+    cython.floating [::1] out,
+    const id_t [::1] element_of_item,
+    const float_or_int [::1] value_of_item,
+    const float_or_int_weights [::1] weight_of_item,
+    const uint8_t[::1] where,
+) noexcept nogil:
+    cdef uint8_t status = OK
+    cdef Py_ssize_t number_of_elements = len(out)
+    cdef Py_ssize_t number_of_items = len(element_of_item)
+    cdef Py_ssize_t item
+    cdef Py_ssize_t element
     cdef double weight
-    cdef double* total_weight = <double*>malloc(
-        number_of_elements * sizeof(double)
-    )
-    cdef double* total_weighted_log = <double*>malloc(
-        number_of_elements * sizeof(double)
-    )
+    cdef double * total_weight = <double *>malloc(number_of_elements * sizeof(double))
+    cdef double * total= <double *>malloc(number_of_elements * sizeof(double))
+    cdef uint8_t * touched= <uint8_t *>malloc(number_of_elements * sizeof(uint8_t))
+
+    if total_weight == NULL or total == NULL or touched == NULL:
+        free(total_weight)
+        free(total)
+        free(touched)
+        return MEMORY_ERROR
 
     try:
         for element in prange(number_of_elements, nogil=True, schedule="static"):
-            total_weighted_log[element] = 0.0
+            total[element] = 0.0
             total_weight[element] = 0.0
+            touched[element] = 0
 
         for item in range(number_of_items):
             if not where[item]:
                 continue
 
             element = element_of_item[item]
-            if element >= 0:
-                weight = weight_of_item[item]
-                total_weighted_log[element] = (
-                    total_weighted_log[element] + weight * log(value_of_item[item])
-                )
+            weight = weight_of_item[item]
+
+            total[element] = total[element] + value_of_item[item] * weight
+            total_weight[element] = total_weight[element] + weight
+            touched[element] = 1
+
+        for element in range(number_of_elements):
+            if total_weight[element] > 0:
+                out[element] = total[element] / total_weight[element]
+            elif touched[element] == 1:
+                status = ZERO_TOTAL_WEIGHT_ERROR
+    finally:
+        free(total)
+        free(total_weight)
+        free(touched)
+    return status
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.nonecheck(False)
+cpdef uint8_t aggregate_items_as_gmean(
+    cython.floating [::1] out,
+    const id_t [::1] element_of_item,
+    const float_or_int [::1] value_of_item,
+    const float_or_int_weights [::1] weight_of_item,
+    const uint8_t[::1] where,
+) noexcept nogil:
+    cdef uint8_t status = OK
+    cdef Py_ssize_t number_of_elements = len(out)
+    cdef Py_ssize_t number_of_items = len(element_of_item)
+    cdef Py_ssize_t item
+    cdef Py_ssize_t element
+    cdef double weight
+    cdef double* total_weight = <double*>malloc(number_of_elements * sizeof(double))
+    cdef double* total = <double*>malloc(number_of_elements * sizeof(double))
+    cdef uint8_t * touched = <uint8_t *>malloc(number_of_elements * sizeof(uint8_t))
+
+    if total_weight == NULL or total == NULL or touched == NULL:
+        free(total_weight)
+        free(total)
+        free(touched)
+        return MEMORY_ERROR
+
+    try:
+        for element in prange(number_of_elements, nogil=True, schedule="static"):
+            total[element] = 0.0
+            total_weight[element] = 0.0
+            touched[element] = 0
+
+        for item in range(number_of_items):
+            if not where[item]:
+                continue
+
+            element = element_of_item[item]
+            weight = weight_of_item[item]
+
+            if weight > 0.0:
+                total[element] = total[element] + weight * log(value_of_item[item])
                 total_weight[element] = total_weight[element] + weight
+            touched[element] = 1
 
         for element in range(number_of_elements):
             if total_weight[element] > 0.0:
-                out[element] = exp(total_weighted_log[element] / total_weight[element])
+                out[element] = exp(total[element] / total_weight[element])
+            elif touched[element]:
+                status = ZERO_TOTAL_WEIGHT_ERROR
     finally:
         free(total_weight)
-        free(total_weighted_log)
+        free(total)
+        free(touched)
+    return status

--- a/src/landlab/data_record/aggregators.py
+++ b/src/landlab/data_record/aggregators.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 from numpy.typing import ArrayLike
 from numpy.typing import NDArray
 from requireit import require_array
+from requireit import require_between
 from requireit import require_greater_than
 from requireit import require_greater_than_or_equal
 from requireit import require_length_at_least
 
+from landlab.data_record._aggregators import AGGREGATE_ITEMS_MEMORY_ERROR
+from landlab.data_record._aggregators import AGGREGATE_ITEMS_ZERO_TOTAL_WEIGHT
 from landlab.data_record._aggregators import (
     aggregate_items_as_count as _aggregate_items_as_count,
 )
@@ -22,8 +27,19 @@ from landlab.data_record._aggregators import (
 )
 
 
+@dataclass(frozen=True)
+class PreparedAggregatorInputs:
+    ids: NDArray[np.integer]
+    active: NDArray[np.bool_]
+    out: NDArray
+
+
 def aggregate_items_as_sum(
-    ids: ArrayLike, values: ArrayLike, size: int | None = None
+    ids: ArrayLike,
+    values: ArrayLike,
+    *,
+    where: ArrayLike | None = None,
+    out: NDArray[np.floating] | None = None,
 ) -> NDArray[np.floating]:
     """Find the sum of values associated with an id.
 
@@ -33,9 +49,11 @@ def aggregate_items_as_sum(
         An array of ids.
     values : array_like
         The value associated with the corresponding id in the `id` array.
-    size : int, optional
-        The size of the output array. This is useful if the `ids`
-        array doesn't contain all possible ids.
+    where : array_like of bool, shape (n,), optional
+        Boolean mask indicating which items to include. If not provided,
+        all items are included.
+    out : ndarray of float, shape (n_groups,), optional
+        Output array. If provided, results are written in-place.
 
     Returns
     -------
@@ -47,31 +65,29 @@ def aggregate_items_as_sum(
     >>> from landlab.data_record.aggregators import aggregate_items_as_sum
     >>> aggregate_items_as_sum([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5])
     array([3., 3., 0., 3., 1., 5.])
-    >>> aggregate_items_as_sum([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5], size=8)
+
+    >>> out = np.full(8, -1, dtype=float)
+    >>> aggregate_items_as_sum([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5], out=out)
     array([3., 3., 0., 3., 1., 5., 0., 0.])
-
-    Negative ids are ignored.
-
-    >>> aggregate_items_as_sum([0, -1, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5])
-    array([1., 3., 0., 3., 1., 5.])
     """
-    values = np.asarray(values, dtype=float)
-    ids = np.asarray(ids, dtype=int)
+    inputs = _prepare_aggregator_inputs(ids, where=where, out=out)
+    n_items = len(inputs.ids)
 
-    size = _validate_size(ids, size=size)
+    values = np.ascontiguousarray(values, dtype=float)
+    require_array(values, shape=(n_items,), contiguous=True, name="values")
 
-    out = np.empty(size, dtype=float)
+    _aggregate_items_as_sum(inputs.out, inputs.ids, values, inputs.active)
 
-    _aggregate_items_as_sum(out, ids, values)
-
-    return out
+    return inputs.out
 
 
 def aggregate_items_as_mean(
     ids: ArrayLike,
     values: ArrayLike,
+    *,
     weights: ArrayLike | None = None,
-    size: int | None = None,
+    where: ArrayLike | None = None,
+    out: NDArray[np.floating] | None = None,
 ) -> NDArray[np.floating]:
     """Find the mean of values associated with an id.
 
@@ -81,9 +97,11 @@ def aggregate_items_as_mean(
         An array of ids.
     values : array_like
         The value associated with the corresponding id in the `id` array.
-    size : int, optional
-        The size of the output array. This is useful if the `ids`
-        array doesn't contain all possible ids.
+    where : array_like of bool, shape (n,), optional
+        Boolean mask indicating which items to include. If not provided,
+        all items are included.
+    out : ndarray of float, shape (n_groups,), optional
+        Output array. If provided, results are written in-place.
 
     Returns
     -------
@@ -95,30 +113,38 @@ def aggregate_items_as_mean(
     >>> from landlab.data_record.aggregators import aggregate_items_as_mean
     >>> aggregate_items_as_mean([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5])
     array([1.5, 3. , 0. , 3. , 1. , 5. ])
-    >>> aggregate_items_as_mean([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5], size=8)
+
+    >>> out = np.zeros(8, dtype=float)
+    >>> aggregate_items_as_mean([0, 0, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5], out=out)
     array([1.5, 3. , 0. , 3. , 1. , 5. , 0. , 0. ])
-
-    Negative ids are ignored.
-
-    >>> aggregate_items_as_mean([0, -1, 1, 3, 4, 5], [1, 2, 3, 3, 1, 5])
-    array([1., 3., 0., 3., 1., 5.])
     """
-    values = np.asarray(values)
+    inputs = _prepare_aggregator_inputs(ids, where=where, out=out)
+    n_items = len(inputs.ids)
+
+    if not np.any(inputs.active):
+        return inputs.out
+
+    values = np.ascontiguousarray(values)
+
     if weights is None:
-        weights = np.ones_like(values)
-    else:
-        weights = np.asarray(weights, dtype=values.dtype)
-    ids = np.asarray(ids, dtype=int)
+        weights = np.ones(n_items, dtype=float)
+    weights = np.ascontiguousarray(weights)
 
-    size = _validate_size(ids, size=size)
+    values = require_array(values, shape=(n_items,), contiguous=True, name="values")
+    weights = require_array(weights, shape=(n_items,), contiguous=True, name="weights")
 
-    out = np.empty(size, dtype=float)
+    require_greater_than_or_equal(weights[inputs.active], 0.0, name="weights")
 
-    assert len(values) == len(weights)
+    status = _aggregate_items_as_mean(
+        inputs.out, inputs.ids, values, weights, inputs.active
+    )
 
-    _aggregate_items_as_mean(out, ids, values, weights)
+    if status == AGGREGATE_ITEMS_MEMORY_ERROR:  # pragma: no cover
+        raise MemoryError("failed to allocate temporary workspace")
+    if status == AGGREGATE_ITEMS_ZERO_TOTAL_WEIGHT:
+        raise ValueError("weights must sum to a positive value for selected groups")
 
-    return out
+    return inputs.out
 
 
 def aggregate_items_as_gmean(
@@ -144,8 +170,9 @@ def aggregate_items_as_gmean(
         Weights associated with each value. If not provided, all weights
         are taken to be 1.
     where : array_like of bool, shape (n,), optional
-        Boolean mask indicating which items to include. If not provided,
-        all items are included.
+        Boolean mask indicating which items to include. If provided, ``out``
+        must also be provided so that groups with no selected items have a
+        defined output value.
     out : ndarray of float, shape (n_groups,), optional
         Output array. If provided, results are written in-place.
 
@@ -170,7 +197,7 @@ def aggregate_items_as_gmean(
     Use ``where`` to filter items:
 
     >>> where = [True, True, False, False, True]
-    >>> aggregate_items_as_gmean(ids, values, where=where)
+    >>> aggregate_items_as_gmean(ids, values, where=where, out=np.empty(2, dtype=float))
     array([2., 9.])
 
     Reuse an output array:
@@ -182,44 +209,41 @@ def aggregate_items_as_gmean(
     >>> out
     array([ 2., nan])
     """
-    ids, values = np.asarray(ids), np.asarray(values)
+    inputs = _prepare_aggregator_inputs(ids, where=where, out=out)
+    n_items = len(inputs.ids)
 
-    require_array(ids, dtype=np.integer, contiguous=True, shape=("n",), name="ids")
+    values = np.ascontiguousarray(values)
 
-    n_items, max_id = ids.shape[0], np.max(ids)
-
-    max_id = np.max(ids)
-    if out is None:
-        out = np.empty(max_id + 1, dtype=float)
-    out = require_array(np.asarray(out), shape=("n_items",), name="out")
-    require_length_at_least(out, max_id + 1, name="out")
-
-    if where is None:
-        where = np.full(n_items, True, dtype=np.bool_)
-    where = require_array(np.asarray(where), shape=(n_items,), name="where")
-
-    if not np.any(where):
-        return out
+    if not np.any(inputs.active):
+        return inputs.out
 
     if weights is None:
         weights = np.ones(n_items, dtype=float)
-    weights = np.asarray(weights)
+    weights = np.ascontiguousarray(weights)
 
-    out = require_array(out, writable=True, contiguous=True, dtype=float, name="out")
     values = require_array(values, shape=(n_items,), contiguous=True, name="values")
     weights = require_array(weights, shape=(n_items,), contiguous=True, name="weights")
-    where = require_array(where, contiguous=True, dtype=np.bool_, name="where")
 
-    require_greater_than(values[where], 0.0, name="values")
-    require_greater_than_or_equal(weights[where], 0.0, name="weights")
+    require_greater_than(values[inputs.active], 0.0, name="values")
+    require_greater_than_or_equal(weights[inputs.active], 0.0, name="weights")
 
-    _aggregate_items_as_gmean(out, ids, values, weights, where)
+    status = _aggregate_items_as_gmean(
+        inputs.out, inputs.ids, values, weights, inputs.active
+    )
 
-    return out
+    if status == AGGREGATE_ITEMS_MEMORY_ERROR:  # pragma: no cover
+        raise MemoryError("failed to allocate temporary workspace")
+    if status == AGGREGATE_ITEMS_ZERO_TOTAL_WEIGHT:
+        raise ValueError("weights must sum to a positive value for selected groups")
+
+    return inputs.out
 
 
 def aggregate_items_as_count(
-    ids: ArrayLike, size: int | None = None
+    ids: ArrayLike,
+    *,
+    where: ArrayLike | None = None,
+    out: NDArray[np.floating] | None = None,
 ) -> NDArray[np.int_]:
     """Count the number of time an id appears in an array.
 
@@ -227,9 +251,11 @@ def aggregate_items_as_count(
     ----------
     ids : array_like of int
         An array of ids.
-    size : int, optional
-        The size of the output array. This is useful if the `ids`
-        array doesn't contain all possible ids.
+    where : array_like of bool, shape (n,), optional
+        Boolean mask indicating which items to include. If not provided,
+        all items are included.
+    out : ndarray of float, shape (n_groups,), optional
+        Output array. If provided, results are written in-place.
 
     Returns
     -------
@@ -241,30 +267,51 @@ def aggregate_items_as_count(
     >>> from landlab.data_record.aggregators import aggregate_items_as_count
     >>> aggregate_items_as_count([1, 2, 3, 3, 1, 5])
     array([0, 2, 1, 2, 0, 1])
-    >>> aggregate_items_as_count([1, 2, 3, 3, 1, 5], size=8)
+
+    >>> aggregate_items_as_count([1, 2, 3, 3, 1, 5], out=np.empty(8, dtype=float))
     array([0, 2, 1, 2, 0, 1, 0, 0])
-
-    Negative ids are ignored.
-
-    >>> aggregate_items_as_count([1, 2, 3, 3, -1, 5])
-    array([0, 1, 1, 2, 0, 1])
     """
-    ids = np.asarray(ids, dtype=int)
+    inputs = _prepare_aggregator_inputs(ids, where=where, out=out, dtype=int)
 
-    size = _validate_size(ids, size=size)
+    _aggregate_items_as_count(inputs.out, inputs.ids, inputs.active)
 
-    out = np.empty(size, dtype=int)
-
-    _aggregate_items_as_count(out, ids)
-
-    return out
+    return inputs.out
 
 
-def _validate_size(ids: NDArray[np.int_], size: int | None = None):
-    if size is None:
-        size = ids.max() + 1
+def _prepare_aggregator_inputs(
+    ids: ArrayLike,
+    *,
+    dtype=float,
+    where: ArrayLike | None = None,
+    out: NDArray[np.floating | np.integer] | None = None,
+) -> PreparedAggregatorInputs:
+    if where is not None and out is None:
+        raise ValueError("'out' must be provided when 'where' is used")
+
+    ids = np.ascontiguousarray(ids)
+
+    require_array(ids, dtype=np.integer, contiguous=True, shape=("n",), name="ids")
+
+    n_items = ids.shape[0]
+
+    active = ids >= 0
+    if where is not None:
+        where = np.ascontiguousarray(where)
+        require_array(where, shape=(n_items,), name="where")
+        active &= where
+
+    if np.any(active):
+        n_groups = int(np.max(ids[active])) + 1
     else:
-        assert (
-            size >= ids.max() + 1
-        ), "size must be greater than or equal to the largest input id"
-    return size
+        n_groups = 0
+
+    if out is None:
+        out = np.empty(n_groups, dtype=dtype)
+    out = require_array(np.asarray(out), shape=("n_groups",), name="out")
+    require_length_at_least(out, n_groups, name="out")
+
+    require_between(ids[active], 0, len(out), inclusive_max=False, name="ids")
+    active = require_array(active, contiguous=True, dtype=np.bool_, name="where")
+    out = require_array(out, writable=True, contiguous=True, dtype=dtype, name="out")
+
+    return PreparedAggregatorInputs(ids=ids, active=active, out=out)

--- a/tests/components/network_sediment_transporter/test_transport.py
+++ b/tests/components/network_sediment_transporter/test_transport.py
@@ -179,10 +179,11 @@ def test_defined_parcel_transport():
     )  # single parcel, so qb = qbi
 
     # TEST A:
-    nst_qb = aggregate_items_as_sum(
+    nst_qb = np.zeros(nst._grid.number_of_links, dtype=float)
+    aggregate_items_as_sum(
         nst._parcels.dataset["element_id"].values[:, -1].astype(int),
         nst._qbi,
-        size=nst._grid.number_of_links,
+        out=nst_qb,
     )  # total sediment flux per unit width, m2/s
 
     # TEST B: transport via sum of parcel motion

--- a/tests/data_record/test_aggregators.py
+++ b/tests/data_record/test_aggregators.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import requireit
+from numpy import average
 from numpy.testing import assert_allclose
 from numpy.testing import assert_array_equal
 from scipy.stats import gmean
@@ -19,6 +20,15 @@ from landlab.data_record.aggregators import aggregate_items_as_gmean
 from landlab.data_record.aggregators import aggregate_items_as_mean
 from landlab.data_record.aggregators import aggregate_items_as_sum
 
+AGGREGATE = {
+    "mean": aggregate_items_as_mean,
+    "gmean": aggregate_items_as_gmean,
+}
+BENCH = {
+    "mean": average,
+    "gmean": gmean,
+}
+
 
 def test_count_bench_cython():
     n_links = 1000
@@ -26,7 +36,7 @@ def test_count_bench_cython():
     out = np.empty(n_links, dtype=int)
     link_of_parcel = np.zeros(n_parcels, dtype=int)
 
-    _aggregate_items_as_count(out, link_of_parcel)
+    _aggregate_items_as_count(out, link_of_parcel, np.full(n_parcels, True))
 
     assert_array_equal(out[0], 100000)
     assert_array_equal(out[1:], 0)
@@ -38,10 +48,12 @@ def test_count_bench():
     n_parcels = 100000
     link_of_parcel = np.zeros(n_parcels, dtype=int)
 
-    out = aggregate_items_as_count(link_of_parcel, size=n_links)
+    out = np.full(n_links, -1, dtype=int)
+    actual = aggregate_items_as_count(link_of_parcel, out=out)
 
-    assert_array_equal(out[0], 100000)
-    assert_array_equal(out[1:], 0)
+    assert actual is out
+    assert_array_equal(actual[0], 100000)
+    assert_array_equal(actual[1:], 0)
 
 
 def test_sum_bench_cython():
@@ -50,8 +62,9 @@ def test_sum_bench_cython():
     out = np.empty(n_links, dtype=float)
     value_of_parcel = np.ones(n_parcels, dtype=float)
     link_of_parcel = np.zeros(n_parcels, dtype=int)
+    where = np.full(n_parcels, True, dtype=bool)
 
-    _aggregate_items_as_sum(out, link_of_parcel, value_of_parcel)
+    _aggregate_items_as_sum(out, link_of_parcel, value_of_parcel, where)
 
     assert_array_equal(out[0], 100000.0)
     assert_array_equal(out[1:], 0.0)
@@ -63,24 +76,29 @@ def test_sum_bench():
     value_of_parcel = np.ones(n_parcels, dtype=float)
     link_of_parcel = np.zeros(n_parcels, dtype=int)
 
-    out = aggregate_items_as_sum(link_of_parcel, value_of_parcel, size=n_links)
+    out = np.full(n_links, np.nan, dtype=float)
+    actual = aggregate_items_as_sum(link_of_parcel, value_of_parcel, out=out)
 
-    assert_array_equal(out[0], 100000.0)
-    assert_array_equal(out[1:], 0.0)
+    assert actual is out
+    assert_array_equal(actual[0], 100000.0)
+    assert_array_equal(actual[1:], 0.0)
 
 
 def test_mean_bench_cython():
     n_links = 100
     n_parcels = 100000
-    out = np.empty(n_links, dtype=float)
+    out = np.full(n_links, np.nan, dtype=float)
     value_of_parcel = np.ones(n_parcels, dtype=float)
     weight_of_parcel = np.ones(n_parcels, dtype=float)
     link_of_parcel = np.zeros(n_parcels, dtype=int)
+    where = np.full(n_parcels, True, dtype=bool)
 
-    _aggregate_items_as_mean(out, link_of_parcel, value_of_parcel, weight_of_parcel)
+    _aggregate_items_as_mean(
+        out, link_of_parcel, value_of_parcel, weight_of_parcel, where
+    )
 
     assert_array_equal(out[0], 1.0)
-    assert_array_equal(out[1:], 0.0)
+    assert np.all(np.isnan(out[1:]))
 
 
 def test_mean_bench():
@@ -89,16 +107,16 @@ def test_mean_bench():
     value_of_parcel = np.ones(n_parcels, dtype=float)
     weight_of_parcel = np.ones(n_parcels, dtype=float)
     link_of_parcel = np.zeros(n_parcels, dtype=int)
-
-    out = aggregate_items_as_mean(
+    out = np.full(n_links, np.nan)
+    aggregate_items_as_mean(
         link_of_parcel,
         value_of_parcel,
         weights=weight_of_parcel,
-        size=n_links,
+        out=out,
     )
 
     assert_array_equal(out[0], 1.0)
-    assert_array_equal(out[1:], 0.0)
+    assert np.all(np.isnan(out[1:]))
 
 
 def test_sum():
@@ -107,8 +125,11 @@ def test_sum():
     value_of_parcel = np.ones(n_parcels, dtype=float)
     link_of_parcel = np.arange(n_parcels, dtype=int) // n_links
 
-    out = aggregate_items_as_sum(link_of_parcel, value_of_parcel, size=n_links)
-    assert_array_equal(out, 10.0)
+    out = np.full(n_links, np.nan, dtype=float)
+    actual = aggregate_items_as_sum(link_of_parcel, value_of_parcel, out=out)
+
+    assert actual is out
+    assert_array_equal(actual, 10.0)
 
 
 def test_count():
@@ -151,10 +172,14 @@ def test_mean_with_negative_links():
     link_of_parcel = np.full(n_parcels, -1, dtype=int)
 
     out = aggregate_items_as_mean(
-        link_of_parcel, value_of_parcel, weights=weight_of_parcel
+        link_of_parcel,
+        value_of_parcel,
+        weights=weight_of_parcel,
+        where=link_of_parcel >= 0,
+        out=np.asarray([-1], dtype=float),
     )
 
-    assert_array_equal(out, 0.0)
+    assert_array_equal(out, -1)
 
 
 def test_aggregate_items_as_gmean():
@@ -181,44 +206,44 @@ def test_aggregate_items_as_gmean_with_weights():
     assert_allclose(actual, expected)
 
 
-def test_aggregate_items_as_gmean_with_where():
+@pytest.mark.parametrize("name", ("mean", "gmean"))
+def test_aggregate_items_as_gmean_with_where(name):
     ids = np.array([0, 0, 1, 1, 1])
     values = np.array([1.0, 4.0, 1.0, 3.0, 9.0])
     where = np.array([True, True, False, False, True])
+    out = np.empty(2, dtype=float)
 
-    actual = aggregate_items_as_gmean(ids, values, where=where)
-    expected = [gmean(values[(ids == 0) & where]), gmean(values[(ids == 1) & where])]
+    aggregate = AGGREGATE[name]
+    bench = BENCH[name]
+
+    actual = aggregate(ids, values, where=where, out=out)
+    expected = [bench(values[(ids == 0) & where]), bench(values[(ids == 1) & where])]
 
     assert_allclose(actual, expected)
 
 
-def test_aggregate_items_as_gmean_ignores_negative_ids():
-    ids = [0, -1, 0, 1]
-    values = [2.0, 100.0, 8.0, 9.0]
-
-    actual = aggregate_items_as_gmean(ids, values)
-
-    assert_allclose(actual, [4.0, 9.0])
-
-
-def test_aggregate_items_as_gmean_leaves_unselected_out_values_unchanged():
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_leaves_unselected_out_values_unchanged(name):
     ids = np.array([0, 2])
     values = np.array([4.0, 9.0])
     out = np.array([-1.0, -2.0, -3.0, -4.0])
 
-    actual = aggregate_items_as_gmean(ids, values, out=out)
+    aggregate = AGGREGATE[name]
+    actual = aggregate(ids, values, out=out)
 
     assert actual is out
     assert_allclose(actual, [4.0, -2.0, 9.0, -4.0])
 
 
-def test_aggregate_items_as_gmean_nowhere_is_noop():
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_nowhere_is_noop(name):
     ids = [0, 1, 2]
     values = [4.0, 9.0, 16.0]
     where = [False, False, False]
     out = np.array([-1.0, -2.0, -3.0])
 
-    actual = aggregate_items_as_gmean(ids, values, where=where, out=out)
+    aggregate = AGGREGATE[name]
+    actual = aggregate(ids, values, where=where, out=out)
 
     assert actual is out
     assert_array_equal(actual, [-1.0, -2.0, -3.0])
@@ -240,21 +265,28 @@ def test_aggregate_items_as_gmean_rejects_nonpositive_selected_values(bad_values
         aggregate_items_as_gmean([0], bad_values)
 
 
-def test_aggregate_items_as_gmean_rejects_negative_selected_weights():
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_rejects_negative_selected_weights(name):
+    aggregate = AGGREGATE[name]
     with pytest.raises(requireit.ValidationError):
-        aggregate_items_as_gmean([0], [1.0], weights=[-1.0])
+        aggregate([0], [1.0], weights=[-1.0])
 
 
-def test_aggregate_items_as_gmean_allows_zero_weight():
-    actual = aggregate_items_as_gmean([0, 0], [2.0, 8.0], weights=[0.0, 1.0])
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_allows_zero_weight(name):
+    aggregate = AGGREGATE[name]
+    actual = aggregate([0, 0], [2.0, 8.0], weights=[0.0, 1.0])
 
     assert_allclose(actual, [8.0])
 
 
-def test_aggregate_items_as_gmean_rejects_out_that_is_too_small():
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_rejects_out_that_is_too_small(name):
     out = np.empty(2, dtype=float)
+
+    aggregate = AGGREGATE[name]
     with pytest.raises(requireit.ValidationError):
-        aggregate_items_as_gmean([0, 2], [1.0, 4.0], out=out)
+        aggregate([0, 2], [1.0, 4.0], out=out)
 
 
 @pytest.mark.parametrize(
@@ -265,9 +297,27 @@ def test_aggregate_items_as_gmean_rejects_out_that_is_too_small():
         pytest.param({"where": [True, False]}, id="where"),
     ],
 )
-def test_aggregate_items_as_gmean_rejects_shape_mismatch(kwds):
-    args = {"ids": [0], "values": [1.0]}
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_rejects_shape_mismatch(name, kwds):
+    args = {"ids": [0], "values": [1.0], "out": np.empty(1, dtype=float)}
     args.update(kwds)
 
+    aggregate = AGGREGATE[name]
     with pytest.raises(requireit.ValidationError):
-        aggregate_items_as_gmean(**args)
+        aggregate(**args)
+
+
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_where_without_out(name):
+    aggregate = AGGREGATE[name]
+
+    with pytest.raises(ValueError, match="^'out' must be provided"):
+        aggregate([0, 0, 1], [1.0, 1.0, 1.0], where=[True, True])
+
+
+@pytest.mark.parametrize("name", ("gmean", "mean"))
+def test_aggregate_items_as_gmean_with_zero_weights(name):
+    aggregate = AGGREGATE[name]
+
+    with pytest.raises(ValueError, match="^weights must sum to a positive value"):
+        aggregate([0, 0, 1], [1.0, 1.0, 1.0], weights=[1, 1, 0])


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've added support for masked aggregation to the DataRecord aggregation helpers. All of the aggregation functions (`sum`, `mean`, `gmean`, `count`) now accept a `where` argument to restrict aggregation to a subset of items. When a mask is provided, an output array must also be supplied so that groups with no selected items have a defined value.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
