### PR TITLE
Add utilities for reindexing arrays and ids

### DIFF
--- a/news/2419.feature
+++ b/news/2419.feature
@@ -1,0 +1,1 @@
+Added utilities for reindexing arrays and remapping ids between old and new schemes.

--- a/src/landlab/graph/_reindexer.py
+++ b/src/landlab/graph/_reindexer.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+from numpy.typing import ArrayLike
+from numpy.typing import NDArray
+from requireit import raise_as
+from requireit import require_array
+from requireit import require_between
+from requireit import require_length
+from requireit import require_positive
+
+
+class Reindexer:
+    """Map arrays from an old indexing scheme to a new one.
+
+    Parameters
+    ----------
+    order : array_like of int
+        Permutation such that ``order[new_id] == old_id``. In other words,
+        this gives the old index of each item in the new ordering.
+    """
+
+    def __init__(self, order: ArrayLike) -> None:
+        order = np.asarray(order)
+        if order.ndim == 1 and order.size == 0:
+            order = order.astype(np.intp)
+
+        with raise_as(ValueError):
+            new_to_old = require_array(
+                order, shape=("n",), dtype=np.intp, allow_cast=True, name="order"
+            )
+        new_to_old = np.asarray(new_to_old, dtype=np.intp)
+
+        n = new_to_old.size
+        if n and (
+            np.any(new_to_old < 0)
+            or np.any(new_to_old >= n)
+            or np.unique(new_to_old).size != n
+        ):
+            raise ValueError("order must be a permutation of [0, n)")
+
+        self._new_to_old = new_to_old
+        self._old_to_new = np.empty_like(self._new_to_old, dtype=np.intp)
+        self._old_to_new[self._new_to_old] = np.arange(
+            self._new_to_old.size, dtype=np.intp
+        )
+
+    def __len__(self) -> int:
+        return self._new_to_old.size
+
+    def __repr__(self) -> str:
+        return f"Reindexer(size={len(self)})"
+
+    @classmethod
+    def from_xy(cls, xy: NDArray, axes: Iterable[int] | None = None) -> Reindexer:
+        """Create a reindexer from lexicographic sorting of coordinates."""
+        return cls(sort_order_from_coords(xy, axes=axes))
+
+    @classmethod
+    def from_ids(cls, ids: ArrayLike) -> Reindexer:
+        """Create a reindexer that orders elements by integer ids.
+
+        Parameters
+        ----------
+        ids : array_like of int
+            Array of integer ids that define the desired ordering. The returned
+            reindexer sorts elements in ascending order of `ids`, such that
+            elements with smaller ids appear first.
+
+        Returns
+        -------
+        Reindexer
+            A reindexer whose ordering is given by ``np.argsort(ids)``.
+
+        Notes
+        -----
+        This constructor is useful for deriving an ordering from a related
+        element type. For example, if each cell corresponds to a node via
+        `node_at_cell`, then ``Reindexer.from_ids(node_at_cell)`` produces
+        a cell ordering consistent with the current node ordering.
+
+        Ties in `ids` are resolved by the behavior of ``np.argsort``.
+        """
+        with raise_as(ValueError):
+            ids = require_array(
+                np.asarray(ids), shape=("n_ids",), dtype=np.integer, name="ids"
+            )
+        ids = np.asarray(ids, dtype=np.intp)
+
+        return cls(np.argsort(ids, kind="stable"))
+
+    def reorder(self, array: ArrayLike, out: NDArray | None = None) -> NDArray:
+        """Reorder an array along axis 0.
+
+        Parameters
+        ----------
+        array : array_like
+            Array whose first axis uses the old indexing.
+        out : ndarray, optional
+            Output array. Must have the same shape as `array`.
+
+        Returns
+        -------
+        ndarray
+            Array reordered so that axis 0 uses the new indexing.
+        """
+        with raise_as(ValueError):
+            array = require_length(np.asarray(array), length=len(self), name="array")
+
+        if out is None:
+            out = np.empty_like(array)
+        elif np.shares_memory(array, out):
+            raise ValueError("out must not share memory with array")
+
+        if out.shape != array.shape:
+            raise ValueError("out must have the same shape as array")
+        with raise_as(ValueError):
+            require_array(out, dtype=array.dtype, name="out")
+
+        out[:] = array[self._new_to_old]
+        return out
+
+    def remap(
+        self,
+        array: ArrayLike,
+        *,
+        fill_value: int | None = None,
+        out: NDArray | None = None,
+    ) -> NDArray:
+        """Remap integer ids from the old indexing to the new indexing.
+
+        Parameters
+        ----------
+        array : array_like of int
+            Integer id array expressed in the old indexing.
+        fill_value : int, optional
+            Sentinel value that should be left unchanged.
+        out : ndarray, optional
+            Output array. Must have the same shape as `array`.
+
+        Returns
+        -------
+        ndarray
+            Array with ids remapped into the new indexing.
+        """
+        with raise_as(ValueError):
+            array = require_array(
+                np.asarray(array, dtype=np.intp), dtype=np.integer, name="array"
+            )
+
+        if out is None:
+            out = np.empty_like(array)
+        elif np.shares_memory(array, out):
+            raise ValueError("out must not share memory with array")
+
+        if out.shape != array.shape:
+            raise ValueError("out must have the same shape as array")
+        with raise_as(ValueError):
+            require_array(out, dtype=np.integer, name="out")
+
+        if fill_value is None:
+            with raise_as(ValueError):
+                require_between(array, a_min=0, a_max=len(self) - 1)
+            out[...] = self._old_to_new[array]
+        else:
+            mask = array != fill_value
+            valid_ids = array[mask]
+            with raise_as(ValueError):
+                require_between(valid_ids, a_min=0, a_max=len(self) - 1)
+            out[...] = array
+            out[mask] = self._old_to_new[valid_ids]
+
+        return out
+
+
+def sort_order_from_coords(
+    coords: ArrayLike,
+    axes: Iterable[int] | None = None,
+    tol: float | None = None,
+) -> NDArray:
+    """Return indices that lexicographically sort coordinates.
+
+    Parameters
+    ----------
+    coords : array_like of ``shape (n, ndim)``
+        Coordinates to sort.
+    axes : tuple of int, optional
+        Permutation of coordinate axes that defines the sort priority.
+        The axes are interpreted from **least** significant to most
+        **significant** key (i.e., the last axis in the tuple is the
+        primary sort key). By default, axes are ``range(ndim)``, so the
+        last column is the primary key.
+    tol : float, optional
+        Quantization bin width. Coordinates are rounded to the nearest
+        multiple of `tol` before sorting, so two values are treated as
+        equal only if they are within ``tol / 2`` of the same multiple.
+        If ``None``, coordinates are compared exactly.
+
+    Returns
+    -------
+    ndarray of int
+        Indices that reorder `coords` into lexicographic order.
+
+    Notes
+    -----
+    Sorting is performed using ``np.lexsort``. Because of its semantics,
+    the last key has highest priority. For example, with ``axes=(1, 0)``,
+    sorting is primarily by column 0, and ties are broken by column 1.
+
+    Examples
+    --------
+    ::
+
+        1 --- 3
+        |     |
+        0 --- 2
+
+    >>> xy = np.asarray([[0, 0], [0, 1], [1, 0], [1, 1]], dtype=float)
+
+    The default is to first sort by column 1, and then column 0.
+
+    >>> order = sort_order_from_coords(xy)
+    >>> order
+    array([0, 2, 1, 3])
+    >>> xy[order]
+    array([[0., 0.],
+           [1., 0.],
+           [0., 1.],
+           [1., 1.]])
+
+    When specifying ``axes``, the last value gives the dimension with
+    the highest priority. For example, ``axes=(1, 0)`` sorts primarily
+    by column 0, and ties are broken by column 1.
+
+    >>> order = sort_order_from_coords(xy, axes=(1, 0))
+    >>> order
+    array([0, 1, 2, 3])
+    >>> xy[order]
+    array([[0., 0.],
+           [0., 1.],
+           [1., 0.],
+           [1., 1.]])
+    """
+    xy = np.asarray(coords)
+    if tol is not None:
+        with raise_as(ValueError):
+            tol = require_positive(tol, name="tol")
+
+    if xy.ndim != 2:
+        raise ValueError("coords must be 2D")
+
+    n_dim = xy.shape[1]
+    axes = range(n_dim) if axes is None else axes
+
+    if set(axes) != set(range(n_dim)):
+        raise ValueError(f"axes must be a permutation of {tuple(range(n_dim))}")
+
+    if tol is not None:
+        xy = np.round(xy / tol).astype(np.int64)
+
+    return np.lexsort(tuple(xy[:, axis] for axis in axes))

--- a/tests/graph/test_reindexer.py
+++ b/tests/graph/test_reindexer.py
@@ -1,0 +1,250 @@
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from landlab.graph._reindexer import Reindexer
+from landlab.graph._reindexer import sort_order_from_coords
+
+
+@pytest.mark.parametrize("order", ([0, 1, 2, 3], [3, 2, 1, 0], []))
+def test_order_length(order):
+    r = Reindexer(order)
+    assert len(r) == len(order)
+
+
+@pytest.mark.parametrize("order", ([1, 0, 2], []))
+def test_repr(order):
+    r = Reindexer(order)
+    assert repr(r) == f"Reindexer(size={len(order)})"
+
+
+@pytest.mark.parametrize(
+    "bad_order",
+    [
+        [0, 0, 2],  # duplicate
+        [0, 1, 3],  # out of range
+        [-1, 0, 1],  # negative
+        [1, 2],  # missing element
+    ],
+)
+def test_invalid_order_raises(bad_order):
+    with pytest.raises(ValueError, match="^order must be a permutation"):
+        Reindexer(bad_order)
+
+
+@pytest.mark.parametrize(
+    "order, array, expected",
+    [
+        ([0, 1, 2], [10, 20, 30], [10, 20, 30]),  # identity
+        ([2, 0, 1], [10, 20, 30], [30, 10, 20]),  # rotation
+        ([2, 1, 0], [10, 20, 30], [30, 20, 10]),  # reversal
+    ],
+)
+def test_reorder_1d(order, array, expected):
+    r = Reindexer(order)
+    assert_array_equal(r.reorder(array), expected)
+
+
+def test_reorder_2d():
+    r = Reindexer([1, 0])
+    array = np.array([[1, 2, 5], [3, 4, 0]])
+    assert_array_equal(r.reorder(array), [[3, 4, 0], [1, 2, 5]])
+
+
+def test_reorder_into_out():
+    r = Reindexer([2, 0, 1])
+    array = np.array([10, 20, 30])
+    out = np.full(3, -999, dtype=int)
+    result = r.reorder(array, out=out)
+    assert result is out
+    assert_array_equal(out, [30, 10, 20])
+
+
+def test_reorder_out_wrong_shape_raises():
+    r = Reindexer([1, 0])
+    with pytest.raises(ValueError, match="^out must have the same shape"):
+        r.reorder([10, 20], out=np.empty(3, dtype=int))
+
+
+def test_reorder_out_shared_memory_raises():
+    r = Reindexer([1, 0])
+    array = np.array([10, 20, -1])
+    with pytest.raises(ValueError, match="^out must not share memory"):
+        r.reorder(array[:2], out=array[-2:])
+
+
+def test_reorder_wrong_length_raises():
+    r = Reindexer([1, 0])
+    with pytest.raises(ValueError, match="^array must have length 2"):
+        r.reorder([10, 20, 30])
+
+
+@pytest.mark.parametrize(
+    "values", ([], np.array([], dtype=float), np.array([], dtype=int))
+)
+def test_reorder_empty(values):
+    r = Reindexer([])
+    assert_array_equal(r.reorder(values), values)
+
+
+@pytest.mark.parametrize(
+    "order, array, expected",
+    [
+        ([0, 1, 2], [0, 1, 2], [0, 1, 2]),  # identity
+        ([2, 0, 1], [0, 1, 2], [1, 2, 0]),  # rotation: old→new
+        ([2, 1, 0], [0, 1, 2], [2, 1, 0]),  # reversal
+    ],
+)
+def test_remap_1d(order, array, expected):
+    r = Reindexer(order)
+    assert_array_equal(r.remap(array), expected)
+
+
+def test_remap_2d():
+    r = Reindexer([1, 0, 2])
+    array = np.array([[0, 1], [2, 0]])
+    actual = r.remap(array)
+    assert_array_equal(actual, [[1, 0], [2, 1]])
+
+
+def test_remap_with_fill_value():
+    r = Reindexer([2, 0, 1])
+    array = np.array([0, -1, 1, -1, 2])
+    actual = r.remap(array, fill_value=-1)
+    assert_array_equal(actual, [1, -1, 2, -1, 0])
+
+
+def test_remap_fill_value_preserved():
+    r = Reindexer([1, 0])
+    array = np.array([-1, -1])
+    actual = r.remap(array, fill_value=-1)
+    assert_array_equal(actual, [-1, -1])
+
+
+def test_remap_into_out():
+    r = Reindexer([1, 0, 2])
+    array = np.array([0, 1, 2])
+    out = np.full(3, -999, dtype=int)
+    actual = r.remap(array, out=out)
+    assert actual is out
+    assert_array_equal(actual, [1, 0, 2])
+
+
+def test_remap_out_shared_memory_raises():
+    r = Reindexer([1, 0])
+    array = np.array([0, 1])
+    with pytest.raises(ValueError, match="^out must not share memory"):
+        r.remap(array, out=array)
+
+
+def test_remap_out_wrong_shape_raises():
+    r = Reindexer([1, 0])
+    array = np.array([0, 1])
+    with pytest.raises(ValueError, match="^out must have the same shape"):
+        r.remap(array, out=np.empty_like(array).reshape((2, -1)))
+
+
+def test_remap_out_wrong_dtype_raises():
+    r = Reindexer([1, 0])
+    array = np.array([0, 1])
+    with pytest.raises(ValueError, match="^out must have dtype"):
+        r.remap(array, out=np.empty_like(array, dtype=float))
+
+
+def test_remap_out_of_range_raises():
+    r = Reindexer([1, 0])
+    with pytest.raises(ValueError, match="^value must be <= 1"):
+        r.remap([0, 5])
+
+
+@pytest.mark.parametrize(
+    "array", ([], np.array([], dtype=float), np.array([], dtype=int))
+)
+def test_remap_empty(array):
+    r = Reindexer([])
+    assert_array_equal(r.remap(array), array)
+
+
+@pytest.mark.parametrize(
+    "ids, expected_order",
+    [
+        ([0, 1, 2], [0, 1, 2]),  # already sorted
+        ([2, 0, 1], [1, 2, 0]),  # argsort of ids
+        ([3, 1, 2], [1, 2, 0]),  # general case
+    ],
+)
+def test_from_ids_order(ids, expected_order):
+    r = Reindexer.from_ids(ids)
+    # reorder(ids) should give sorted ids
+    assert_array_equal(r.reorder(ids), sorted(ids))
+
+
+def test_from_ids_stable():
+    # Ties resolved stably: first occurrence keeps lower new index
+    ids = [1, 1, 0]
+    r = Reindexer.from_ids(ids)
+    result = r.reorder(ids)
+    assert result[0] == 0  # the 0 comes first
+    assert result[1] == result[2] == 1
+
+
+def test_from_xy_sorts_by_y_then_x():
+    # Default: primary key is last column (y), tie-break by x
+    xy = np.array([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], [1.0, 1.0]])
+    r = Reindexer.from_xy(xy)
+    sorted_xy = r.reorder(xy)
+    # Should be sorted by y first (ascending), then x
+    assert_array_equal(sorted_xy[:, 1], sorted(xy[:, 1]))
+
+
+def test_from_xy_axes_swap():
+    xy = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+    _ = Reindexer.from_xy(xy)  # primary key: col 1 (y)
+    r_swapped = Reindexer.from_xy(xy, axes=(1, 0))  # primary key: col 0 (x)
+    # With swapped axes, col-0 values should be non-decreasing
+    sorted_xy = r_swapped.reorder(xy)
+    assert all(sorted_xy[i, 0] <= sorted_xy[i + 1, 0] for i in range(len(xy) - 1))
+
+
+def test_sort_order_from_coords_basic():
+    xy = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+    order = sort_order_from_coords(xy)
+    assert_array_equal(order, [0, 2, 1, 3])
+
+
+@pytest.mark.parametrize(
+    "axes, expected",
+    [
+        ((0, 1), [0, 2, 1, 3]),  # primary key: col 1 (y)
+        ((1, 0), [0, 1, 2, 3]),  # primary key: col 0 (x)
+    ],
+)
+def test_sort_order_from_coords_axes(axes, expected):
+    xy = np.array([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]])
+    assert_array_equal(sort_order_from_coords(xy, axes=axes), expected)
+
+
+def test_sort_order_from_coords_tol():
+    # Two points differ by less than tol — treated as equal, sorted by other axis
+    xy = np.array([[0.0, 0.0], [0.001, 0.0], [1.0, 0.0]])
+    order = sort_order_from_coords(xy, tol=0.01)
+    # First two x-values are within tol, so secondary key (y=0 for all) doesn't
+    # distinguish them — but both come before x=1.0
+    assert order[2] == 2
+
+
+def test_sort_order_from_coords_not_2d_raises():
+    with pytest.raises(ValueError, match="coords must be 2D"):
+        sort_order_from_coords(np.array([0.0, 1.0, 2.0]))
+
+
+def test_sort_order_from_coords_bad_axes_raises():
+    xy = np.array([[0.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(ValueError, match="^axes must be a permutation of"):
+        sort_order_from_coords(xy, axes=(0, 2))
+
+
+def test_sort_order_from_coords_negative_tol_raises():
+    xy = np.array([[0.0, 0.0], [1.0, 1.0]])
+    with pytest.raises(ValueError, match="^tol must be > 0.0"):
+        sort_order_from_coords(xy, tol=-0.1)


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

## Summary

I've aded a new module, `_reindexer.py`, that contains utilities for reording and reindexing *Landlab* index arrays. This is useful when sorting, for example, nodes by *y* and then *x*, and then mapping value-at-node arrays from the old ordering to the new.

The `Reindexer` class stores a permutation between old and new ids and provides methods to:
* reorder arrays into the new ordering
* remap id arrays from old ids to new ids
* construct reindexers from *x*-*y* values

I've also added a `sort_order_from_coords` function that creates sort orders from *x*-*y* arrays.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
