### PR TITLE
Fix stale grid field aliases in TidalFlowCalculator

### DIFF
--- a/news/2431.bugfix
+++ b/news/2431.bugfix
@@ -1,0 +1,5 @@
+Fixed a bug where instance attributes that cached references to grid field arrays
+could silently point to stale data if another component replaced the underlying
+array in the grid. Fixed in the following components:
+
+* `TidalFlowCalculator`

--- a/src/landlab/components/tidal_flow/tidal_flow_calculator.py
+++ b/src/landlab/components/tidal_flow/tidal_flow_calculator.py
@@ -4,14 +4,16 @@ Calculate cycle-averaged tidal flow field using approach of Mariotti (2018)
 """
 
 import numpy as np
+from numpy.typing import ArrayLike
+from numpy.typing import NDArray
 from scipy.sparse.linalg import spsolve
 
 from landlab import Component
 from landlab import HexModelGrid
 from landlab import RasterModelGrid
+from landlab.field.errors import FieldError
 from landlab.grid.mappers import map_min_of_link_nodes_to_link
 from landlab.utils import get_core_node_matrix
-from landlab.utils.return_array import return_array_at_link
 
 _FOUR_THIRDS = 4.0 / 3.0
 _M2_PERIOD = (12.0 + (25.2 / 60.0)) * 3600.0  # M2 tidal period, in seconds
@@ -174,12 +176,6 @@ class TidalFlowCalculator(Component):
         super().__init__(grid)
         self.initialize_output_fields()
 
-        # Get references to various fields, for convenience
-        self._elev = self.grid.at_node["topographic__elevation"]
-        self._water_depth = self.grid.at_node["mean_water__depth"]
-        self._flood_tide_vel = self.grid.at_link["flood_tide_flow__velocity"]
-        self._ebb_tide_vel = self.grid.at_link["ebb_tide_flow__velocity"]
-
         # Handle inputs
         self.roughness = roughness  # uses setter below
         self._tidal_range = tidal_range
@@ -196,13 +192,25 @@ class TidalFlowCalculator(Component):
         self._boundary_mean_water_surf_elev = np.zeros(grid.number_of_nodes)
 
     @property
-    def roughness(self):
+    def roughness(self) -> NDArray:
         """Roughness coefficient (Manning's n)."""
+        if isinstance(self._roughness, str):
+            return self.grid.at_link[self._roughness]
         return self._roughness
 
     @roughness.setter
-    def roughness(self, new_val):
-        self._roughness = return_array_at_link(self.grid, new_val)
+    def roughness(self, new_val: str | ArrayLike) -> None:
+        if isinstance(new_val, str):
+            if new_val not in self.grid.at_link:
+                raise FieldError(new_val)
+        else:
+            new_val = np.asarray(new_val, copy=True).reshape(-1)
+            if new_val.size not in (1, self.grid.number_of_links):
+                raise ValueError(
+                    "roughness must be a scalar or array of length n_links"
+                )
+
+        self._roughness = new_val
 
     @property
     def tidal_range(self):
@@ -254,11 +262,10 @@ class TidalFlowCalculator(Component):
         -----
         This calculates I in Mariotti (2018) using his equation (1).
         """
+        z = self.grid.at_node["topographic__elevation"]
         return (
             self._tidal_half_range
-            - np.maximum(
-                -self._tidal_half_range, np.minimum(self._elev, self._tidal_half_range)
-            )
+            - np.clip(z, -self._tidal_half_range, self._tidal_half_range)
         ) / self._tidal_half_period
 
     def _calc_effective_water_depth(self):
@@ -278,12 +285,20 @@ class TidalFlowCalculator(Component):
         >>> tfc._water_depth[6:9]
         array([0.275, 0.02 , 2.   ])
         """
-        high_tide_depth = (self.mean_sea_level + self._tidal_half_range) - self._elev
-        low_tide_depth = np.maximum(
-            (self.mean_sea_level - self._tidal_half_range) - self._elev, 0.0
+        z = self.grid.at_node["topographic__elevation"]
+
+        high_tide_depth = (self.mean_sea_level + self._tidal_half_range) - z
+        low_tide_depth = np.clip(
+            (self.mean_sea_level - self._tidal_half_range) - z,
+            a_min=0.0,
+            a_max=None,
         )
-        self._water_depth[:] = (high_tide_depth + low_tide_depth) / 2.0
-        self._water_depth[self._water_depth <= self._min_depth] = self._min_depth
+        np.clip(
+            (high_tide_depth + low_tide_depth) / 2.0,
+            a_min=self._min_depth,
+            a_max=None,
+            out=self.grid.at_node["mean_water__depth"],
+        )
 
     def run_one_step(self):
         """Calculate the tidal flow field and water-surface elevation."""
@@ -296,7 +311,9 @@ class TidalFlowCalculator(Component):
 
         # Map water depth to links
         map_min_of_link_nodes_to_link(
-            self.grid, self._water_depth, out=self._water_depth_at_links
+            self.grid,
+            self.grid.at_node["mean_water__depth"],
+            out=self._water_depth_at_links,
         )
 
         # Calculate velocity and diffusion coefficients on links
@@ -332,8 +349,9 @@ class TidalFlowCalculator(Component):
 
         # Calculate flow velocity field at links for flood tide, and assign
         # negative of the flood tide values to ebb tide
-        self._flood_tide_vel[self.grid.active_links] = (
+        flood_tide_vel = self.grid.at_link["flood_tide_flow__velocity"]
+        flood_tide_vel[self.grid.active_links] = (
             -velocity_coef[self.grid.active_links]
             * tidal_wse_grad[self.grid.active_links]
         )
-        self._ebb_tide_vel[:] = -self._flood_tide_vel
+        np.negative(flood_tide_vel, out=self.grid.at_link["ebb_tide_flow__velocity"])

--- a/src/landlab/components/tidal_flow/tidal_flow_calculator.py
+++ b/src/landlab/components/tidal_flow/tidal_flow_calculator.py
@@ -186,11 +186,6 @@ class TidalFlowCalculator(Component):
         self._mean_sea_level = mean_sea_level
         self._min_depth = min_water_depth
 
-        # Make other data structures
-        self._water_depth_at_links = np.zeros(grid.number_of_links)
-        self._diffusion_coef_at_links = np.zeros(grid.number_of_links)
-        self._boundary_mean_water_surf_elev = np.zeros(grid.number_of_nodes)
-
     @property
     def roughness(self) -> NDArray:
         """Roughness coefficient (Manning's n)."""
@@ -302,25 +297,21 @@ class TidalFlowCalculator(Component):
 
     def run_one_step(self):
         """Calculate the tidal flow field and water-surface elevation."""
-
         # Tidal mean water depth  and water surface elevation at nodes
         # (Note: mean water surf elev only used for boundary conditions in
         # matrix construction; should be mean sea level)
         self._calc_effective_water_depth()
-        self._boundary_mean_water_surf_elev[:] = self._mean_sea_level
 
         # Map water depth to links
-        map_min_of_link_nodes_to_link(
-            self.grid,
-            self.grid.at_node["mean_water__depth"],
-            out=self._water_depth_at_links,
+        water_depth_at_links = map_min_of_link_nodes_to_link(
+            self.grid, self.grid.at_node["mean_water__depth"]
         )
 
         # Calculate velocity and diffusion coefficients on links
-        velocity_coef = self._water_depth_at_links**_FOUR_THIRDS / (
+        velocity_coef = water_depth_at_links**_FOUR_THIRDS / (
             (self.roughness**2) * self._scale_velocity
         )
-        self._diffusion_coef_at_links[:] = self._water_depth_at_links * velocity_coef
+        diffusion_coef_at_links = water_depth_at_links * velocity_coef
 
         # Calculate inundation / drainage rate at nodes
         tidal_inundation_rate = self.calc_tidal_inundation_rate()
@@ -333,8 +324,8 @@ class TidalFlowCalculator(Component):
         # mat, rhs = make_core_node_matrix_var_coef(
         mat, rhs = get_core_node_matrix(
             self.grid,
-            self._boundary_mean_water_surf_elev,
-            coef_at_link=self._diffusion_coef_at_links,
+            self._mean_sea_level,
+            coef_at_link=diffusion_coef_at_links,
         )
 
         rhs[:, 0] += self._grid_multiplier * tidal_inundation_rate[cores]

--- a/tests/components/tidal_flow_calculator/test_tidal_flow_calculator.py
+++ b/tests/components/tidal_flow_calculator/test_tidal_flow_calculator.py
@@ -16,6 +16,7 @@ from landlab import RadialModelGrid
 from landlab import RasterModelGrid
 from landlab.components import TidalFlowCalculator
 from landlab.field.errors import FieldError
+from landlab.grid.mappers import map_min_of_link_nodes_to_link
 
 
 def test_constant_depth_deeper_than_tidal_amplitude():
@@ -186,7 +187,11 @@ def test_with_hex_grid():
     tfc = TidalFlowCalculator(grid, tidal_period=4.0e4)
     tfc.run_one_step()
 
-    q = grid.at_link["flood_tide_flow__velocity"] * tfc._water_depth_at_links
+    water_depth_at_links = map_min_of_link_nodes_to_link(
+        grid, grid.at_node["mean_water__depth"]
+    )
+
+    q = grid.at_link["flood_tide_flow__velocity"] * water_depth_at_links
     assert_array_almost_equal(q[3:7], [0.0002625, 0.0002625, 0.0002625, 0.0002625])
 
 

--- a/tests/components/tidal_flow_calculator/test_tidal_flow_calculator.py
+++ b/tests/components/tidal_flow_calculator/test_tidal_flow_calculator.py
@@ -5,7 +5,7 @@ Created on Sun Jul 12 10:22:59 2020
 @author: gtucker
 """
 
-import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 from numpy.testing import assert_array_equal
 from numpy.testing import assert_equal
@@ -15,6 +15,7 @@ from landlab import HexModelGrid
 from landlab import RadialModelGrid
 from landlab import RasterModelGrid
 from landlab.components import TidalFlowCalculator
+from landlab.field.errors import FieldError
 
 
 def test_constant_depth_deeper_than_tidal_amplitude():
@@ -200,7 +201,7 @@ def test_getters_and_setters():
     tfc = TidalFlowCalculator(grid)
 
     tfc.roughness = 0.01
-    assert_array_equal(tfc.roughness, 0.01 + np.zeros(grid.number_of_links))
+    assert_array_equal(tfc.roughness, 0.01)
 
     tfc.tidal_range = 4.0
     assert_equal(tfc.tidal_range, 4.0)
@@ -212,3 +213,28 @@ def test_getters_and_setters():
 
     tfc.mean_sea_level = 1.0
     assert_equal(tfc.mean_sea_level, 1.0)
+
+
+def test_roughness():
+    grid = RasterModelGrid((3, 5))
+    grid.add_zeros("topographic__elevation", at="node")
+    tfc = TidalFlowCalculator(grid)
+
+    tfc.roughness = 0.01
+    assert_array_equal(tfc.roughness, 0.01)
+
+    tfc.roughness = grid.ones(at="link")
+    assert_array_equal(tfc.roughness, 1.0)
+
+    grid.add_full("roughness", 0.03, at="link")
+    tfc.roughness = "roughness"
+    assert_array_equal(tfc.roughness, 0.03)
+
+    with pytest.raises(
+        ValueError,
+        match="roughness must be a scalar or array of length n_links",
+    ):
+        tfc.roughness = grid.empty(at="node")
+
+    with pytest.raises(FieldError, match="'foobar'"):
+        tfc.roughness = "foobar"


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

As described in #2431, the `TidalFlowCalculator` is one of the components that stored references to grid field arrays at initialization time, which could silently point to stale data if another component replaced the underlying array in the grid dictionary.

I've removed all such aliases from `TidalFlowCalculator` and replaced them with direct grid field access inside each method.

I've also cleaned up some pre-allocated *numpy* arrays that were only ever used inside a single function. These are now local variables within methods.

---

## Related Issues

Part of #2431.