### PR TITLE
Fix exponent validation in StreamPowerEroder

### DIFF
--- a/news/2438.bugfix
+++ b/news/2438.bugfix
@@ -1,0 +1,2 @@
+Fixed validation bugs in `StreamPowerEroder` and added public functions for
+computing stream power exponents, which can be passed directly via `sp_type="set_mn"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "py-richdem",
   "pyyaml",
   "pyshp != 2.3.0",
-  "requireit>=0.8.0",
+  "requireit>=0.10.0",
   "rich-click",
   "scipy",
   "statsmodels",

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -7,7 +7,7 @@ pandas==3.0.0
 py-richdem==2.2.0rc2
 pyshp==3.0.3
 pyyaml==6.0.3
-requireit==0.8.0
+requireit==0.10.0
 rich-click==1.9.7
 scipy==1.17.0
 statsmodels==0.14.6

--- a/src/landlab/components/stream_power/stream_power.py
+++ b/src/landlab/components/stream_power/stream_power.py
@@ -1,12 +1,47 @@
 import numpy as np
+from requireit import require_between
+from requireit import require_none
+from requireit import require_nonnegative
+from requireit import require_not_none
+from requireit import require_one_of
 
 from landlab import Component
-from landlab import MissingKeyError
 from landlab.utils.return_array import return_array_at_node
 
 from ..depression_finder.lake_mapper import _FLOODED
 from .cfuncs import brent_method_erode_fixed_threshold
 from .cfuncs import brent_method_erode_variable_threshold
+
+
+def stream_power_exponents(m_sp: float, n_sp: float) -> tuple[float, float]:
+    m_sp = require_nonnegative(m_sp, name="m_sp")
+    n_sp = require_nonnegative(n_sp, name="n_sp")
+
+    return (m_sp, n_sp)
+
+
+def total_stream_power_exponents(a_sp: float, c_sp: float) -> tuple[float, float]:
+    a_sp = require_nonnegative(a_sp, name="a_sp")
+    c_sp = require_nonnegative(c_sp, name="c_sp")
+    return (a_sp * c_sp, a_sp)
+
+
+def unit_stream_power_exponents(
+    a_sp: float, b_sp: float, c_sp: float
+) -> tuple[float, float]:
+    a_sp = require_nonnegative(a_sp, name="a_sp")
+    b_sp = require_between(b_sp, 0.0, 1.0, name="b_sp")
+    c_sp = require_nonnegative(c_sp, name="c_sp")
+    return (a_sp * c_sp * (1.0 - b_sp), a_sp)
+
+
+def shear_stress_stream_power_exponents(
+    a_sp: float, b_sp: float, c_sp: float
+) -> tuple[float, float]:
+    a_sp = require_nonnegative(a_sp, name="a_sp")
+    b_sp = require_between(b_sp, 0.0, 1.0, name="b_sp")
+    c_sp = require_nonnegative(c_sp, name="c_sp")
+    return (2.0 * a_sp * c_sp * (1.0 - b_sp) / 3.0, 2.0 * a_sp / 3.0)
 
 
 class StreamPowerEroder(Component):
@@ -178,7 +213,7 @@ class StreamPowerEroder(Component):
         a_sp=None,
         b_sp=None,
         c_sp=None,
-        channel_width_field=1.0,
+        channel_width_field=None,
         discharge_field="drainage_area",
         erode_flooded_nodes=True,
     ):
@@ -270,11 +305,6 @@ class StreamPowerEroder(Component):
 
         assert np.all(self._sp_crit >= 0.0)
 
-        if discharge_field == "drainage_area":
-            self._use_Q = False
-        else:
-            self._use_Q = True
-
         if channel_width_field is None:
             self._use_W = False
         else:
@@ -288,52 +318,37 @@ class StreamPowerEroder(Component):
         else:
             self._set_threshold = False
 
-        self._type = sp_type
+        sp_type = require_one_of(
+            sp_type, allowed=("set_mn", "Total", "Unit", "Shear_stress")
+        )
+
+        if channel_width_field is not None and sp_type == "Total":
+            raise ValueError("channel_width_field must be None if sp_type is 'Total'")
+
+        if sp_type in ("Unit", "Shear_stress"):
+            if channel_width_field is None:
+                b_sp = require_not_none(b_sp, name="b_sp")
+            b_sp = 0.0 if b_sp is None else b_sp
+
+        if sp_type in ("Unit", "Shear_stress", "Total"):
+            if discharge_field == "drainage_area":
+                c_sp = require_not_none(c_sp, name="c_sp")
+            c_sp = 1.0 if c_sp is None else c_sp
+
+        m_sp = _validate_m_sp(m_sp, sp_type=sp_type)
+        n_sp = _validate_n_sp(n_sp, sp_type=sp_type)
+        a_sp = _validate_a_sp(a_sp, sp_type=sp_type)
+        b_sp = _validate_b_sp(b_sp, sp_type=sp_type)
+        c_sp = _validate_c_sp(c_sp, sp_type=sp_type)
+
         if sp_type == "set_mn":
-            assert (float(m_sp) >= 0.0) and (
-                float(n_sp) >= 0.0
-            ), "m and n must be positive"
-            self._m = float(m_sp)
-            self._n = float(n_sp)
-            assert (
-                (a_sp is None) and (b_sp is None) and (c_sp is None)
-            ), "If sp_type is 'set_mn', do not pass values for a, b, or c!"
-        else:
-            assert sp_type in ("Total", "Unit", "Shear_stress"), (
-                "sp_type not recognised. It must be 'set_mn', 'Total', "
-                + "'Unit', or 'Shear_stress'."
-            )
-            assert (
-                m_sp == 0.5 and n_sp == 1.0
-            ), "Do not set m and n if sp_type is not 'set_mn'!"
-            assert float(a_sp) >= 0.0, "a must be positive"
-            self._a = float(a_sp)
-            if b_sp is not None:
-                assert float(b_sp) >= 0.0, "b must be positive"
-                self._b = float(b_sp)
-            else:
-                assert self._use_W, "b was not set"
-                self._b = 0.0
-            if c_sp is not None:
-                assert float(c_sp) >= 0.0, "c must be positive"
-                self._c = float(c_sp)
-            else:
-                assert self._use_Q, "c was not set"
-                self._c = 1.0
-            if self._type == "Total":
-                self._n = self._a
-                self._m = self._a * self._c  # ==_a if use_Q
-            elif self._type == "Unit":
-                self._n = self._a
-                self._m = self._a * self._c * (1.0 - self._b)
-                # ^ ==_a iff use_Q&use_W etc
-            elif self._type == "Shear_stress":
-                self._m = 2.0 * self._a * self._c * (1.0 - self._b) / 3.0
-                self._n = 2.0 * self._a / 3.0
-            else:
-                raise MissingKeyError(
-                    "Not enough information was provided on the exponents to use!"
-                )
+            self._m, self._n = stream_power_exponents(m_sp, n_sp)
+        elif sp_type == "Total":
+            self._m, self._n = total_stream_power_exponents(a_sp, c_sp)
+        elif sp_type == "Unit":
+            self._m, self._n = unit_stream_power_exponents(a_sp, b_sp, c_sp)
+        elif sp_type == "Shear_stress":
+            self._m, self._n = shear_stress_stream_power_exponents(a_sp, b_sp, c_sp)
 
         # m and n will always be set, but care needs to be taken to include Q
         # and W directly if appropriate
@@ -434,3 +449,39 @@ class StreamPowerEroder(Component):
                 self._n,
                 self._elevs,
             )
+
+
+def _validate_m_sp(m_sp: float | None, sp_type: str):
+    if sp_type != "set_mn" and m_sp != 0.5:
+        raise ValueError("m must not be set if sp_type is not 'set_mn'")
+    return m_sp
+
+
+def _validate_n_sp(n_sp: float | None, sp_type: str):
+    if sp_type != "set_mn" and n_sp != 1.0:
+        raise ValueError("n must not be set if sp_type is not 'set_mn'")
+    return n_sp
+
+
+def _validate_a_sp(a_sp: float | None, sp_type: str):
+    if sp_type in ("Unit", "Shear_stress", "Total"):
+        require_not_none(a_sp, name="a_sp")
+    elif sp_type == "set_mn":
+        require_none(a_sp, name="a_sp")
+    return a_sp
+
+
+def _validate_b_sp(b_sp: float | None, sp_type: str):
+    if sp_type in ("Unit", "Shear_stress"):
+        require_not_none(b_sp, name="b_sp")
+    elif sp_type in ("set_mn", "Total"):
+        require_none(b_sp, name="b_sp")
+    return b_sp
+
+
+def _validate_c_sp(c_sp: float | None, sp_type: str):
+    if sp_type in ("Unit", "Shear_stress", "Total"):
+        require_not_none(c_sp, name="c_sp")
+    elif sp_type == "set_mn":
+        require_none(c_sp, name="c_sp")
+    return c_sp

--- a/tests/components/stream_power/test_exponent_validation.py
+++ b/tests/components/stream_power/test_exponent_validation.py
@@ -1,0 +1,298 @@
+"""Tests for StreamPowerEroder's sp_type/m_sp/n_sp/a_sp/b_sp/c_sp validation.
+
+The exponent derivation itself is delegated to four module-level, public
+functions (``stream_power_exponents``, ``total_stream_power_exponents``,
+``unit_stream_power_exponents``, ``shear_stress_stream_power_exponents``),
+so a user can precompute ``m``/``n`` and pass them directly via
+``sp_type="set_mn"`` instead of specifying ``sp_type``/``a_sp``/``b_sp``/
+``c_sp`` on the component itself. Those are tested directly, independent
+of any grid.
+
+Validation raises either ``requireit.ValidationError`` (any check that
+delegates to a ``requireit`` validator: ``require_one_of``,
+``require_nonnegative``, `require_between``, and the local ``require_none``
+/``require_not_none`` helpers) or a plain ``ValueError`` (the two checks
+that are hand-written rather than delegated: ``m_sp``/``n_sp`` must stay
+at their defaults when deriving from ``a_sp``/``b_sp``/``c_sp``, and
+``channel_width_field`` must be ``None`` when ``sp_type == "Total"``).
+"""
+
+import numpy as np
+import pytest
+from requireit import ValidationError
+
+from landlab import RasterModelGrid
+from landlab.components import FlowAccumulator
+from landlab.components import StreamPowerEroder
+from landlab.components.stream_power.stream_power import (
+    shear_stress_stream_power_exponents,
+)
+from landlab.components.stream_power.stream_power import stream_power_exponents
+from landlab.components.stream_power.stream_power import total_stream_power_exponents
+from landlab.components.stream_power.stream_power import unit_stream_power_exponents
+
+
+@pytest.fixture
+def grid():
+    grid = RasterModelGrid((5, 5))
+    grid.add_zeros("topographic__elevation", at="node")
+    grid.at_node["topographic__elevation"][:] = grid.node_x + grid.node_y
+    flow_accumulator = FlowAccumulator(grid, flow_director="D8")
+    flow_accumulator.run_one_step()
+    return grid
+
+
+class TestStreamPowerExponents:
+    """The set_mn identity case: m_sp/n_sp are used, and validated, as-is."""
+
+    def test_pass_through(self):
+        assert stream_power_exponents(0.3, 0.7) == (0.3, 0.7)
+
+    def test_negative_m_raises(self):
+        with pytest.raises(ValidationError):
+            stream_power_exponents(-1.0, 1.0)
+
+    def test_negative_n_raises(self):
+        with pytest.raises(ValidationError):
+            stream_power_exponents(0.5, -1.0)
+
+
+class TestTotalStreamPowerExponents:
+    def test_formula(self):
+        m, n = total_stream_power_exponents(a_sp=2.0, c_sp=3.0)
+        assert m == 2.0 * 3.0
+        assert n == 2.0
+
+    def test_negative_a_sp_raises(self):
+        with pytest.raises(ValidationError):
+            total_stream_power_exponents(a_sp=-1.0, c_sp=1.0)
+
+    def test_negative_c_sp_raises(self):
+        with pytest.raises(ValidationError):
+            total_stream_power_exponents(a_sp=1.0, c_sp=-1.0)
+
+
+class TestUnitStreamPowerExponents:
+    def test_formula(self):
+        m, n = unit_stream_power_exponents(a_sp=2.0, b_sp=0.25, c_sp=3.0)
+        assert m == 2.0 * 3.0 * (1.0 - 0.25)
+        assert n == 2.0
+
+    def test_negative_a_sp_raises(self):
+        with pytest.raises(ValidationError):
+            unit_stream_power_exponents(a_sp=-1.0, b_sp=0.5, c_sp=1.0)
+
+    def test_negative_c_sp_raises(self):
+        with pytest.raises(ValidationError):
+            unit_stream_power_exponents(a_sp=1.0, b_sp=0.5, c_sp=-1.0)
+
+    def test_negative_b_sp_raises(self):
+        with pytest.raises(ValidationError):
+            unit_stream_power_exponents(a_sp=1.0, b_sp=-0.1, c_sp=1.0)
+
+    def test_b_sp_greater_than_one_raises(self):
+        with pytest.raises(ValidationError):
+            unit_stream_power_exponents(a_sp=1.0, b_sp=1.5, c_sp=1.0)
+
+    def test_b_sp_of_one_is_the_inclusive_boundary(self):
+        m, n = unit_stream_power_exponents(a_sp=1.0, b_sp=1.0, c_sp=1.0)
+        assert m == 0.0
+        assert n == 1.0
+
+
+class TestShearStressStreamPowerExponents:
+    def test_formula(self):
+        m, n = shear_stress_stream_power_exponents(a_sp=2.0, b_sp=0.25, c_sp=3.0)
+        assert m == 2.0 * 2.0 * 3.0 * (1.0 - 0.25) / 3.0
+        assert n == 2.0 * 2.0 / 3.0
+
+    def test_negative_a_sp_raises(self):
+        with pytest.raises(ValidationError):
+            shear_stress_stream_power_exponents(a_sp=-1.0, b_sp=0.5, c_sp=1.0)
+
+    def test_b_sp_out_of_range_raises(self):
+        with pytest.raises(ValidationError):
+            shear_stress_stream_power_exponents(a_sp=1.0, b_sp=1.5, c_sp=1.0)
+
+
+class TestSetMN:
+    """sp_type='set_mn' (the default) uses m_sp/n_sp directly."""
+
+    def test_defaults(self, grid):
+        sp = StreamPowerEroder(grid)
+        assert sp._m == 0.5
+        assert sp._n == 1.0
+
+    def test_custom_m_and_n(self, grid):
+        sp = StreamPowerEroder(grid, m_sp=0.3, n_sp=0.7)
+        assert sp._m == 0.3
+        assert sp._n == 0.7
+
+    def test_negative_m_raises(self, grid):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, m_sp=-1.0)
+
+    def test_negative_n_raises(self, grid):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, n_sp=-1.0)
+
+    @pytest.mark.parametrize("param", ("a_sp", "b_sp", "c_sp"))
+    def test_abc_forbidden_with_set_mn(self, grid, param):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type="set_mn", **{param: 1.0})
+
+    def test_precomputed_exponents_can_be_passed_through_set_mn(self, grid):
+        """The whole point of the public *_exponents functions: a user can
+        compute m/n themselves and bypass sp_type/a_sp/b_sp/c_sp entirely.
+        """
+        m, n = unit_stream_power_exponents(a_sp=1.0, b_sp=0.5, c_sp=1.0)
+        sp = StreamPowerEroder(grid, sp_type="set_mn", m_sp=m, n_sp=n)
+        assert sp._m == m
+        assert sp._n == n
+
+
+class TestSpTypeValidation:
+    def test_unrecognized_sp_type_raises(self, grid):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type="not_a_type", a_sp=1.0, c_sp=1.0)
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    @pytest.mark.parametrize("mn_param", ("m_sp", "n_sp"))
+    def test_m_n_must_stay_default_for_non_set_mn(self, grid, sp_type, mn_param):
+        kwargs = {"a_sp": 1.0, "b_sp": 0.5, "c_sp": 1.0, mn_param: 0.3}
+        with pytest.raises(ValueError):
+            StreamPowerEroder(grid, sp_type=sp_type, **kwargs)
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_a_sp_is_required(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, b_sp=0.5, c_sp=1.0)
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_negative_a_sp_raises(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, a_sp=-1.0, b_sp=0.5, c_sp=1.0)
+
+    @pytest.mark.parametrize("sp_type", ("Unit", "Shear_stress"))
+    def test_negative_b_sp_raises(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, a_sp=1.0, b_sp=-1.0, c_sp=1.0)
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_negative_c_sp_raises(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, a_sp=1.0, b_sp=0.5, c_sp=-1.0)
+
+
+class TestExponentDerivation:
+    """StreamPowerEroder dispatches to the matching *_exponents function."""
+
+    def test_total(self, grid):
+        sp = StreamPowerEroder(grid, sp_type="Total", a_sp=2.0, c_sp=3.0)
+        assert sp._m == 2.0 * 3.0
+        assert sp._n == 2.0
+
+    def test_unit(self, grid):
+        sp = StreamPowerEroder(grid, sp_type="Unit", a_sp=2.0, b_sp=0.25, c_sp=3.0)
+        assert sp._m == 2.0 * 3.0 * (1.0 - 0.25)
+        assert sp._n == 2.0
+
+    def test_shear_stress(self, grid):
+        sp = StreamPowerEroder(
+            grid, sp_type="Shear_stress", a_sp=2.0, b_sp=0.25, c_sp=3.0
+        )
+        assert sp._m == 2.0 * 2.0 * 3.0 * (1.0 - 0.25) / 3.0
+        assert sp._n == 2.0 * 2.0 / 3.0
+
+
+class TestChannelWidthFieldInteraction:
+    """channel_width_field's interaction with b_sp, gated on sp_type."""
+
+    def test_forbidden_for_total(self, grid):
+        with pytest.raises(ValueError):
+            StreamPowerEroder(
+                grid,
+                sp_type="Total",
+                a_sp=1.0,
+                c_sp=1.0,
+                channel_width_field=np.ones(grid.number_of_nodes),
+            )
+
+    @pytest.mark.parametrize("sp_type", ("Unit", "Shear_stress"))
+    def test_b_sp_required_without_a_width_field(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, a_sp=1.0, c_sp=1.0)
+
+    @pytest.mark.parametrize("sp_type", ("Unit", "Shear_stress"))
+    def test_b_sp_defaults_to_zero_when_width_field_given(self, grid, sp_type):
+        sp = StreamPowerEroder(
+            grid,
+            sp_type=sp_type,
+            a_sp=1.0,
+            c_sp=1.0,
+            channel_width_field=np.ones(grid.number_of_nodes),
+        )
+        # b_sp defaulted to 0.0, so m matches the b_sp=0 formula.
+        if sp_type == "Unit":
+            assert sp._m == 1.0 * 1.0 * (1.0 - 0.0)
+        else:
+            assert sp._m == 2.0 * 1.0 * 1.0 * (1.0 - 0.0) / 3.0
+
+    @pytest.mark.parametrize("sp_type", ("Unit", "Shear_stress"))
+    def test_b_sp_and_width_field_can_both_be_given(self, grid, sp_type):
+        sp = StreamPowerEroder(
+            grid,
+            sp_type=sp_type,
+            a_sp=1.0,
+            b_sp=0.5,
+            c_sp=1.0,
+            channel_width_field=np.ones(grid.number_of_nodes),
+        )
+        if sp_type == "Unit":
+            assert sp._m == 1.0 * 1.0 * (1.0 - 0.5)
+        else:
+            assert sp._m == 2.0 * 1.0 * 1.0 * (1.0 - 0.5) / 3.0
+
+
+def _b_sp_kwargs(sp_type):
+    """b_sp is only accepted for Unit/Shear_stress -- must stay unset for Total."""
+    return {} if sp_type == "Total" else {"b_sp": 0.5}
+
+
+class TestDischargeFieldInteraction:
+    """discharge_field's interaction with c_sp, gated on sp_type."""
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_c_sp_required_with_default_discharge_field(self, grid, sp_type):
+        with pytest.raises(ValidationError):
+            StreamPowerEroder(grid, sp_type=sp_type, a_sp=1.0, **_b_sp_kwargs(sp_type))
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_c_sp_defaults_to_one_with_custom_discharge_field(self, grid, sp_type):
+        # FlowAccumulator's D8 director already populates this field.
+        sp = StreamPowerEroder(
+            grid,
+            sp_type=sp_type,
+            a_sp=1.0,
+            discharge_field="surface_water__discharge",
+            **_b_sp_kwargs(sp_type),
+        )
+        expected_n = 2.0 / 3.0 if sp_type == "Shear_stress" else 1.0
+        assert sp._n == expected_n
+
+    @pytest.mark.parametrize("sp_type", ("Total", "Unit", "Shear_stress"))
+    def test_c_sp_and_custom_discharge_field_can_both_be_given(self, grid, sp_type):
+        sp = StreamPowerEroder(
+            grid,
+            sp_type=sp_type,
+            a_sp=1.0,
+            c_sp=1.0,
+            discharge_field="surface_water__discharge",
+            **_b_sp_kwargs(sp_type),
+        )
+        if sp_type == "Total":
+            assert sp._m == 1.0 * 1.0
+        elif sp_type == "Unit":
+            assert sp._m == 1.0 * 1.0 * (1.0 - 0.5)
+        else:
+            assert sp._m == 2.0 * 1.0 * 1.0 * (1.0 - 0.5) / 3.0


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [ ] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've fixed the validation of `StreamPowerEroder1's `sp_type`/`m_sp`/`n_sp`/`a_sp`/`b_sp`/`c_sp`/`channel_width_field`/`discharge_field` parameters with bare asserts, which are silently stripped under `python -O`, and which had several real bugs hiding behind them.

I've replaced the asserts with `requireit` validators and extracted the `m` and `n` derivations into new functions. This does two things:
* makes these calculations testable
* allows a user to pre-compute these exponents and pass them into `StreamPowerEroder` directly. I hope this is a step toward simplifying the component's constructor by removing `sp_type`, `a_sp`, `b_sp`, and `c_sp`.


Some other changes:
* `channel_width_field` now defaults to `None` (previously `1.0`,
  which numerically no-ops but obscured a bug).
- `b_sp` is now bounded to `[0, 1]`, matching its role as a
  hydraulic-geometry width-discharge exponent (values outside that
  range make the derived `m` exponent go negative, which doesn't fit
  the model).
- `channel_width_field`/`discharge_field` can now be freely combined
  with explicit `b_sp`/`c_sp` (previously these were incorrectly
  mutually exclusive in some combinations).

## Related Issues

None.


---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
