### PR TITLE
Add time-step iterators for components

### DIFF
--- a/news/2442.feature
+++ b/news/2442.feature
@@ -1,0 +1,1 @@
+Added fixed and adaptive time-step iterator utilities for component authors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "py-richdem",
   "pyyaml",
   "pyshp != 2.3.0",
-  "requireit>=0.8.0",
+  "requireit>=0.11.0",
   "rich-click",
   "scipy",
   "statsmodels",

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -7,7 +7,7 @@ pandas==3.0.0
 py-richdem==2.2.0rc2
 pyshp==3.0.3
 pyyaml==6.0.3
-requireit==0.8.0
+requireit==0.11.0
 rich-click==1.9.7
 scipy==1.17.0
 statsmodels==0.14.6

--- a/src/landlab/core/component_utils.py
+++ b/src/landlab/core/component_utils.py
@@ -1,0 +1,173 @@
+import math
+from collections.abc import Callable
+from collections.abc import Iterator
+from numbers import Integral
+
+from requireit import require_between
+from requireit import require_instance
+from requireit import require_positive
+
+
+def iter_time_steps(duration: float, *, dt: float | None = None) -> Iterator[float]:
+    """Yield fixed-size time steps that evenly span a requested duration.
+
+    Split *duration* into equally-sized substeps, so that no substeps
+    are longer that *dt*.
+
+    Parameters
+    ----------
+    duration : float
+        Total amount of time to advance.
+    dt : float, optional
+        Maximum time-step size. If not given, use *duration* as a
+        single time step.
+
+    Yields
+    ------
+    float
+        The next time-step size.
+
+    Raises
+    ------
+    ValueError
+        If *duration* is negative, or if *dt* is not finite and
+        positive.
+
+    Examples
+    --------
+    >>> from landlab.core.component_utils import iter_time_steps
+
+    >>> list(iter_time_steps(10.0, dt=2.5))
+    [2.5, 2.5, 2.5, 2.5]
+
+    A duration that doesn't divide evenly is split into equal substeps,
+    each no longer than *dt*, rather than leaving a short final step.
+
+    >>> list(iter_time_steps(10.0, dt=3.0))
+    [2.5, 2.5, 2.5, 2.5]
+
+    If *dt* isn't given, *duration* is used as a single time step.
+
+    >>> list(iter_time_steps(5.0))
+    [5.0]
+    """
+    duration = require_between(
+        duration, 0.0, math.inf, inclusive_max=False, name="duration"
+    )
+
+    if duration == 0.0:
+        return
+
+    dt = duration if dt is None else dt
+
+    dt = require_between(
+        dt, 0.0, math.inf, inclusive_min=False, inclusive_max=False, name="dt"
+    )
+
+    n_steps = math.ceil(duration / dt)
+
+    step = duration / n_steps
+    for _ in range(n_steps):
+        yield step
+
+
+def iter_adaptive_time_steps(
+    duration: float,
+    *,
+    calc_dt: Callable[[], float | None],
+    max_steps: int | None = None,
+    rtol: float = 1e-12,
+) -> Iterator[float]:
+    """Yield adaptive time steps that advance up to a requested duration.
+
+    Repeatedly call *calc_dt* to obtain the next stable time-step size,
+    capping each step so that the total does not exceed *duration*.
+    Note that iteration may stop within the tolerance specified by *rtol*.
+
+    Parameters
+    ----------
+    duration : float
+        Total amount of time to advance.
+    calc_dt : callable
+        Called with no arguments before each substep to obtain the
+        current stable time-step size. A return value of ``None`` signals
+        that iteration should be stopped before *duration* is reached.
+        A return value of `inf` advances to *duration*.
+    max_steps : int, optional
+        Maximum number of substeps to yield before raising a
+        ``RuntimeError``.
+    rtol : float, optional
+        Stop once the remaining time is no greater than
+        ``rtol * duration``. Consequently, the yielded time steps may
+        sum to slightly less than *duration*.
+
+    Yields
+    ------
+    float
+        The next time-step size.
+
+    Raises
+    ------
+    ValueError
+        If *duration* or *rtol* are out of range.
+    RuntimeError
+        If *max_steps* is exceeded, or if a returned step is either
+        invalid or is too small, relative to the elapsed time, to make
+        further progress.
+
+    Examples
+    --------
+    >>> from landlab.core.component_utils import iter_adaptive_time_steps
+
+    >>> steps = iter([2.0, 2.0, 2.0, 1.0])
+    >>> list(iter_adaptive_time_steps(7.0, calc_dt=lambda: next(steps)))
+    [2.0, 2.0, 2.0, 1.0]
+
+    Return ``None`` from *calc_dt* to stop before *duration* is reached.
+
+    >>> steps = iter([2.0, 2.0, None])
+    >>> list(iter_adaptive_time_steps(10.0, calc_dt=lambda: next(steps)))
+    [2.0, 2.0]
+
+    >>> list(iter_adaptive_time_steps(10.0, calc_dt=lambda: 3.0))
+    [3.0, 3.0, 3.0, 1.0]
+    """
+    duration = require_between(
+        duration, 0.0, math.inf, inclusive_max=False, name="duration"
+    )
+
+    rtol = require_between(rtol, 0.0, 1.0, inclusive_max=False, name="rtol")
+    if max_steps is not None:
+        require_instance(max_steps, Integral, name="max_steps")
+        require_positive(max_steps, name="max_steps")
+
+    if duration == 0.0:
+        return
+
+    tol = rtol * duration
+    elapsed = 0.0
+    n_steps = 0
+
+    while duration - elapsed > tol:
+        if max_steps is not None and n_steps >= max_steps:
+            raise RuntimeError(f"unable to reach {duration!r} in {max_steps} substeps")
+
+        step = calc_dt()
+        if step is None:
+            break
+        if step <= 0.0 or math.isnan(step):
+            raise RuntimeError("step must be positive or None")
+
+        this_dt = min(step, duration - elapsed)
+
+        new_elapsed = elapsed + this_dt
+        if new_elapsed == elapsed:
+            raise RuntimeError(
+                "time step is too small relative to the elapsed time"
+                " to make further progress due to floating-point precision"
+            )
+
+        yield this_dt
+
+        elapsed = new_elapsed
+        n_steps += 1

--- a/tests/core/test_component_utils.py
+++ b/tests/core/test_component_utils.py
@@ -1,0 +1,112 @@
+import math
+
+import numpy as np
+import pytest
+from requireit import ValidationError
+
+from landlab.core.component_utils import iter_adaptive_time_steps
+from landlab.core.component_utils import iter_time_steps
+
+
+@pytest.mark.parametrize(
+    ("duration", "dt", "expected"),
+    [
+        (0.0, None, []),
+        (5.0, None, [5.0]),
+        (10.0, 2.5, [2.5, 2.5, 2.5, 2.5]),
+        (10.0, 3.0, [2.5, 2.5, 2.5, 2.5]),
+        (5.0, 10.0, [5.0]),
+    ],
+)
+def test_iter_time_steps(duration, dt, expected):
+    assert list(iter_time_steps(duration, dt=dt)) == expected
+
+
+@pytest.mark.parametrize("duration", [-1.0, math.inf, math.nan])
+def test_iter_time_steps_rejects_invalid_duration(duration):
+    with pytest.raises(ValidationError):
+        list(iter_time_steps(duration))
+
+
+@pytest.mark.parametrize("dt", [-1.0, 0.0, math.inf, math.nan])
+def test_iter_time_steps_rejects_invalid_dt(dt):
+    with pytest.raises(ValidationError):
+        list(iter_time_steps(1.0, dt=dt))
+
+
+def test_iter_adaptive_time_steps_caps_final_step():
+    expected = [3.0, 3.0, 3.0, 1.0]
+    actual = list(iter_adaptive_time_steps(10.0, calc_dt=lambda: 3.0))
+    assert actual == expected
+
+
+def test_iter_adaptive_time_steps_stops_on_none():
+    steps = iter([2.0, 2.0, None])
+
+    expected = [2.0, 2.0]
+    actual = list(iter_adaptive_time_steps(10.0, calc_dt=lambda: next(steps)))
+    assert actual == expected
+
+
+def test_iter_adaptive_time_steps_accepts_infinite_step():
+    assert list(iter_adaptive_time_steps(10.0, calc_dt=lambda: math.inf)) == [10.0]
+
+
+def test_iter_adaptive_time_steps_does_not_calculate_step_for_zero_duration():
+    def calc_dt():
+        raise AssertionError("calc_dt should not be called")
+
+    with pytest.raises(AssertionError, match="calc_dt should not be called"):
+        list(iter_adaptive_time_steps(10.0, calc_dt=calc_dt))
+    assert list(iter_adaptive_time_steps(0.0, calc_dt=calc_dt)) == []
+
+
+def test_iter_adaptive_time_steps_stops_within_tolerance():
+    step = 1.0 - 5.0e-13
+
+    assert list(iter_adaptive_time_steps(1.0, calc_dt=lambda: step)) == [step]
+
+
+def test_iter_adaptive_time_steps_honors_zero_tolerance():
+    steps = list(iter_adaptive_time_steps(1.0, calc_dt=lambda: 1.0 - 5.0e-13, rtol=0.0))
+
+    assert len(steps) == 2
+    assert sum(steps) == 1.0
+
+
+@pytest.mark.parametrize("max_steps", (1, np.int64(1), np.int32(1)))
+def test_iter_adaptive_time_steps_accepts_int(max_steps):
+    actual = list(
+        iter_adaptive_time_steps(1.0, calc_dt=lambda: 1.0, max_steps=max_steps)
+    )
+    assert actual == [1.0]
+
+
+def test_iter_adaptive_time_steps_raises_when_max_steps_exceeded():
+    with pytest.raises(RuntimeError, match="unable to reach 2.0 in 1 substeps"):
+        list(iter_adaptive_time_steps(2.0, calc_dt=lambda: 1.0, max_steps=1))
+
+
+@pytest.mark.parametrize("max_steps", [0, -1, 1.5])
+def test_iter_adaptive_time_steps_rejects_invalid_max_steps(max_steps):
+    with pytest.raises(ValidationError):
+        list(iter_adaptive_time_steps(1.0, calc_dt=lambda: 1.0, max_steps=max_steps))
+
+
+@pytest.mark.parametrize("rtol", [-1.0, 1.0, math.inf, math.nan])
+def test_iter_adaptive_time_steps_rejects_invalid_rtol(rtol):
+    with pytest.raises(ValidationError):
+        list(iter_adaptive_time_steps(1.0, calc_dt=lambda: 1.0, rtol=rtol))
+
+
+@pytest.mark.parametrize("step", [-1.0, 0.0, math.nan])
+def test_iter_adaptive_time_steps_rejects_invalid_step(step):
+    with pytest.raises(RuntimeError, match="step must be positive"):
+        list(iter_adaptive_time_steps(1.0, calc_dt=lambda: step))
+
+
+def test_iter_adaptive_time_steps_detects_step_too_small_to_advance():
+    steps = iter([1.0, 1.0e-20])
+
+    with pytest.raises(RuntimeError, match="too small relative to the elapsed time"):
+        list(iter_adaptive_time_steps(2.0, calc_dt=lambda: next(steps), rtol=0.0))


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've added two new utility iterators to help component authors add time stepping to their components. Many components already do this (sometimes correctly, sometimes not) but these utility functions will help replace repeated.

* `iter_time_steps` evenly divides a duration into fixed-size substeps no larger than a requested maximum.
* `iter_adaptive_time_steps` repeatedly calculates stable substeps, and clips the final step to the remaining duration. This function supports early termination, and infinite time step (i.e. there is no time step limit, in which case just take a single step to the specified duration).


---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
