### PR TITLE
Add GeoEnthalpyDelta to docs/index.toml

### DIFF
--- a/docs/index.toml
+++ b/docs/index.toml
@@ -1362,6 +1362,35 @@ mapping = 'node'
 optional = false
 units = '-'
 
+[components.GeoEnthalpyDelta]
+name = 'landlab.components.geoenthalpy_delta.geoenthalpy_delta.GeoEnthalpyDelta'
+unit_agnostic = true
+summary = 'Simulate 2D sediment diffusion, transport, and deposition using an'
+
+[components.GeoEnthalpyDelta.info.sea_level__elevation]
+doc = 'Sea level elevation'
+dtype = 'float64'
+intent = 'in'
+mapping = 'grid'
+optional = false
+units = '-'
+
+[components.GeoEnthalpyDelta.info.sediment__influx]
+doc = 'Sediment flux (volume per unit time of sediment entering each node)'
+dtype = 'float64'
+intent = 'in'
+mapping = 'node'
+optional = false
+units = '-'
+
+[components.GeoEnthalpyDelta.info.topographic__elevation]
+doc = 'Land surface topographic elevation'
+dtype = 'float64'
+intent = 'inout'
+mapping = 'node'
+optional = false
+units = '-'
+
 [components.GravelBedrockEroder]
 name = 'landlab.components.gravel_bedrock_eroder.gravel_bedrock_eroder.GravelBedrockEroder'
 unit_agnostic = true
@@ -4765,6 +4794,7 @@ provided_by = []
 desc = 'Sea level elevation'
 used_by = [
   'landlab.components.carbonate.carbonate_producer.CarbonateProducer',
+  'landlab.components.geoenthalpy_delta.geoenthalpy_delta.GeoEnthalpyDelta',
   'landlab.components.marine_sediment_transport.simple_submarine_diffuser.SimpleSubmarineDiffuser',
 ]
 provided_by = []
@@ -4813,7 +4843,9 @@ provided_by = [
 
 [fields.sediment__influx]
 desc = 'Sediment flux (volume per unit time of sediment entering each node)'
-used_by = []
+used_by = [
+  'landlab.components.geoenthalpy_delta.geoenthalpy_delta.GeoEnthalpyDelta',
+]
 provided_by = [
   'landlab.components.erosion_deposition.erosion_deposition.ErosionDeposition',
   'landlab.components.lateral_erosion.lateral_erosion.LateralEroder',
@@ -5250,6 +5282,7 @@ used_by = [
   'landlab.components.flow_director.flow_director_dinf.FlowDirectorDINF',
   'landlab.components.flow_director.flow_director_mfd.FlowDirectorMFD',
   'landlab.components.flow_director.flow_director_steepest.FlowDirectorSteepest',
+  'landlab.components.geoenthalpy_delta.geoenthalpy_delta.GeoEnthalpyDelta',
   'landlab.components.gravel_bedrock_eroder.gravel_bedrock_eroder.GravelBedrockEroder',
   'landlab.components.gravel_river_transporter.gravel_river_transporter.GravelRiverTransporter',
   'landlab.components.groundwater.dupuit_percolator.GroundwaterDupuitPercolator',
@@ -5299,6 +5332,7 @@ provided_by = [
   'landlab.components.dimensionless_discharge.dimensionless_discharge.DimensionlessDischarge',
   'landlab.components.discharge_diffuser.diffuse_by_discharge.DischargeDiffuser',
   'landlab.components.erosion_deposition.erosion_deposition.ErosionDeposition',
+  'landlab.components.geoenthalpy_delta.geoenthalpy_delta.GeoEnthalpyDelta',
   'landlab.components.gflex.flexure.gFlex',
   'landlab.components.gravel_bedrock_eroder.gravel_bedrock_eroder.GravelBedrockEroder',
   'landlab.components.gravel_river_transporter.gravel_river_transporter.GravelRiverTransporter',


### PR DESCRIPTION
Add GeoEnthalpyDelta to docs/index.toml so that GeoEnthalpyDelta can appear on the website document.

# Pull Request Guidelines

Thank you for contributing! Please follow these guidelines to help keep our
codebase clean, consistent, and maintainable.

## What Makes a Good Pull Request

- **Small and focused**: Address one issue or feature per pull request. Avoid
  bundling multiple unrelated changes.
- **Clear purpose**: The pull request should explain *why* a change is needed,
  not just *what* was changed.
- **Draft first**: Open your pull request in **draft mode** so others can
  follow progress and provide early feedback.
- **Readable history**: Prefer a clean commit history. Consider squashing
  or rebasing before final review.
- **Well-tested and documented**: All code changes should be accompanied
  by appropriate tests and updated documentation.

---

## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries)
      describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

- `nox -s build-index` hadn't been re-run since `GeoEnthalpyDelta` was merged in #2441, so it was missing from the auto-generated "List of Components" page and the field cross-reference tables (`used_by`/`provided_by`) on the docs site.
- Adds the `[components.GeoEnthalpyDelta]` entry and registers it in the `sea_level__elevation`, `sediment__influx`, and `topographic__elevation` field entries.
---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->

Following up of #2441
This PR is about the nox -s build-index.
