### PR TITLE
Deploy documentation after merges to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
 on:
+  push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
@@ -22,7 +25,7 @@ concurrency:
 jobs:
   build-sdist:
     name: Build source distribution
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -37,7 +40,7 @@ jobs:
 
   build-wheels:
     name: Build wheels on ${{ matrix.cibw-only }}
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've fixed an issue where  the `deploy-docs` step was not being run after a  pull request was merged into master.


---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
