### PR TITLE
Remove links to slack and twitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,6 @@ The recommended way to contact the Landlab team is with a
   the most appropriate member of the core Landlab team. We will work to clarify
   your question and revise the documentation so that it is clear for the next user.
 
-Keep in touch with the latest *landlab* news by following us on [Twitter](https://twitter.com/landlabtoolkit).
-
-During workshops and clinics, we sometimes use the
-[Landlab Slack channel](https://landlab.slack.com).
-
 <!-- end-contact -->
 
 [citation guidelines]: https://landlab.csdms.io/about/citing.html

--- a/docs/source/user_guide/faq.md
+++ b/docs/source/user_guide/faq.md
@@ -161,7 +161,6 @@ Tell us about your issue, and we'll be in touch.
 
 There are a few ways to follow Landlab developments. You can
 
-- follow Landlab on [Twitter](https://mobile.twitter.com/landlabtoolkit)  @landlabtoolkit,
 - "watch" Landlab's GitHub repository,
 - file a pull request or an issue at [https://github.com/landlab/landlab](https://github.com/landlab/landlab),
 


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

The readme had links to *Landlab* on *Slack* and *Twitter.* The *Slack* link was causing our links checks to fail, and since we don't use either anymore, I removed them.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
