### PR TITLE
Drop importlib-resources dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -274,7 +274,6 @@ with open(os.path.join(src_dir, "../cython-files.txt")) as fp:
 autodoc_mock_imports = [
     "richdem",
     "bmipy",
-    "importlib-resources",
     "matplotlib",
     "netcdf4",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
   "bmipy",
-  "importlib-resources; python_version < '3.12'",
   "matplotlib",
   "netcdf4",
   "numpy >=1.20",

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,4 @@
 bmipy
-importlib-resources; python_version < '3.12'
 matplotlib
 netcdf4
 numpy >=1.20

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,5 +1,4 @@
 bmipy==2.0.1
-importlib-resources==6.5.2; python_version < '3.12'
 matplotlib==3.10.8
 netcdf4==1.7.4
 numpy==2.4.2

--- a/src/landlab/core/utils.py
+++ b/src/landlab/core/utils.py
@@ -21,19 +21,14 @@ Landlab utilities
 
 import errno
 import importlib
+import importlib.resources as importlib_resources
 import inspect
 import os
 import pathlib
 import re
 import shutil
-import sys
 
 import numpy as np
-
-if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)
-    import importlib.resources as importlib_resources
-else:  # pragma: no cover (<PY312)
-    import importlib_resources
 
 SIZEOF_INT = np.dtype(int).itemsize
 


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

Because *Landlab* is now Python 3.12+, we no longer require *importlib-resources*. As such, I've dropped it from our dependencies.

---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
