### PR TITLE
Temporarily ignore Mesa updates from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/requirements"
+    ignore:
+      - dependency-name: "mesa"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 1


### PR DESCRIPTION
## Pull Request Checklist

Please confirm the following before marking the pull request as "Ready for Review"
(if any of the following items aren't relevant for your contribution please still
tick them so we know you've gone through the checklist):

- [x] The PR is opened in **draft mode**
- [x] The PR addresses a single feature, fix, or issue
- [x] Code has been linted and is free of style issues (`nox -s lint`)
- [x] All tests pass locally (`pytest`, or `nox -s test`)
- [x] Documentation builds without errors (`nox -s docs-build`)
- [x] A [**news fragment**](https://landlab.csdms.io/development/contribution/#news-entries) describing the change has been added
- [x] Relevant docstrings, examples, or changelog entries have been updated
- [x] Related issues or discussions are linked in the description (e.g., `Closes #1973`)

---

## Description

I've temporarily configured *Dependabot* to ignore updates for the `mesa` Python dependency. Mesa is currently pinned at `3.0.3` because newer releases are incompatible with Landlab's notebook requirements. We can remove this rule once that incompatibility is resolved.


---

## Related Issues

<!--
List any related issues, discussions, or pull requests.
Use keywords like "Closes #1973" to automatically close issues when merged.
-->
